### PR TITLE
Make tests run in the same order every time

### DIFF
--- a/tests/talitest.py
+++ b/tests/talitest.py
@@ -39,8 +39,8 @@ TALI_ERRORS = ['Undefined word',
                'Already in compile mode']
 
 # Add name of file with test to the set of LEGAL_TESTS
-LEGAL_TESTS = frozenset(['core', 'string', 'double', 'facility',
-                         'stringlong', 'tali', 'tools'])
+LEGAL_TESTS = ['core', 'string', 'double', 'facility',
+               'stringlong', 'tali', 'tools']
 TESTLIST = ' '.join(["'"+str(t)+"' " for t in LEGAL_TESTS])
 
 OUTPUT_HELP = 'Output File, default "'+RESULTS+'"'


### PR DESCRIPTION
Fix for #94 - I just removed the set where the test list was declared so that it was a list, and all of the set-ish stuff appears to work fine on lists in python.  They now run in the order given in the test list or in the order given on the command line.

As a side note, this pull request is likely to conflict with pull request #95 as they edit the same line of source code.  This one is so simple, you can just look at the diff and fix it up yourself (by removing the frozenset).

I'm hoping this will make the results.txt diff a lot more sane.  You might want to reorder the tests (eg put the strings tests together), and I'll recommend putting the cycle timing tests last when you get to merging them.