### PR TITLE
Feature/updated cycle tests

### DIFF
--- a/native_words.asm
+++ b/native_words.asm
@@ -7727,7 +7727,7 @@ _found_char:
                 lda cp+1
                 adc #0                  ; we only need the carry
                 sta cp+1
-z_word:         
+z_word:         rts
 .scend
 
 

--- a/platform-py65mon.asm
+++ b/platform-py65mon.asm
@@ -32,7 +32,7 @@
 ; the basic I/O routines at the beginning of $f000. We don't want to change
 ; that because it would make using it out of the box harder, so we just 
 ; advance past the virtual hardware addresses.
-.advance $f006
+.advance $f010
 
 ; All vectors currently end up in the same place - we restart the system
 ; hard. If you want to use them on actual hardware, you'll have to redirect

--- a/tests/cycles.fs
+++ b/tests/cycles.fs
@@ -29,18 +29,74 @@ FF00 constant cycles
       AD c, 03 c, F0 c, ]  \ lda $F003
     cycles 2@              \ fetch result
     cycles_overhead d-     \ subtract overhead
-    ." CYCLES: "  ud. cr   \ print results
+    ." CYCLES: "
+    \ d.r isn't available
+    2dup 2710 ( 10000) sm/rem swap drop 0= if bl emit then
+    2dup  3e8 (  1000) sm/rem swap drop 0= if bl emit then
+    2dup   64 (   100) sm/rem swap drop 0= if bl emit then
+    2dup    A (    10) sm/rem swap drop 0= if bl emit then
+    ud.   \ print results
 ;
 
 \ cycle_test updates the address of the given xt in cycle_test_runtime
 \ then it runs the test.
