### PR TITLE
Bugfix/tester

### DIFF
--- a/tests/talitest.py
+++ b/tests/talitest.py
@@ -47,7 +47,7 @@ def sendline(kid, string):
     """
     # print(string) # For debugging
     sendslow(kid, string + '\n')
-    # Look for all of the expcted responses.  The errors from the test
+    # Look for all of the expected responses.  The errors from the test
     # suite are not explicitly listed as they end in "ok".
     # Give up after 1 second.
     try:


### PR DESCRIPTION
Here is my solution for #49.

It has some extra benefits, such as running the entire test suite in about 3 minutes.  Apparently the characters were originally getting lost when Tali was busy thinking and not looking at the input.  Now that we wait for one of Tali's valid responses, I was able to eliminate my own delay and reduce the delay built into pexpect.  I have tested all four of Tali's responses (ok, compiled, Undefined word, and Stack underflow).

I also changed your check for the crash to an "in" test because the response started with the characters sent and then had the confused py65mon response.  It seems to work now (tested with the strings that still currently crash Tali).

When I comment out the output-test test, it finishes correctly and prints the summary.