### PR TITLE
Documentation/fixstar

### DIFF
--- a/docs/ch_running.tex
+++ b/docs/ch_running.tex
@@ -258,7 +258,7 @@ restarting completely.
 % -------------------------------------
 \section{Gotchas}
 
-Tali has a 16-bit cell size (use \texttt{1 cells 8 \textasteriskcentered{}  .} to get the cells size in
+Tali has a 16-bit cell size (use \texttt{1 cells 8 * .} to get the cells size in
 bits with any Forth), which can trip up calculations when compared to the
 \textit{de facto} standard Gforth\index{Gforth} with 64 bits. Take this example:
 

--- a/docs/ch_running.tex
+++ b/docs/ch_running.tex
@@ -258,7 +258,7 @@ restarting completely.
 % -------------------------------------
 \section{Gotchas}
 
-Tali has a 16-bit cell size (use \texttt{1 cells 8 \* .} to get the cells size in
+Tali has a 16-bit cell size (use \texttt{1 cells 8 \textasteriskcentered{}  .} to get the cells size in
 bits with any Forth), which can trip up calculations when compared to the
 \textit{de facto} standard Gforth\index{Gforth} with 64 bits. Take this example:
 


### PR DESCRIPTION
I was reading the Tali documentation (manual.pdf) and noticed some Forth code that didn't make sense.  It was missing the * in the Forth code in the Gotchas section, but a glance in the .tex file showed that there was supposed to be one.

It looks like * is not a special character and therefore doesn't need the backslash to escape it.

I'm not submitting the compiled version along with my fix because I get the warning:
`LaTeX Font Warning: Some font shapes were not available, defaults substituted.`
when I compile with pdflatex on my system.