### PR TITLE
Fixed hex/decimal issue in test

### DIFF
--- a/tests/talitests.fs
+++ b/tests/talitests.fs
@@ -1090,6 +1090,7 @@ create sbuf 12 c, 34 c, 56 c,
 
 \ CMOVE and CMOVE> propogation tests taken from 
 \ https://forth-standard.org/standard/string/CMOVE and .../CMOVEtop
+decimal
 create cmbuf  97 c, 98 c, 99 c, 100 c, \ "abcd"
 : seecmbuf  cmbuf c@  cmbuf char+ c@  cmbuf char+ char+ c@  cmbuf char+ char+ char+ c@ ;
 { cmbuf dup char+ 3 cmove -> }


### PR DESCRIPTION
Fix for #57.  I stepped through CMOVE> and it was working fine, so I checked the test program.
Test program was still in hex mode, so `100 c,` was saving the lower byte of $100, and that explained the 0s seen in the results.  I added a decimal word before the test and now it seems to work fine.