### PR TITLE
Added tests for very long strings.

### DIFF
--- a/tests/string.fs
+++ b/tests/string.fs
@@ -79,4 +79,12 @@ decimal
 ( TODO SUBSTITUTE not implemented yet )
 ( TODO UNESCAPE not implemented yet )
 
+\ Test strings longer than 255 chars (important for 8-bit systems)
+\ 516 character string
+: s14 s" test                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                " ;
+{ s14 swap drop -> 516 }
+{ s14 -trailing -> s14 drop 4 }
 
+: s15 ." abcdefghijklmnopqrstuvwxyz1abcdefghijklmnopqrstuvwxyz2abcdefghijklmnopqrstuvwxyz3abcdefghijklmnopqrstuvwxyz4abcdefghijklmnopqrstuvwxyz5abcdefghijklmnopqrstuvwxyz6abcdefghijklmnopqrstuvwxyz7abcdefghijklmnopqrstuvwxyz8abcdefghijklmnopqrstuvwxyz9abcdefghijklmnopqrstuvwxyz10abcdefghijklmnopqrstuvwxyz11abcdefghijklmnopqrstuvwxyz12abcdefghijklmnopqrstuvwxyz13abcdefghijklmnopqrstuvwxyz14abcdefghijklmnopqrstuvwxyz15abcdefghijklmnopqrstuvwxyz16abcdefghijklmnopqrstuvwxyz17abcdefghijklmnopqrstuvwxyz18abcdefghijklmnopqrstuvwxyz19abcdefghijklmnopqrstuvwxyz20" ;
+\ This should output the alphabet 20 times.
+{ s15 -> }


### PR DESCRIPTION
#71 tests `.s`, `."`, and `-trailing`.  The test for `."` is put to the screen, so it's not really a fully-automatic test.  To be able to have a fully automatic test, I think I'd need the ability to redirect output (temporarily) to a string, and COMPARE.

I had to slow down the intercharacter delay to get the tester program to not lose any of the characters or intermangle the test input with the output, but these tests should pass.  If the test looking at the count (516) fails with a smaller number, it's likely the tester dropped some characters.  When ACCEPT fills up the input buffer (every 255 characters), Tali needs time to shuffle 127 of the characters into the history.

I didn't include a results.txt for this one, but you'll definitely want to determine what intercharacter delay you need on your system to get it to pass (running just the string test) before running the entire test suite.