+
+\ To test a word, put any arguments it needs on the stack, use tick
+\ (') on the word to get it's execution token (xt) and then put
+\ cycle_test, then any stack cleanup.
+\ eg. 5 ' dup cycle_test 2drop
 : cycle_test ( xt -- )
     [ ' cycle_test_runtime 4 + ] literal ! cycle_test_runtime ;
 
 decimal
-5 ' drop cycle_test
+\ In all of these tests, a 5 is usually just a dummy input for the
+\ word to work with.
+
+\ skipping cold
+\ skipping abort
+\ skipping quit
+\ skipping abort"
+5 ' abs cycle_test drop
+\ accept is a little weird as it needs some input on its own line.
+pad 20 ' accept cycle_test
+some text
+drop
+\ accept test complete
+           ' align         cycle_test       
+5          ' aligned       cycle_test drop  
+5          ' allot         cycle_test       
+: aword ;  ' always-native cycle_test       
+5 5        ' and           cycle_test drop  
+\ skipping at-xy
+           ' \             cycle_test       
+\ not sure if \ starts on this line
+           ' base          cycle_test drop  
+\ skipping begin
+           ' bell          cycle_test       
+           ' bl            cycle_test drop  
+5 5        ' bounds        cycle_test 2drop 
+\ skipping [char]
+\ skipping [']
+\ skipping branch
+\ skipping bye
+5          ' c,            cycle_test       
+5          ' c@            cycle_test drop  
+5 here     ' c!            cycle_test       
+5 5        ' cell+         cycle_test drop  
+5          ' cells         cycle_test drop  
+           ' char          cycle_test w drop
+5 5        ' char+         cycle_test drop  
+5          ' chars         cycle_test drop  
+pad here 5 ' cmove         cycle_test       
+pad here 5 ' cmove>        cycle_test       
+           ' :             cycle_test wrd ; 
+           ' :noname       cycle_test ; drop
+5          ' ,             cycle_test       
+' aword    ' compile,      cycle_test       
+
+5 ' drop    cycle_test
 
 5 ' dup cycle_test 2drop
 
 s" drop" ' find-name cycle_test
-s" cycle_test" ' find-name cycle_test
+s" aword" ' find-name cycle_test

--- a/tests/cycles.fs
+++ b/tests/cycles.fs
@@ -56,6 +56,9 @@ F008 constant cycles
 : 4drop 2drop 2drop ;
 : 6drop 2drop 2drop 2drop ;
 
+variable myvar
+5 myvar !
+
 decimal
 \ In all of these tests, a 5 is usually just a dummy input for the
 \ word to work with.
@@ -194,11 +197,11 @@ char "       ' parse         cycle_test " 2drop
 5 5          ' +             cycle_test drop      
 5 here       ' +!            cycle_test           
 \ skipping     postpone
-here         ' ?             cycle_test         
+myvar        ' ?             cycle_test         
 5            ' ?dup          cycle_test 2drop     
 \ skipping     r>
 \ skipping     recurse
-             ' refill        cycle_test           
+             ' refill        cycle_test          
 
 drop \ refill
 \ skipping     ]

--- a/tests/cycles.fs
+++ b/tests/cycles.fs
@@ -4,9 +4,9 @@ testing cycle counts
 \ These tests time the number of cylcles each word takes to run for a
 \ given input.  These tests only work with the talitest.py script
 \ which has handlers watching for the reading of the special addresses
-\ $F002 and $F003 that calculate the number of cycles between reading
+\ $F006 and $F007; they calculate the number of cycles between reading
 \ from the special addresses.  The cycles elapsed can then be read
-\ from the virtual memory location $FF00 (as a double word)
+\ from the virtual memory location $F008 (as a double word)
 
 \ Take care when editing this file as the whitespace on the ends of lines is
 \ desired to keep the CYCLE: counts lined up.
@@ -14,22 +14,22 @@ testing cycle counts
 hex
 
 \ The location of the result
-FF00 constant cycles
+F008 constant cycles
 
 \ direct byte compiled
-\  lda $f002
-\  lda $f003
-: cycles_overhead [ AD c, 02 c, F0 c, AD c, 03 c, F0 c, ] cycles 2@ ;
+\  lda $f006
+\  lda $f007
+: cycles_overhead [ AD c, 06 c, F0 c, AD c, 07 c, F0 c, ] cycles 2@ ;
 
 \ direct byte compiled
-\  lda $F002
+\  lda $F006
 \  jsr (xt on stack goes here)
-\  lda $f002
+\  lda $f007
 \ then forth code to fetch and print results.
 : cycle_test_runtime
-    [ AD c, 02 c, F0 c,    \ lda $F002
+    [ AD c, 06 c, F0 c,    \ lda $F006
       20 c,  0000 ,        \ jsr (address to be filled in)
-      AD c, 03 c, F0 c, ]  \ lda $F003
+      AD c, 07 c, F0 c, ]  \ lda $F007
     cycles 2@              \ fetch result
     cycles_overhead d-     \ subtract overhead
     ." CYCLES: "

--- a/tests/cycles.fs
+++ b/tests/cycles.fs
@@ -8,6 +8,9 @@ testing cycle counts
 \ from the special addresses.  The cycles elapsed can then be read
 \ from the virtual memory location $FF00 (as a double word)
 
+\ Take care when editing this file as the whitespace on the ends of lines is
+\ desired to keep the CYCLE: counts lined up.
+
 hex
 
 \ The location of the result
@@ -48,55 +51,217 @@ FF00 constant cycles
 : cycle_test ( xt -- )
     [ ' cycle_test_runtime 4 + ] literal ! cycle_test_runtime ;
 
+\ Some test leave lots of stuff on the stack.
+\ These words help clean up the mess.
+: 4drop 2drop 2drop ;
+: 6drop 2drop 2drop 2drop ;
+
 decimal
 \ In all of these tests, a 5 is usually just a dummy input for the
 \ word to work with.
 
-\ skipping cold
-\ skipping abort
-\ skipping quit
-\ skipping abort"
-5 ' abs cycle_test drop
-\ accept is a little weird as it needs some input on its own line.
-pad 20 ' accept cycle_test
-some text
-drop
-\ accept test complete
-           ' align         cycle_test       
-5          ' aligned       cycle_test drop  
-5          ' allot         cycle_test       
-: aword ;  ' always-native cycle_test       
-5 5        ' and           cycle_test drop  
-\ skipping at-xy
-           ' \             cycle_test       
-\ not sure if \ starts on this line
-           ' base          cycle_test drop  
-\ skipping begin
-           ' bell          cycle_test       
-           ' bl            cycle_test drop  
-5 5        ' bounds        cycle_test 2drop 
-\ skipping [char]
-\ skipping [']
-\ skipping branch
-\ skipping bye
-5          ' c,            cycle_test       
-5          ' c@            cycle_test drop  
-5 here     ' c!            cycle_test       
-5 5        ' cell+         cycle_test drop  
-5          ' cells         cycle_test drop  
-           ' char          cycle_test w drop
-5 5        ' char+         cycle_test drop  
-5          ' chars         cycle_test drop  
-pad here 5 ' cmove         cycle_test       
-pad here 5 ' cmove>        cycle_test       
-           ' :             cycle_test wrd ; 
-           ' :noname       cycle_test ; drop
-5          ' ,             cycle_test       
-' aword    ' compile,      cycle_test       
+\ skipping     cold
+\ skipping     abort
+\ skipping     quit
+\ skipping     abort"
+5            ' abs           cycle_test drop      
+pad 20       ' accept        cycle_test
+some text 
+drop \ accept test complete
+             ' align         cycle_test           
+5            ' aligned       cycle_test drop      
+5            ' allot         cycle_test           
+: aword ;    ' always-native cycle_test           
+5 5          ' and           cycle_test drop      
+\ skipping     at-xy
+             ' \             cycle_test           
+             ' base          cycle_test drop      
+\ skipping     begin
+             ' bell          cycle_test           
+             ' bl            cycle_test drop      
+here 5       ' blank         cycle_test           
+5 5          ' bounds        cycle_test 2drop     
+\ skipping     [char]
+\ skipping     [']
+\ skipping     branch
+\ skipping     bye
+5            ' c,            cycle_test           
+5            ' c@            cycle_test drop      
+5 here       ' c!            cycle_test           
+5            ' cell+         cycle_test drop      
+5            ' cells         cycle_test drop      
+             ' char          cycle_test w drop    
+5            ' char+         cycle_test drop      
+5            ' chars         cycle_test drop      
+pad here 5   ' cmove         cycle_test           
+pad here 5   ' cmove>        cycle_test           
+             ' :             cycle_test wrd ;     
+             ' :noname       cycle_test ; drop    
+5            ' ,             cycle_test           
+' aword      ' compile,      cycle_test           
+: bword ;    ' compile-only  cycle_test           
+5            ' constant      cycle_test mycnst    
+here         ' count         cycle_test 2drop     
+\ skipping     cr
+\ skipping     create
+5. 5.        ' d-            cycle_test 2drop     
+5. 5.        ' d+            cycle_test 2drop     
+5.           ' d>s           cycle_test drop      
+-5.          ' dabs          cycle_test 2drop     
+             ' decimal       cycle_test           
+\ skipping     defer
+             ' depth         cycle_test drop      
+char w       ' digit?        cycle_test 2drop     
+\ skipping     disasm
+5.           ' dnegate       cycle_test 2drop     
+\ skipping     ?do
+\ skipping     do
+\ skipping     does
+\ skipping     .
+\ skipping     ."
+             ' s"            cycle_test " 2drop   
+5            ' drop          cycle_test           
+\ skipping     dump
+5            ' dup           cycle_test 2drop     
+42           ' emit          cycle_test          
+5 5          ' =             cycle_test drop      
+here 5       ' erase         cycle_test           
+here 5 5     ' fill          cycle_test           
+s" 5"        ' evaluate      cycle_test drop      
+5 ' drop     ' execute       cycle_test           
+\ skipping     exit
+             ' false         cycle_test drop      
+here         ' @             cycle_test drop      
+\ making counted string for find
+here 5 c, char a c, char w c, char o c,
+char r c, char d c,
+             ' find          cycle_test 2drop     
+s" aword"    ' find-name     cycle_test drop      
+5. 5         ' fm/mod        cycle_test 2drop     
+5 5          ' >             cycle_test drop      
+             ' here          cycle_test drop      
+             ' hex           cycle_test decimal   
+\ skipping     hold
+\ skipping     i
+: cword ;    ' immediate     cycle_test           
+             ' input         cycle_test drop      
+' dup        ' int>name      cycle_test drop      
+5            ' invert        cycle_test drop      
+\ skipping     j
+             ' key           cycle_test drop      
 
-5 ' drop    cycle_test
+             ' latestnt      cycle_test drop      
+             ' latestxt      cycle_test drop      
+\ skipping     leave
+\ skipping     [
+\ skipping     <#
+5 5          ' <             cycle_test drop      
+\ skipping     literal
+\ skipping     loop
+\ skipping     +loop
+5 5          ' lshift        cycle_test drop      
+5 5          ' m*            cycle_test 2drop     
+             ' marker        cycle_test marka     
+             ' marka         cycle_test           
+5 5          ' max           cycle_test drop      
+5 5          ' min           cycle_test drop      
+5 5          ' -             cycle_test drop      
+s" txt   "   ' -trailing     cycle_test 2drop     
+here s" a"   ' move          cycle_test           
+' + int>name ' name>int      cycle_test drop      
+' + int>name ' name>string   cycle_test 2drop     
+             ' nc-limit      cycle_test drop      
+5            ' negate        cycle_test drop      
+: dword ;    ' never-native  cycle_test           
+5 5          ' nip           cycle_test drop      
+5 5          ' <>            cycle_test drop      
+5 5 5        ' -rot          cycle_test 2drop drop
+s" 5"        ' number        cycle_test drop      
+\ skipping     #
+\ skipping     #>
+\ skipping     #s
+             ' 1             cycle_test drop      
+5            ' 1+            cycle_test drop      
+5            ' 1-            cycle_test drop      
+5 5          ' or            cycle_test drop      
+             ' output        cycle_test drop      
+5 5          ' over          cycle_test 2drop drop
+             ' pad           cycle_test drop      
+\ skipping     page
+             ' parse-name    cycle_test a 2drop   
+char "       ' parse         cycle_test " 2drop   
+5 0          ' pick          cycle_test 2drop     
+5 5          ' +             cycle_test drop      
+5 here       ' +!            cycle_test           
+\ skipping     postpone
+here         ' ?             cycle_test         
+5            ' ?dup          cycle_test 2drop     
+\ skipping     r>
+\ skipping     recurse
+             ' refill        cycle_test           
 
-5 ' dup cycle_test 2drop
+drop \ refill
+\ skipping     ]
+5 5 5        ' rot           cycle_test 2drop drop
+5 5          ' rshift        cycle_test drop      
+             ' s"            cycle_test " 2drop   
+5            ' s>d           cycle_test 2drop     
+\ skipping     ;
+\ skipping     sign
+s" abc" 1    ' /string       cycle_test 2drop     
+\ skipping     sliteral
+5. 5         ' sm/rem        cycle_test 2drop     
+             ' source        cycle_test 2drop     
+             ' source-id     cycle_test drop      
+             ' space         cycle_test          
+1            ' spaces        cycle_test          
+5 5          ' *             cycle_test drop      
+             ' state         cycle_test drop      
+5 here       ' !             cycle_test           
+5 5          ' swap          cycle_test 2drop     
+             ' '             cycle_test aword drop
+\ postponing   to ( see value )
+' aword      ' >body         cycle_test drop      
+             ' >in           cycle_test drop      
+0. s" 55"    ' >number       cycle_test 4drop     
+\ skipping     >r
+             ' true          cycle_test drop      
+5 5          ' tuck          cycle_test 2drop drop
+             ' 2             cycle_test drop      
+5 5          ' 2drop         cycle_test           
+5 5          ' 2dup          cycle_test 4drop     
+here         ' 2@            cycle_test 2drop     
+5 5 5 5      ' 2over         cycle_test 6drop     
+\ skipping     2r@
+\ skipping     2r>
+5            ' 2/            cycle_test drop      
+5            ' 2*            cycle_test drop      
+5. here      ' 2!            cycle_test           
+5 5 5 5      ' 2swap         cycle_test 4drop     
+\ skipping     2>r
+             ' 2variable     cycle_test eword     
+             ' eword         cycle_test drop      
+s" *"        ' type          cycle_test          
+5            ' u.            cycle_test         
+5 5          ' u<            cycle_test drop      
+             ' uf-strip      cycle_test drop      
+5. 5         ' um/mod        cycle_test 2drop     
+5 5          ' um*           cycle_test 2drop     
+\ skipping     unloop
+             ' unused        cycle_test drop      
+5            ' value         cycle_test fword     
+             ' fword         cycle_test drop      
+5            ' to            cycle_test fword     
+             ' variable      cycle_test gword     
+             ' gword         cycle_test drop      
+char "       ' word          cycle_test "txt" drop
+\ skipping     words
+' aword      ' wordsize      cycle_test drop      
+5 5          ' xor           cycle_test drop      
+             ' 0             cycle_test drop      
+\ skipping     0branch
+5            ' 0=            cycle_test drop      
+5            ' 0>            cycle_test drop      
+5            ' 0<            cycle_test drop      
+5            ' 0<>           cycle_test drop      
 
-s" drop" ' find-name cycle_test
-s" aword" ' find-name cycle_test

--- a/tests/talitest.py
+++ b/tests/talitest.py
@@ -11,7 +11,7 @@ PROGRAMMERS : Sam Colwell and Scot W. Stevenson
 FILE        : talitest.py
 
 First version: 16. May 2018
-This version: 07. July 2018
+This version: 09. July 2018
 """
 
 import argparse
@@ -176,15 +176,15 @@ with open(args.output, 'wb') as fout:
                 read out of virtual memory.  Note that the hex value
                 12345678 is stored in memory as bytes 34 12 78 56.
                 The value will be read (as a double) starting at
-                memory address 0xFF00
+                memory address 0xF008
                 """
-                if address == 0xFF00:
+                if address == 0xF008:
                     return ((self.cycle_end-self.cycle_start)&0x00FF0000)>>16
-                elif address == 0xFF01:
+                elif address == 0xF009:
                     return ((self.cycle_end-self.cycle_start)&0xFF000000)>>24
-                elif address == 0xFF02:
+                elif address == 0xF00A:
                     return ((self.cycle_end-self.cycle_start)&0x000000FF)
-                elif address == 0xFF03:
+                elif address == 0xF00B:
                     return ((self.cycle_end-self.cycle_start)&0x0000FF00)>>8
                 else:
                     return 0
@@ -195,9 +195,9 @@ with open(args.output, 'wb') as fout:
             mem.subscribe_to_read([0xF004], getc_from_test)
 
             # Install the handlers for timing cycles.
-            mem.subscribe_to_read([0xF002], update_cycle_start)
-            mem.subscribe_to_read([0xF003], update_cycle_end)
-            mem.subscribe_to_read([0xFF00, 0xFF01, 0xFF02, 0xFF03], read_cycle_count)
+            mem.subscribe_to_read([0xF006], update_cycle_start)
+            mem.subscribe_to_read([0xF007], update_cycle_end)
+            mem.subscribe_to_read([0xF008, 0xF009, 0xF00A, 0xF00B], read_cycle_count)
             self._mpu.memory = mem
 
     # Start Tali.


### PR DESCRIPTION
#103 
I moved the start of the py65mon kernel up a little bit in memory to make room for putting the cycle test words all together in the memory map.  Start is now a read at 0xF006, Stop is now a read at 0xF007 and the result shows up (as a double) at 0xF008-0xF00B

The cycles.fs file has some whitespace on the end of each line to make the CYCLES: printout line up on the screen and in the results.txt file.  It also has extra whitespace in each line to make the names of the tested routines line up.  I went through WORDLIST.md and wrote a test for every word except compile-only words and a few with lots of output (like see and disasm).

I didn't include the generated files and compiled binary file so this request wouldn't conflict with the outstanding pull request and upcoming pull requests.  After merging, you'll want to run make in the main directory and then run the full test suite before pushing.  The cycle tests should show up at the bottom.

I also discovered an issue with **WORD** - it was missing an `rts` at the very end and was falling into the code for **WORDS**.  It's fixed in this pull request.