### PR TITLE
Changed tests to use ANS test words

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 # expected to have the asciidoc toolchain installed
 
 COMMON_SOURCES=taliforth.asm definitions.asm native_words.asm headers.asm strings.asm forth_words.asc user_words.asc
+TEST_SOURCES=tests/core.fs tests/string.fs tests/double.fs tests/facility.fs tests/stringlong.fs tests/tali.fs tests/tools.fs tests/block.fs tests/user.fs tests/cycles.fs tests/talitest.py
 
 all: taliforth-py65mon.bin | WORDLIST.md
 
@@ -26,7 +27,9 @@ WORDLIST.md: docs/WORDLIST.md
 
 
 # Some convenience targets to make running the tests and simulation easier.
-tests:	taliforth-py65mon.bin
+tests:	tests/results.txt
+
+tests/results.txt:	taliforth-py65mon.bin $(TEST_SOURCES)
 	cd tests; ./talitest.py
 
 sim:	taliforth-py65mon.bin

--- a/tests/block.fs
+++ b/tests/block.fs
@@ -4,15 +4,15 @@ testing block words: BLK SCR LOAD THRU BUFFER BLOCK UPDATE FLUSH
 marker block_tests
 
 \ Bring in a 4-block ram drive
-{ 4 block-ramdrive-init -> }
+T{ 4 block-ramdrive-init -> }T
 
 \ Put a string into the first block.
-{ : teststring s" Testing Blocks!" ; -> }
-{ : teststringlength teststring swap drop ; -> }
-{ teststring 0 block swap move update flush -> }
+T{ : teststring s" Testing Blocks!" ; -> }T
+T{ : teststringlength teststring swap drop ; -> }T
+T{ teststring 0 block swap move update flush -> }T
 
 \ See if it's in the ramdrive.
-{ ramdrive teststringlength teststring compare -> 0 }
+T{ ramdrive teststringlength teststring compare -> 0 }T
 
 \ We don't have an official editor yet, so bring in just
 \ enough to create some basic screens.
@@ -53,11 +53,11 @@ decimal
   dup scr ! buffer 1024 blank update ;
 
 
-{ 0 erase-screen flush -> }
+T{ 0 erase-screen flush -> }T
 
 \ Make sure the test string from before is gone by looking for space
 \ at the beginning of the ramdrive.
-{ s"           " ramdrive 10 compare -> 0 }
+T{ s"           " ramdrive 10 compare -> 0 }T
 
 \ Enter screens for testing LOAD and THRU
 1 enter-screen
@@ -79,12 +79,12 @@ decimal
 ( 15 )
 
 \ Load screen 1 and then check for the expected side effects.
-{ 1 load -> }
+T{ 1 load -> }T
 
 \ BLK should be 0 while in the string and 1 while in the rest of the block.
-{ blkinscreen @  -> 1 }
-{ blkinstring @  -> 0 }
-{ blkinscreenA @ -> 1 }
+T{ blkinscreen @  -> 1 }T
+T{ blkinstring @  -> 0 }T
+T{ blkinscreenA @ -> 1 }T
 
 2 enter-screen
 ( Test screen 2 )
@@ -122,17 +122,17 @@ decimal
 ( 14 ) ( blkinscreen4 should be 3 because we are on screen 3 )
 ( 15 ) ( testing the last line )     blk @ constant blkinscreenC
 
-{ 2 list -> }
-{ scr @ -> 2 } \ Screen 2 is the last one we listed.
+T{ 2 list -> }T
+T{ scr @ -> 2 }T \ Screen 2 is the last one we listed.
 
 \ Load screens 2 and 3 with THRU and check for side effects.
 \ shouldbe19 should be 5 + 7 + 7 because screen 2 loads screen 3.
-{ 2 3 thru -> }
+T{ 2 3 thru -> }T
 
-{ blkinscreenB @ -> 2  } \ Note: blkinscreen3 is a variable.
-{ blkinscreenC   -> 3  } \ Note: blkinscreen4 is a constant.
-{ blkinscreenD   -> 2  } \ Note: blkinscreen5 is a constant.
-{ shouldbe19 @   -> 19 }
+T{ blkinscreenB @ -> 2  }T \ Note: blkinscreen3 is a variable.
+T{ blkinscreenC   -> 3  }T \ Note: blkinscreen4 is a constant.
+T{ blkinscreenD   -> 2  }T \ Note: blkinscreen5 is a constant.
+T{ shouldbe19 @   -> 19 }T
 
 \ Release all of the memory used.
 block_tests

--- a/tests/core.fs
+++ b/tests/core.fs
@@ -23,79 +23,79 @@ marker core_tests
 \ ------------------------------------------------------------------------
 testing basic assumptions
 
-{ -> }     \ Start with clean slate
+T{ -> }T     \ Start with clean slate
 ( test if any bits are set; answer in base 1 )
-{ : bitsset? if 0 0 else 0 then ; -> }
-{  0 bitsset? -> 0 }   \ zero is all bits clear
-{  1 bitsset? -> 0 0 } \ other number have at least one bit
-{ -1 bitsset? -> 0 0 }
+T{ : bitsset? if 0 0 else 0 then ; -> }T
+T{  0 bitsset? -> 0 }T   \ zero is all bits clear
+T{  1 bitsset? -> 0 0 }T \ other number have at least one bit
+T{ -1 bitsset? -> 0 0 }T
 
 \ ------------------------------------------------------------------------
 testing booleans: and invert or xor
 
-{ 0 0 and -> 0 }
-{ 0 1 and -> 0 }
-{ 1 0 and -> 0 }
-{ 1 1 and -> 1 }
+T{ 0 0 and -> 0 }T
+T{ 0 1 and -> 0 }T
+T{ 1 0 and -> 0 }T
+T{ 1 1 and -> 1 }T
 
-{ 0 invert 1 and -> 1 }
-{ 1 invert 1 and -> 0 }
+T{ 0 invert 1 and -> 1 }T
+T{ 1 invert 1 and -> 0 }T
 
 0 constant 0s
 0 invert constant 1s
 
-{ 0s invert -> 1s }
-{ 1s invert -> 0s }
+T{ 0s invert -> 1s }T
+T{ 1s invert -> 0s }T
 
-{ 0s 0s and -> 0s }
-{ 0s 1s and -> 0s }
-{ 1s 0s and -> 0s }
-{ 1s 1s and -> 1s }
+T{ 0s 0s and -> 0s }T
+T{ 0s 1s and -> 0s }T
+T{ 1s 0s and -> 0s }T
+T{ 1s 1s and -> 1s }T
 
-{ 0s 0s or -> 0s }
-{ 0s 1s or -> 1s }
-{ 1s 0s or -> 1s }
-{ 1s 1s or -> 1s }
+T{ 0s 0s or -> 0s }T
+T{ 0s 1s or -> 1s }T
+T{ 1s 0s or -> 1s }T
+T{ 1s 1s or -> 1s }T
 
-{ 0s 0s xor -> 0s }
-{ 0s 1s xor -> 1s }
-{ 1s 0s xor -> 1s }
-{ 1s 1s xor -> 0s }
+T{ 0s 0s xor -> 0s }T
+T{ 0s 1s xor -> 1s }T
+T{ 1s 0s xor -> 1s }T
+T{ 1s 1s xor -> 0s }T
 
 \ ------------------------------------------------------------------------
 testing 2* 2/ lshift rshift
 
 ( we trust 1s, invert, and bitsset?; we will confirm rshift later )
 1s 1 rshift invert constant msb
-{ msb bitsset? -> 0 0 }
+T{ msb bitsset? -> 0 0 }T
 
-{ 0s 2* -> 0s }
-{ 1 2* -> 2 }
-{ 4000 2* -> 8000 }
-{ 1s 2* 1 xor -> 1s }
-{ msb 2* -> 0s }
+T{ 0s 2* -> 0s }T
+T{ 1 2* -> 2 }T
+T{ 4000 2* -> 8000 }T
+T{ 1s 2* 1 xor -> 1s }T
+T{ msb 2* -> 0s }T
 
-{ 0s 2/ -> 0s }
-{ 1 2/ -> 0 }
-{ 4000 2/ -> 2000 }
-{ 1s 2/ -> 1s } \ msb propogated
-{ 1s 1 xor 2/ -> 1s }
-{ msb 2/ msb and -> msb }
+T{ 0s 2/ -> 0s }T
+T{ 1 2/ -> 0 }T
+T{ 4000 2/ -> 2000 }T
+T{ 1s 2/ -> 1s }T \ msb propogated
+T{ 1s 1 xor 2/ -> 1s }T
+T{ msb 2/ msb and -> msb }T
 
-{ 1 0 lshift -> 1 }
-{ 1 1 lshift -> 2 }
-{ 1 2 lshift -> 4 }
-{ 1 f lshift -> 8000 } \ biggest guaranteed shift
-{ 1s 1 lshift 1 xor -> 1s }
-{ msb 1 lshift -> 0 }
+T{ 1 0 lshift -> 1 }T
+T{ 1 1 lshift -> 2 }T
+T{ 1 2 lshift -> 4 }T
+T{ 1 f lshift -> 8000 }T \ biggest guaranteed shift
+T{ 1s 1 lshift 1 xor -> 1s }T
+T{ msb 1 lshift -> 0 }T
 
-{ 1 0 rshift -> 1 }
-{ 1 1 rshift -> 0 }
-{ 2 1 rshift -> 1 }
-{ 4 2 rshift -> 1 }
-{ 8000 f rshift -> 1 } \ biggest
-{ msb 1 rshift msb and -> 0 }  \ rshift zero fills msbs
-{ msb 1 rshift 2* -> msb }
+T{ 1 0 rshift -> 1 }T
+T{ 1 1 rshift -> 0 }T
+T{ 2 1 rshift -> 1 }T
+T{ 4 2 rshift -> 1 }T
+T{ 8000 f rshift -> 1 }T \ biggest
+T{ msb 1 rshift msb and -> 0 }T  \ rshift zero fills msbs
+T{ msb 1 rshift 2* -> msb }T
 
 \ ------------------------------------------------------------------------
 testing comparisons: true false 0= 0<> = <> 0< 0> < > u< min max within
@@ -108,406 +108,406 @@ testing comparisons: true false 0= 0<> = <> 0< 0> < > u< min max within
 0s constant <false>
 1s constant <true>
 
-{ false -> 0 }
-{ false -> <false> }
+T{ false -> 0 }T
+T{ false -> <false> }T
 
-{ true -> <true> }
-{ true -> 0 invert }
+T{ true -> <true> }T
+T{ true -> 0 invert }T
 
-{ 0 0= -> <true> }
-{ 1 0= -> <false> }
-{ 2 0= -> <false> }
-{ -1 0= -> <false> }
-{ max-uint 0= -> <false> }
-{ min-int 0= -> <false> }
-{ max-int 0= -> <false> }
+T{ 0 0= -> <true> }T
+T{ 1 0= -> <false> }T
+T{ 2 0= -> <false> }T
+T{ -1 0= -> <false> }T
+T{ max-uint 0= -> <false> }T
+T{ min-int 0= -> <false> }T
+T{ max-int 0= -> <false> }T
 
-{ 0 0<> -> <false> }
-{ 1 0<> -> <true> }
-{ 2 0<> -> <true> }
-{ -1 0<> -> <true> }
-{ max-uint 0<> -> <true> }
-{ min-int 0<> -> <true> }
-{ max-int 0<> -> <true> }
+T{ 0 0<> -> <false> }T
+T{ 1 0<> -> <true> }T
+T{ 2 0<> -> <true> }T
+T{ -1 0<> -> <true> }T
+T{ max-uint 0<> -> <true> }T
+T{ min-int 0<> -> <true> }T
+T{ max-int 0<> -> <true> }T
 
-{ 0 0 = -> <true> }
-{ 1 1 = -> <true> }
-{ -1 -1 = -> <true> }
-{ 1 0 = -> <false> }
-{ -1 0 = -> <false> }
-{ 0 1 = -> <false> }
-{ 0 -1 = -> <false> }
+T{ 0 0 = -> <true> }T
+T{ 1 1 = -> <true> }T
+T{ -1 -1 = -> <true> }T
+T{ 1 0 = -> <false> }T
+T{ -1 0 = -> <false> }T
+T{ 0 1 = -> <false> }T
+T{ 0 -1 = -> <false> }T
 
-{ 0 0 <> -> <false> }
-{ 1 1 <> -> <false> }
-{ -1 -1 <> -> <false> }
-{ 1 0 <> -> <true> }
-{ -1 0 <> -> <true> }
-{ 0 1 <> -> <true> }
-{ 0 -1 <> -> <true> }
+T{ 0 0 <> -> <false> }T
+T{ 1 1 <> -> <false> }T
+T{ -1 -1 <> -> <false> }T
+T{ 1 0 <> -> <true> }T
+T{ -1 0 <> -> <true> }T
+T{ 0 1 <> -> <true> }T
+T{ 0 -1 <> -> <true> }T
 
-{ 0 0< -> <false> }
-{ -1 0< -> <true> }
-{ min-int 0< -> <true> }
-{ 1 0< -> <false> }
-{ max-int 0< -> <false> }
+T{ 0 0< -> <false> }T
+T{ -1 0< -> <true> }T
+T{ min-int 0< -> <true> }T
+T{ 1 0< -> <false> }T
+T{ max-int 0< -> <false> }T
 
-{ 0 0> -> <false> }
-{ -1 0> -> <false> }
-{ min-int 0> -> <false> }
-{ 1 0> -> <true> }
-{ max-int 0> -> <true> }
+T{ 0 0> -> <false> }T
+T{ -1 0> -> <false> }T
+T{ min-int 0> -> <false> }T
+T{ 1 0> -> <true> }T
+T{ max-int 0> -> <true> }T
 
-{ 0 1 < -> <true> }
-{ 1 2 < -> <true> }
-{ -1 0 < -> <true> }
-{ -1 1 < -> <true> }
-{ min-int 0 < -> <true> }
-{ min-int max-int < -> <true> }
-{ 0 max-int < -> <true> }
-{ 0 0 < -> <false> }
-{ 1 1 < -> <false> }
-{ 1 0 < -> <false> }
-{ 2 1 < -> <false> }
-{ 0 -1 < -> <false> }
-{ 1 -1 < -> <false> }
-{ 0 min-int < -> <false> }
-{ max-int min-int < -> <false> }
-{ max-int 0 < -> <false> }
+T{ 0 1 < -> <true> }T
+T{ 1 2 < -> <true> }T
+T{ -1 0 < -> <true> }T
+T{ -1 1 < -> <true> }T
+T{ min-int 0 < -> <true> }T
+T{ min-int max-int < -> <true> }T
+T{ 0 max-int < -> <true> }T
+T{ 0 0 < -> <false> }T
+T{ 1 1 < -> <false> }T
+T{ 1 0 < -> <false> }T
+T{ 2 1 < -> <false> }T
+T{ 0 -1 < -> <false> }T
+T{ 1 -1 < -> <false> }T
+T{ 0 min-int < -> <false> }T
+T{ max-int min-int < -> <false> }T
+T{ max-int 0 < -> <false> }T
 
-{ 0 1 > -> <false> }
-{ 1 2 > -> <false> }
-{ -1 0 > -> <false> }
-{ -1 1 > -> <false> }
-{ min-int 0 > -> <false> }
-{ min-int max-int > -> <false> }
-{ 0 max-int > -> <false> }
-{ 0 0 > -> <false> }
-{ 1 1 > -> <false> }
-{ 1 0 > -> <true> }
-{ 2 1 > -> <true> }
-{ 0 -1 > -> <true> }
-{ 1 -1 > -> <true> }
-{ 0 min-int > -> <true> }
-{ max-int min-int > -> <true> }
-{ max-int 0 > -> <true> }
+T{ 0 1 > -> <false> }T
+T{ 1 2 > -> <false> }T
+T{ -1 0 > -> <false> }T
+T{ -1 1 > -> <false> }T
+T{ min-int 0 > -> <false> }T
+T{ min-int max-int > -> <false> }T
+T{ 0 max-int > -> <false> }T
+T{ 0 0 > -> <false> }T
+T{ 1 1 > -> <false> }T
+T{ 1 0 > -> <true> }T
+T{ 2 1 > -> <true> }T
+T{ 0 -1 > -> <true> }T
+T{ 1 -1 > -> <true> }T
+T{ 0 min-int > -> <true> }T
+T{ max-int min-int > -> <true> }T
+T{ max-int 0 > -> <true> }T
 
-{ 0 1 u< -> <true> }
-{ 1 2 u< -> <true> }
-{ 0 mid-uint u< -> <true> }
-{ 0 max-uint u< -> <true> }
-{ mid-uint max-uint u< -> <true> }
-{ 0 0 u< -> <false> }
-{ 1 1 u< -> <false> }
-{ 1 0 u< -> <false> }
-{ 2 1 u< -> <false> }
-{ mid-uint 0 u< -> <false> }
-{ max-uint 0 u< -> <false> }
-{ max-uint mid-uint u< -> <false> }
+T{ 0 1 u< -> <true> }T
+T{ 1 2 u< -> <true> }T
+T{ 0 mid-uint u< -> <true> }T
+T{ 0 max-uint u< -> <true> }T
+T{ mid-uint max-uint u< -> <true> }T
+T{ 0 0 u< -> <false> }T
+T{ 1 1 u< -> <false> }T
+T{ 1 0 u< -> <false> }T
+T{ 2 1 u< -> <false> }T
+T{ mid-uint 0 u< -> <false> }T
+T{ max-uint 0 u< -> <false> }T
+T{ max-uint mid-uint u< -> <false> }T
 
-{ 1 0 u> -> <true> }
-{ 2 1 u> -> <true> }
-{ mid-uint 0 u> -> <true> }
-{ max-uint 0 u> -> <true> }
-{ max-uint mid-uint u> -> <true> }
-{ 0 0 u> -> <false> }
-{ 1 1 u> -> <false> }
-{ 0 1 u> -> <false> }
-{ 1 2 u> -> <false> }
-{ 0 mid-uint u> -> <false> }
-{ 0 max-uint u> -> <false> }
-{ mid-uint max-uint u> -> <false> }
+T{ 1 0 u> -> <true> }T
+T{ 2 1 u> -> <true> }T
+T{ mid-uint 0 u> -> <true> }T
+T{ max-uint 0 u> -> <true> }T
+T{ max-uint mid-uint u> -> <true> }T
+T{ 0 0 u> -> <false> }T
+T{ 1 1 u> -> <false> }T
+T{ 0 1 u> -> <false> }T
+T{ 1 2 u> -> <false> }T
+T{ 0 mid-uint u> -> <false> }T
+T{ 0 max-uint u> -> <false> }T
+T{ mid-uint max-uint u> -> <false> }T
 
-{ 0 1 min -> 0 }
-{ 1 2 min -> 1 }
-{ -1 0 min -> -1 }
-{ -1 1 min -> -1 }
-{ min-int 0 min -> min-int }
-{ min-int max-int min -> min-int }
-{ 0 max-int min -> 0 }
-{ 0 0 min -> 0 }
-{ 1 1 min -> 1 }
-{ 1 0 min -> 0 }
-{ 2 1 min -> 1 }
-{ 0 -1 min -> -1 }
-{ 1 -1 min -> -1 }
-{ 0 min-int min -> min-int }
-{ max-int min-int min -> min-int }
-{ max-int 0 min -> 0 }
+T{ 0 1 min -> 0 }T
+T{ 1 2 min -> 1 }T
+T{ -1 0 min -> -1 }T
+T{ -1 1 min -> -1 }T
+T{ min-int 0 min -> min-int }T
+T{ min-int max-int min -> min-int }T
+T{ 0 max-int min -> 0 }T
+T{ 0 0 min -> 0 }T
+T{ 1 1 min -> 1 }T
+T{ 1 0 min -> 0 }T
+T{ 2 1 min -> 1 }T
+T{ 0 -1 min -> -1 }T
+T{ 1 -1 min -> -1 }T
+T{ 0 min-int min -> min-int }T
+T{ max-int min-int min -> min-int }T
+T{ max-int 0 min -> 0 }T
 
-{ 0 1 max -> 1 }
-{ 1 2 max -> 2 }
-{ -1 0 max -> 0 }
-{ -1 1 max -> 1 }
-{ min-int 0 max -> 0 }
-{ min-int max-int max -> max-int }
-{ 0 max-int max -> max-int }
-{ 0 0 max -> 0 }
-{ 1 1 max -> 1 }
-{ 1 0 max -> 1 }
-{ 2 1 max -> 2 }
-{ 0 -1 max -> 0 }
-{ 1 -1 max -> 1 }
-{ 0 min-int max -> 0 }
-{ max-int min-int max -> max-int }
-{ max-int 0 max -> max-int }
+T{ 0 1 max -> 1 }T
+T{ 1 2 max -> 2 }T
+T{ -1 0 max -> 0 }T
+T{ -1 1 max -> 1 }T
+T{ min-int 0 max -> 0 }T
+T{ min-int max-int max -> max-int }T
+T{ 0 max-int max -> max-int }T
+T{ 0 0 max -> 0 }T
+T{ 1 1 max -> 1 }T
+T{ 1 0 max -> 1 }T
+T{ 2 1 max -> 2 }T
+T{ 0 -1 max -> 0 }T
+T{ 1 -1 max -> 1 }T
+T{ 0 min-int max -> 0 }T
+T{ max-int min-int max -> max-int }T
+T{ max-int 0 max -> max-int }T
 
-{ 1 2 4 within -> <false> }
-{ 2 2 4 within -> <true> }
-{ 3 2 4 within -> <true> }
-{ 4 2 4 within -> <false> }
-{ 5 2 4 within -> <false> }
+T{ 1 2 4 within -> <false> }T
+T{ 2 2 4 within -> <true> }T
+T{ 3 2 4 within -> <true> }T
+T{ 4 2 4 within -> <false> }T
+T{ 5 2 4 within -> <false> }T
 
-{ 0 2 4 within -> <false> }
-{ 1 0 4 within -> <true> }
-{ 0 0 4 within -> <true> }
-{ 4 0 4 within -> <false> }
-{ 5 0 4 within -> <false> }
+T{ 0 2 4 within -> <false> }T
+T{ 1 0 4 within -> <true> }T
+T{ 0 0 4 within -> <true> }T
+T{ 4 0 4 within -> <false> }T
+T{ 5 0 4 within -> <false> }T
 
-{ -1 -3 -1 within -> <false> }
-{ -2 -3 -1 within -> <true> }
-{ -3 -3 -1 within -> <true> }
-{ -4 -3 -1 within -> <false> }
+T{ -1 -3 -1 within -> <false> }T
+T{ -2 -3 -1 within -> <true> }T
+T{ -3 -3 -1 within -> <true> }T
+T{ -4 -3 -1 within -> <false> }T
 
-{ -2 -2 0 within -> <true> }
-{ -1 -2 0 within -> <true> }
-{ 0 -2 0 within -> <false> }
-{ 1 -2 0 within -> <false> }
+T{ -2 -2 0 within -> <true> }T
+T{ -1 -2 0 within -> <true> }T
+T{ 0 -2 0 within -> <false> }T
+T{ 1 -2 0 within -> <false> }T
 
-{ 0 min-int max-int within -> <true> }
-{ 1 min-int max-int within -> <true> }
-{ -1 min-int max-int within -> <true> }
-{ min-int min-int max-int within -> <true> }
-{ max-int min-int max-int within -> <false> }
+T{ 0 min-int max-int within -> <true> }T
+T{ 1 min-int max-int within -> <true> }T
+T{ -1 min-int max-int within -> <true> }T
+T{ min-int min-int max-int within -> <true> }T
+T{ max-int min-int max-int within -> <false> }T
 
 \ ------------------------------------------------------------------------
 testing stack ops: 2drop 2dup 2over 2swap ?dup depth drop dup nip over rot -rot 
 testing stack ops: swap tuck pick
 
-{ 1 2 2drop -> }
-{ 1 2 2dup -> 1 2 1 2 }
-{ 1 2 3 4 2over -> 1 2 3 4 1 2 }
-{ 1 2 3 4 2swap -> 3 4 1 2 }
-{ 0 ?dup -> 0 }
-{ 1 ?dup -> 1 1 }
-{ -1 ?dup -> -1 -1 }
-{ depth -> 0 }
-{ 0 depth -> 0 1 }
-{ 0 1 depth -> 0 1 2 }
-{ 0 drop -> }
-{ 1 2 drop -> 1 }
-{ 1 dup -> 1 1 }
-{ 1 2 nip -> 2 }
-{ 1 2 over -> 1 2 1 }
-{ 1 2 3 rot -> 2 3 1 }
-{ 1 2 3 -rot -> 3 1 2 }
-{ 1 2 swap -> 2 1 }
+T{ 1 2 2drop -> }T
+T{ 1 2 2dup -> 1 2 1 2 }T
+T{ 1 2 3 4 2over -> 1 2 3 4 1 2 }T
+T{ 1 2 3 4 2swap -> 3 4 1 2 }T
+T{ 0 ?dup -> 0 }T
+T{ 1 ?dup -> 1 1 }T
+T{ -1 ?dup -> -1 -1 }T
+T{ depth -> 0 }T
+T{ 0 depth -> 0 1 }T
+T{ 0 1 depth -> 0 1 2 }T
+T{ 0 drop -> }T
+T{ 1 2 drop -> 1 }T
+T{ 1 dup -> 1 1 }T
+T{ 1 2 nip -> 2 }T
+T{ 1 2 over -> 1 2 1 }T
+T{ 1 2 3 rot -> 2 3 1 }T
+T{ 1 2 3 -rot -> 3 1 2 }T
+T{ 1 2 swap -> 2 1 }T
 
 \ There is no formal ANS test for TUCK, this added 01. July 2018
-{ 2 1 tuck -> 1 2 1 }
+T{ 2 1 tuck -> 1 2 1 }T
 
 \ There is no formal ANS test for PICK, this added 01. July 2018
 \ Note that ANS's PICK is different from FIG Forth PICK
-{ 1      0 pick -> 1 1 }    \ Defined by standard: 0 PICK is same as DUP
-{ 1 2    1 pick -> 1 2 1 }  \ Defined by standard: 1 PICK is same as OVER
-{ 1 2 3  2 pick -> 1 2 3 1 }
+T{ 1      0 pick -> 1 1 }T    \ Defined by standard: 0 PICK is same as DUP
+T{ 1 2    1 pick -> 1 2 1 }T  \ Defined by standard: 1 PICK is same as OVER
+T{ 1 2 3  2 pick -> 1 2 3 1 }T
 
 \ ------------------------------------------------------------------------
 testing >r r> r@ 2>r 2r> 2r@
 
-{ : gr1 >r r> ; -> }
-{ : gr2 >r r@ r> drop ; -> }
-{ 123 gr1 -> 123 }
-{ 123 gr2 -> 123 }
-{ 1s gr1 -> 1s } \ return stack holds cells
+T{ : gr1 >r r> ; -> }T
+T{ : gr2 >r r@ r> drop ; -> }T
+T{ 123 gr1 -> 123 }T
+T{ 123 gr2 -> 123 }T
+T{ 1s gr1 -> 1s }T \ return stack holds cells
 
 \ There are no official ANS tests for 2>R, 2R>, or 2R@, added 22. June 2018
-{ : gr3 2>r 2r> ; -> }
-{ : gr4 2>r 2r@ 2r> 2drop ; -> }
-{ : gr5 2>r r> r> ; } \ must reverse sequence, as 2r> is not r> r> 
-{ 123. gr3 -> 123. }
-{ 123. gr4 -> 123. }
-{ 123. gr5 -> 0 123 }
+T{ : gr3 2>r 2r> ; -> }T
+T{ : gr4 2>r 2r@ 2r> 2drop ; -> }T
+T{ : gr5 2>r r> r> ; }T \ must reverse sequence, as 2r> is not r> r> 
+T{ 123. gr3 -> 123. }T
+T{ 123. gr4 -> 123. }T
+T{ 123. gr5 -> 0 123 }T
 
 \ ------------------------------------------------------------------------
 testing add/subtract: + - 1+ 1- abs negate 
 
-{ 0 5 + -> 5 }
-{ 5 0 + -> 5 }
-{ 0 -5 + -> -5 }
-{ -5 0 + -> -5 }
-{ 1 2 + -> 3 }
-{ 1 -2 + -> -1 }
-{ -1 2 + -> 1 }
-{ -1 -2 + -> -3 }
-{ -1 1 + -> 0 }
-{ mid-uint 1 + -> mid-uint+1 }
+T{ 0 5 + -> 5 }T
+T{ 5 0 + -> 5 }T
+T{ 0 -5 + -> -5 }T
+T{ -5 0 + -> -5 }T
+T{ 1 2 + -> 3 }T
+T{ 1 -2 + -> -1 }T
+T{ -1 2 + -> 1 }T
+T{ -1 -2 + -> -3 }T
+T{ -1 1 + -> 0 }T
+T{ mid-uint 1 + -> mid-uint+1 }T
 
-{ 0 5 - -> -5 }
-{ 5 0 - -> 5 }
-{ 0 -5 - -> 5 }
-{ -5 0 - -> -5 }
-{ 1 2 - -> -1 }
-{ 1 -2 - -> 3 }
-{ -1 2 - -> -3 }
-{ -1 -2 - -> 1 }
-{ 0 1 - -> -1 }
-{ mid-uint+1 1 - -> mid-uint }
+T{ 0 5 - -> -5 }T
+T{ 5 0 - -> 5 }T
+T{ 0 -5 - -> 5 }T
+T{ -5 0 - -> -5 }T
+T{ 1 2 - -> -1 }T
+T{ 1 -2 - -> 3 }T
+T{ -1 2 - -> -3 }T
+T{ -1 -2 - -> 1 }T
+T{ 0 1 - -> -1 }T
+T{ mid-uint+1 1 - -> mid-uint }T
 
-{ 0 1+ -> 1 }
-{ -1 1+ -> 0 }
-{ 1 1+ -> 2 }
-{ mid-uint 1+ -> mid-uint+1 }
+T{ 0 1+ -> 1 }T
+T{ -1 1+ -> 0 }T
+T{ 1 1+ -> 2 }T
+T{ mid-uint 1+ -> mid-uint+1 }T
 
-{ 2 1- -> 1 }
-{ 1 1- -> 0 }
-{ 0 1- -> -1 }
-{ mid-uint+1 1- -> mid-uint }
+T{ 2 1- -> 1 }T
+T{ 1 1- -> 0 }T
+T{ 0 1- -> -1 }T
+T{ mid-uint+1 1- -> mid-uint }T
 
-{ 0 negate -> 0 }
-{ 1 negate -> -1 }
-{ -1 negate -> 1 }
-{ 2 negate -> -2 }
-{ -2 negate -> 2 }
+T{ 0 negate -> 0 }T
+T{ 1 negate -> -1 }T
+T{ -1 negate -> 1 }T
+T{ 2 negate -> -2 }T
+T{ -2 negate -> 2 }T
 
-{ 0 abs -> 0 }
-{ 1 abs -> 1 }
-{ -1 abs -> 1 }
-{ min-int abs -> mid-uint+1 }
+T{ 0 abs -> 0 }T
+T{ 1 abs -> 1 }T
+T{ -1 abs -> 1 }T
+T{ min-int abs -> mid-uint+1 }T
 
 \ ------------------------------------------------------------------------
 testing multiply: s>d * m* um*
 
-{ 0 s>d -> 0 0 }
-{ 1 s>d -> 1 0 }
-{ 2 s>d -> 2 0 }
-{ -1 s>d -> -1 -1 }
-{ -2 s>d -> -2 -1 }
-{ min-int s>d -> min-int -1 }
-{ max-int s>d -> max-int 0 }
+T{ 0 s>d -> 0 0 }T
+T{ 1 s>d -> 1 0 }T
+T{ 2 s>d -> 2 0 }T
+T{ -1 s>d -> -1 -1 }T
+T{ -2 s>d -> -2 -1 }T
+T{ min-int s>d -> min-int -1 }T
+T{ max-int s>d -> max-int 0 }T
 
-{ 0 0 m* -> 0 s>d }
-{ 0 1 m* -> 0 s>d }
-{ 1 0 m* -> 0 s>d }
-{ 1 2 m* -> 2 s>d }
-{ 2 1 m* -> 2 s>d }
-{ 3 3 m* -> 9 s>d }
-{ -3 3 m* -> -9 s>d }
-{ 3 -3 m* -> -9 s>d }
-{ -3 -3 m* -> 9 s>d }
-{ 0 min-int m* -> 0 s>d }
-{ 1 min-int m* -> min-int s>d }
-{ 2 min-int m* -> 0 1s }
-{ 0 max-int m* -> 0 s>d }
-{ 1 max-int m* -> max-int s>d }
-{ 2 max-int m* -> max-int 1 lshift 0 }
-{ min-int min-int m* -> 0 msb 1 rshift }
-{ max-int min-int m* -> msb msb 2/ }
-{ max-int max-int m* -> 1 msb 2/ invert }
+T{ 0 0 m* -> 0 s>d }T
+T{ 0 1 m* -> 0 s>d }T
+T{ 1 0 m* -> 0 s>d }T
+T{ 1 2 m* -> 2 s>d }T
+T{ 2 1 m* -> 2 s>d }T
+T{ 3 3 m* -> 9 s>d }T
+T{ -3 3 m* -> -9 s>d }T
+T{ 3 -3 m* -> -9 s>d }T
+T{ -3 -3 m* -> 9 s>d }T
+T{ 0 min-int m* -> 0 s>d }T
+T{ 1 min-int m* -> min-int s>d }T
+T{ 2 min-int m* -> 0 1s }T
+T{ 0 max-int m* -> 0 s>d }T
+T{ 1 max-int m* -> max-int s>d }T
+T{ 2 max-int m* -> max-int 1 lshift 0 }T
+T{ min-int min-int m* -> 0 msb 1 rshift }T
+T{ max-int min-int m* -> msb msb 2/ }T
+T{ max-int max-int m* -> 1 msb 2/ invert }T
 
-{ 0 0 * -> 0 } \ test identities
-{ 0 1 * -> 0 }
-{ 1 0 * -> 0 }
-{ 1 2 * -> 2 }
-{ 2 1 * -> 2 }
-{ 3 3 * -> 9 }
-{ -3 3 * -> -9 }
-{ 3 -3 * -> -9 }
-{ -3 -3 * -> 9 }
+T{ 0 0 * -> 0 }T \ test identities
+T{ 0 1 * -> 0 }T
+T{ 1 0 * -> 0 }T
+T{ 1 2 * -> 2 }T
+T{ 2 1 * -> 2 }T
+T{ 3 3 * -> 9 }T
+T{ -3 3 * -> -9 }T
+T{ 3 -3 * -> -9 }T
+T{ -3 -3 * -> 9 }T
 
-{ mid-uint+1 1 rshift 2 * -> mid-uint+1 }
-{ mid-uint+1 2 rshift 4 * -> mid-uint+1 }
-{ mid-uint+1 1 rshift mid-uint+1 or 2 * -> mid-uint+1 }
+T{ mid-uint+1 1 rshift 2 * -> mid-uint+1 }T
+T{ mid-uint+1 2 rshift 4 * -> mid-uint+1 }T
+T{ mid-uint+1 1 rshift mid-uint+1 or 2 * -> mid-uint+1 }T
 
-{ 0 0 um* -> 0 0 }
-{ 0 1 um* -> 0 0 }
-{ 1 0 um* -> 0 0 }
-{ 1 2 um* -> 2 0 }
-{ 2 1 um* -> 2 0 }
-{ 3 3 um* -> 9 0 }
+T{ 0 0 um* -> 0 0 }T
+T{ 0 1 um* -> 0 0 }T
+T{ 1 0 um* -> 0 0 }T
+T{ 1 2 um* -> 2 0 }T
+T{ 2 1 um* -> 2 0 }T
+T{ 3 3 um* -> 9 0 }T
 
-{ mid-uint+1 1 rshift 2 um* -> mid-uint+1 0 }
-{ mid-uint+1 2 um* -> 0 1 }
-{ mid-uint+1 4 um* -> 0 2 }
-{ 1s 2 um* -> 1s 1 lshift 1 }
-{ max-uint max-uint um* -> 1 1 invert }
+T{ mid-uint+1 1 rshift 2 um* -> mid-uint+1 0 }T
+T{ mid-uint+1 2 um* -> 0 1 }T
+T{ mid-uint+1 4 um* -> 0 2 }T
+T{ 1s 2 um* -> 1s 1 lshift 1 }T
+T{ max-uint max-uint um* -> 1 1 invert }T
 
 \ ------------------------------------------------------------------------
 testing divide: fm/mod sm/rem um/mod */ */mod / /mod mod
 
-{ 0 s>d 1 fm/mod -> 0 0 }
-{ 1 s>d 1 fm/mod -> 0 1 }
-{ 2 s>d 1 fm/mod -> 0 2 }
-{ -1 s>d 1 fm/mod -> 0 -1 }
-{ -2 s>d 1 fm/mod -> 0 -2 }
-{ 0 s>d -1 fm/mod -> 0 0 }
-{ 1 s>d -1 fm/mod -> 0 -1 }
-{ 2 s>d -1 fm/mod -> 0 -2 }
-{ -1 s>d -1 fm/mod -> 0 1 }
-{ -2 s>d -1 fm/mod -> 0 2 }
-{ 2 s>d 2 fm/mod -> 0 1 }
-{ -1 s>d -1 fm/mod -> 0 1 }
-{ -2 s>d -2 fm/mod -> 0 1 }
-{  7 s>d  3 fm/mod -> 1 2 }
-{  7 s>d -3 fm/mod -> -2 -3 }
-{ -7 s>d  3 fm/mod -> 2 -3 }
-{ -7 s>d -3 fm/mod -> -1 2 }
-{ max-int s>d 1 fm/mod -> 0 max-int }
-{ min-int s>d 1 fm/mod -> 0 min-int }
-{ max-int s>d max-int fm/mod -> 0 1 }
-{ min-int s>d min-int fm/mod -> 0 1 }
-{ 1s 1 4 fm/mod -> 3 max-int }
-{ 1 min-int m* 1 fm/mod -> 0 min-int }
-{ 1 min-int m* min-int fm/mod -> 0 1 }
-{ 2 min-int m* 2 fm/mod -> 0 min-int }
-{ 2 min-int m* min-int fm/mod -> 0 2 }
-{ 1 max-int m* 1 fm/mod -> 0 max-int }
-{ 1 max-int m* max-int fm/mod -> 0 1 }
-{ 2 max-int m* 2 fm/mod -> 0 max-int }
-{ 2 max-int m* max-int fm/mod -> 0 2 }
-{ min-int min-int m* min-int fm/mod -> 0 min-int }
-{ min-int max-int m* min-int fm/mod -> 0 max-int }
-{ min-int max-int m* max-int fm/mod -> 0 min-int }
-{ max-int max-int m* max-int fm/mod -> 0 max-int }
+T{ 0 s>d 1 fm/mod -> 0 0 }T
+T{ 1 s>d 1 fm/mod -> 0 1 }T
+T{ 2 s>d 1 fm/mod -> 0 2 }T
+T{ -1 s>d 1 fm/mod -> 0 -1 }T
+T{ -2 s>d 1 fm/mod -> 0 -2 }T
+T{ 0 s>d -1 fm/mod -> 0 0 }T
+T{ 1 s>d -1 fm/mod -> 0 -1 }T
+T{ 2 s>d -1 fm/mod -> 0 -2 }T
+T{ -1 s>d -1 fm/mod -> 0 1 }T
+T{ -2 s>d -1 fm/mod -> 0 2 }T
+T{ 2 s>d 2 fm/mod -> 0 1 }T
+T{ -1 s>d -1 fm/mod -> 0 1 }T
+T{ -2 s>d -2 fm/mod -> 0 1 }T
+T{  7 s>d  3 fm/mod -> 1 2 }T
+T{  7 s>d -3 fm/mod -> -2 -3 }T
+T{ -7 s>d  3 fm/mod -> 2 -3 }T
+T{ -7 s>d -3 fm/mod -> -1 2 }T
+T{ max-int s>d 1 fm/mod -> 0 max-int }T
+T{ min-int s>d 1 fm/mod -> 0 min-int }T
+T{ max-int s>d max-int fm/mod -> 0 1 }T
+T{ min-int s>d min-int fm/mod -> 0 1 }T
+T{ 1s 1 4 fm/mod -> 3 max-int }T
+T{ 1 min-int m* 1 fm/mod -> 0 min-int }T
+T{ 1 min-int m* min-int fm/mod -> 0 1 }T
+T{ 2 min-int m* 2 fm/mod -> 0 min-int }T
+T{ 2 min-int m* min-int fm/mod -> 0 2 }T
+T{ 1 max-int m* 1 fm/mod -> 0 max-int }T
+T{ 1 max-int m* max-int fm/mod -> 0 1 }T
+T{ 2 max-int m* 2 fm/mod -> 0 max-int }T
+T{ 2 max-int m* max-int fm/mod -> 0 2 }T
+T{ min-int min-int m* min-int fm/mod -> 0 min-int }T
+T{ min-int max-int m* min-int fm/mod -> 0 max-int }T
+T{ min-int max-int m* max-int fm/mod -> 0 min-int }T
+T{ max-int max-int m* max-int fm/mod -> 0 max-int }T
 
-{ 0 s>d 1 sm/rem -> 0 0 }
-{ 1 s>d 1 sm/rem -> 0 1 }
-{ 2 s>d 1 sm/rem -> 0 2 }
-{ -1 s>d 1 sm/rem -> 0 -1 }
-{ -2 s>d 1 sm/rem -> 0 -2 }
-{ 0 s>d -1 sm/rem -> 0 0 }
-{ 1 s>d -1 sm/rem -> 0 -1 }
-{ 2 s>d -1 sm/rem -> 0 -2 }
-{ -1 s>d -1 sm/rem -> 0 1 }
-{ -2 s>d -1 sm/rem -> 0 2 }
-{ 2 s>d 2 sm/rem -> 0 1 }
-{ -1 s>d -1 sm/rem -> 0 1 }
-{ -2 s>d -2 sm/rem -> 0 1 }
-{  7 s>d  3 sm/rem -> 1 2 }
-{  7 s>d -3 sm/rem -> 1 -2 }
-{ -7 s>d  3 sm/rem -> -1 -2 }
-{ -7 s>d -3 sm/rem -> -1 2 }
-{ max-int s>d 1 sm/rem -> 0 max-int }
-{ min-int s>d 1 sm/rem -> 0 min-int }
-{ max-int s>d max-int sm/rem -> 0 1 }
-{ min-int s>d min-int sm/rem -> 0 1 }
-{ 1s 1 4 sm/rem -> 3 max-int }
-{ 2 min-int m* 2 sm/rem -> 0 min-int }
-{ 2 min-int m* min-int sm/rem -> 0 2 }
-{ 2 max-int m* 2 sm/rem -> 0 max-int }
-{ 2 max-int m* max-int sm/rem -> 0 2 }
-{ min-int min-int m* min-int sm/rem -> 0 min-int }
-{ min-int max-int m* min-int sm/rem -> 0 max-int }
-{ min-int max-int m* max-int sm/rem -> 0 min-int }
-{ max-int max-int m* max-int sm/rem -> 0 max-int }
+T{ 0 s>d 1 sm/rem -> 0 0 }T
+T{ 1 s>d 1 sm/rem -> 0 1 }T
+T{ 2 s>d 1 sm/rem -> 0 2 }T
+T{ -1 s>d 1 sm/rem -> 0 -1 }T
+T{ -2 s>d 1 sm/rem -> 0 -2 }T
+T{ 0 s>d -1 sm/rem -> 0 0 }T
+T{ 1 s>d -1 sm/rem -> 0 -1 }T
+T{ 2 s>d -1 sm/rem -> 0 -2 }T
+T{ -1 s>d -1 sm/rem -> 0 1 }T
+T{ -2 s>d -1 sm/rem -> 0 2 }T
+T{ 2 s>d 2 sm/rem -> 0 1 }T
+T{ -1 s>d -1 sm/rem -> 0 1 }T
+T{ -2 s>d -2 sm/rem -> 0 1 }T
+T{  7 s>d  3 sm/rem -> 1 2 }T
+T{  7 s>d -3 sm/rem -> 1 -2 }T
+T{ -7 s>d  3 sm/rem -> -1 -2 }T
+T{ -7 s>d -3 sm/rem -> -1 2 }T
+T{ max-int s>d 1 sm/rem -> 0 max-int }T
+T{ min-int s>d 1 sm/rem -> 0 min-int }T
+T{ max-int s>d max-int sm/rem -> 0 1 }T
+T{ min-int s>d min-int sm/rem -> 0 1 }T
+T{ 1s 1 4 sm/rem -> 3 max-int }T
+T{ 2 min-int m* 2 sm/rem -> 0 min-int }T
+T{ 2 min-int m* min-int sm/rem -> 0 2 }T
+T{ 2 max-int m* 2 sm/rem -> 0 max-int }T
+T{ 2 max-int m* max-int sm/rem -> 0 2 }T
+T{ min-int min-int m* min-int sm/rem -> 0 min-int }T
+T{ min-int max-int m* min-int sm/rem -> 0 max-int }T
+T{ min-int max-int m* max-int sm/rem -> 0 min-int }T
+T{ max-int max-int m* max-int sm/rem -> 0 max-int }T
 
-{ 0 0 1 um/mod -> 0 0 }
-{ 1 0 1 um/mod -> 0 1 }
-{ 1 0 2 um/mod -> 1 0 }
-{ 3 0 2 um/mod -> 1 1 }
-{ max-uint 2 um* 2 um/mod -> 0 max-uint }
-{ max-uint 2 um* max-uint um/mod -> 0 2 }
-{ max-uint max-uint um* max-uint um/mod -> 0 max-uint }
+T{ 0 0 1 um/mod -> 0 0 }T
+T{ 1 0 1 um/mod -> 0 1 }T
+T{ 1 0 2 um/mod -> 1 0 }T
+T{ 3 0 2 um/mod -> 1 1 }T
+T{ max-uint 2 um* 2 um/mod -> 0 max-uint }T
+T{ max-uint 2 um* max-uint um/mod -> 0 2 }T
+T{ max-uint max-uint um* max-uint um/mod -> 0 max-uint }T
 
 : iffloored
    [ -3 2 / -2 = invert ] literal if postpone \ then ;
@@ -527,111 +527,111 @@ ifsym     : tmod   t/mod drop ;
 ifsym     : t*/mod >r m* r> sm/rem ;
 ifsym     : t*/    t*/mod swap drop ;
 
-{ 0 1 /mod -> 0 1 t/mod }
-{ 1 1 /mod -> 1 1 t/mod }
-{ 2 1 /mod -> 2 1 t/mod }
-{ -1 1 /mod -> -1 1 t/mod }
-{ -2 1 /mod -> -2 1 t/mod }
-{ 0 -1 /mod -> 0 -1 t/mod }
-{ 1 -1 /mod -> 1 -1 t/mod }
-{ 2 -1 /mod -> 2 -1 t/mod }
-{ -1 -1 /mod -> -1 -1 t/mod }
-{ -2 -1 /mod -> -2 -1 t/mod }
-{ 2 2 /mod -> 2 2 t/mod }
-{ -1 -1 /mod -> -1 -1 t/mod }
-{ -2 -2 /mod -> -2 -2 t/mod }
-{ 7 3 /mod -> 7 3 t/mod }
-{ 7 -3 /mod -> 7 -3 t/mod }
-{ -7 3 /mod -> -7 3 t/mod }
-{ -7 -3 /mod -> -7 -3 t/mod }
-{ max-int 1 /mod -> max-int 1 t/mod }
-{ min-int 1 /mod -> min-int 1 t/mod }
-{ max-int max-int /mod -> max-int max-int t/mod }
-{ min-int min-int /mod -> min-int min-int t/mod }
+T{ 0 1 /mod -> 0 1 t/mod }T
+T{ 1 1 /mod -> 1 1 t/mod }T
+T{ 2 1 /mod -> 2 1 t/mod }T
+T{ -1 1 /mod -> -1 1 t/mod }T
+T{ -2 1 /mod -> -2 1 t/mod }T
+T{ 0 -1 /mod -> 0 -1 t/mod }T
+T{ 1 -1 /mod -> 1 -1 t/mod }T
+T{ 2 -1 /mod -> 2 -1 t/mod }T
+T{ -1 -1 /mod -> -1 -1 t/mod }T
+T{ -2 -1 /mod -> -2 -1 t/mod }T
+T{ 2 2 /mod -> 2 2 t/mod }T
+T{ -1 -1 /mod -> -1 -1 t/mod }T
+T{ -2 -2 /mod -> -2 -2 t/mod }T
+T{ 7 3 /mod -> 7 3 t/mod }T
+T{ 7 -3 /mod -> 7 -3 t/mod }T
+T{ -7 3 /mod -> -7 3 t/mod }T
+T{ -7 -3 /mod -> -7 -3 t/mod }T
+T{ max-int 1 /mod -> max-int 1 t/mod }T
+T{ min-int 1 /mod -> min-int 1 t/mod }T
+T{ max-int max-int /mod -> max-int max-int t/mod }T
+T{ min-int min-int /mod -> min-int min-int t/mod }T
 
-{ 0 1 / -> 0 1 t/ }
-{ 1 1 / -> 1 1 t/ }
-{ 2 1 / -> 2 1 t/ }
-{ -1 1 / -> -1 1 t/ }
-{ -2 1 / -> -2 1 t/ }
-{ 0 -1 / -> 0 -1 t/ }
-{ 1 -1 / -> 1 -1 t/ }
-{ 2 -1 / -> 2 -1 t/ }
-{ -1 -1 / -> -1 -1 t/ }
-{ -2 -1 / -> -2 -1 t/ }
-{ 2 2 / -> 2 2 t/ }
-{ -1 -1 / -> -1 -1 t/ }
-{ -2 -2 / -> -2 -2 t/ }
-{ 7 3 / -> 7 3 t/ }
-{ 7 -3 / -> 7 -3 t/ }
-{ -7 3 / -> -7 3 t/ }
-{ -7 -3 / -> -7 -3 t/ }
-{ max-int 1 / -> max-int 1 t/ }
-{ min-int 1 / -> min-int 1 t/ }
-{ max-int max-int / -> max-int max-int t/ }
-{ min-int min-int / -> min-int min-int t/ }
+T{ 0 1 / -> 0 1 t/ }T
+T{ 1 1 / -> 1 1 t/ }T
+T{ 2 1 / -> 2 1 t/ }T
+T{ -1 1 / -> -1 1 t/ }T
+T{ -2 1 / -> -2 1 t/ }T
+T{ 0 -1 / -> 0 -1 t/ }T
+T{ 1 -1 / -> 1 -1 t/ }T
+T{ 2 -1 / -> 2 -1 t/ }T
+T{ -1 -1 / -> -1 -1 t/ }T
+T{ -2 -1 / -> -2 -1 t/ }T
+T{ 2 2 / -> 2 2 t/ }T
+T{ -1 -1 / -> -1 -1 t/ }T
+T{ -2 -2 / -> -2 -2 t/ }T
+T{ 7 3 / -> 7 3 t/ }T
+T{ 7 -3 / -> 7 -3 t/ }T
+T{ -7 3 / -> -7 3 t/ }T
+T{ -7 -3 / -> -7 -3 t/ }T
+T{ max-int 1 / -> max-int 1 t/ }T
+T{ min-int 1 / -> min-int 1 t/ }T
+T{ max-int max-int / -> max-int max-int t/ }T
+T{ min-int min-int / -> min-int min-int t/ }T
 
-{ 0 1 mod -> 0 1 tmod }
-{ 1 1 mod -> 1 1 tmod }
-{ 2 1 mod -> 2 1 tmod }
-{ -1 1 mod -> -1 1 tmod }
-{ -2 1 mod -> -2 1 tmod }
-{ 0 -1 mod -> 0 -1 tmod }
-{ 1 -1 mod -> 1 -1 tmod }
-{ 2 -1 mod -> 2 -1 tmod }
-{ -1 -1 mod -> -1 -1 tmod }
-{ -2 -1 mod -> -2 -1 tmod }
-{ 2 2 mod -> 2 2 tmod }
-{ -1 -1 mod -> -1 -1 tmod }
-{ -2 -2 mod -> -2 -2 tmod }
-{ 7 3 mod -> 7 3 tmod }
-{ 7 -3 mod -> 7 -3 tmod }
-{ -7 3 mod -> -7 3 tmod }
-{ -7 -3 mod -> -7 -3 tmod }
-{ max-int 1 mod -> max-int 1 tmod }
-{ min-int 1 mod -> min-int 1 tmod }
-{ max-int max-int mod -> max-int max-int tmod }
-{ min-int min-int mod -> min-int min-int tmod }
+T{ 0 1 mod -> 0 1 tmod }T
+T{ 1 1 mod -> 1 1 tmod }T
+T{ 2 1 mod -> 2 1 tmod }T
+T{ -1 1 mod -> -1 1 tmod }T
+T{ -2 1 mod -> -2 1 tmod }T
+T{ 0 -1 mod -> 0 -1 tmod }T
+T{ 1 -1 mod -> 1 -1 tmod }T
+T{ 2 -1 mod -> 2 -1 tmod }T
+T{ -1 -1 mod -> -1 -1 tmod }T
+T{ -2 -1 mod -> -2 -1 tmod }T
+T{ 2 2 mod -> 2 2 tmod }T
+T{ -1 -1 mod -> -1 -1 tmod }T
+T{ -2 -2 mod -> -2 -2 tmod }T
+T{ 7 3 mod -> 7 3 tmod }T
+T{ 7 -3 mod -> 7 -3 tmod }T
+T{ -7 3 mod -> -7 3 tmod }T
+T{ -7 -3 mod -> -7 -3 tmod }T
+T{ max-int 1 mod -> max-int 1 tmod }T
+T{ min-int 1 mod -> min-int 1 tmod }T
+T{ max-int max-int mod -> max-int max-int tmod }T
+T{ min-int min-int mod -> min-int min-int tmod }T
 
-{ 0 2 1 */ -> 0 2 1 t*/ }
-{ 1 2 1 */ -> 1 2 1 t*/ }
-{ 2 2 1 */ -> 2 2 1 t*/ }
-{ -1 2 1 */ -> -1 2 1 t*/ }
-{ -2 2 1 */ -> -2 2 1 t*/ }
-{ 0 2 -1 */ -> 0 2 -1 t*/ }
-{ 1 2 -1 */ -> 1 2 -1 t*/ }
-{ 2 2 -1 */ -> 2 2 -1 t*/ }
-{ -1 2 -1 */ -> -1 2 -1 t*/ }
-{ -2 2 -1 */ -> -2 2 -1 t*/ }
-{ 2 2 2 */ -> 2 2 2 t*/ }
-{ -1 2 -1 */ -> -1 2 -1 t*/ }
-{ -2 2 -2 */ -> -2 2 -2 t*/ }
-{ 7 2 3 */ -> 7 2 3 t*/ }
-{ 7 2 -3 */ -> 7 2 -3 t*/ }
-{ -7 2 3 */ -> -7 2 3 t*/ }
-{ -7 2 -3 */ -> -7 2 -3 t*/ }
-{ max-int 2 max-int */ -> max-int 2 max-int t*/ }
-{ min-int 2 min-int */ -> min-int 2 min-int t*/ }
+T{ 0 2 1 */ -> 0 2 1 t*/ }T
+T{ 1 2 1 */ -> 1 2 1 t*/ }T
+T{ 2 2 1 */ -> 2 2 1 t*/ }T
+T{ -1 2 1 */ -> -1 2 1 t*/ }T
+T{ -2 2 1 */ -> -2 2 1 t*/ }T
+T{ 0 2 -1 */ -> 0 2 -1 t*/ }T
+T{ 1 2 -1 */ -> 1 2 -1 t*/ }T
+T{ 2 2 -1 */ -> 2 2 -1 t*/ }T
+T{ -1 2 -1 */ -> -1 2 -1 t*/ }T
+T{ -2 2 -1 */ -> -2 2 -1 t*/ }T
+T{ 2 2 2 */ -> 2 2 2 t*/ }T
+T{ -1 2 -1 */ -> -1 2 -1 t*/ }T
+T{ -2 2 -2 */ -> -2 2 -2 t*/ }T
+T{ 7 2 3 */ -> 7 2 3 t*/ }T
+T{ 7 2 -3 */ -> 7 2 -3 t*/ }T
+T{ -7 2 3 */ -> -7 2 3 t*/ }T
+T{ -7 2 -3 */ -> -7 2 -3 t*/ }T
+T{ max-int 2 max-int */ -> max-int 2 max-int t*/ }T
+T{ min-int 2 min-int */ -> min-int 2 min-int t*/ }T
 
-{ 0 2 1 */mod -> 0 2 1 t*/mod }
-{ 1 2 1 */mod -> 1 2 1 t*/mod }
-{ 2 2 1 */mod -> 2 2 1 t*/mod }
-{ -1 2 1 */mod -> -1 2 1 t*/mod }
-{ -2 2 1 */mod -> -2 2 1 t*/mod }
-{ 0 2 -1 */mod -> 0 2 -1 t*/mod }
-{ 1 2 -1 */mod -> 1 2 -1 t*/mod }
-{ 2 2 -1 */mod -> 2 2 -1 t*/mod }
-{ -1 2 -1 */mod -> -1 2 -1 t*/mod }
-{ -2 2 -1 */mod -> -2 2 -1 t*/mod }
-{ 2 2 2 */mod -> 2 2 2 t*/mod }
-{ -1 2 -1 */mod -> -1 2 -1 t*/mod }
-{ -2 2 -2 */mod -> -2 2 -2 t*/mod }
-{ 7 2 3 */mod -> 7 2 3 t*/mod }
-{ 7 2 -3 */mod -> 7 2 -3 t*/mod }
-{ -7 2 3 */mod -> -7 2 3 t*/mod }
-{ -7 2 -3 */mod -> -7 2 -3 t*/mod }
-{ max-int 2 max-int */mod -> max-int 2 max-int t*/mod }
-{ min-int 2 min-int */mod -> min-int 2 min-int t*/mod }
+T{ 0 2 1 */mod -> 0 2 1 t*/mod }T
+T{ 1 2 1 */mod -> 1 2 1 t*/mod }T
+T{ 2 2 1 */mod -> 2 2 1 t*/mod }T
+T{ -1 2 1 */mod -> -1 2 1 t*/mod }T
+T{ -2 2 1 */mod -> -2 2 1 t*/mod }T
+T{ 0 2 -1 */mod -> 0 2 -1 t*/mod }T
+T{ 1 2 -1 */mod -> 1 2 -1 t*/mod }T
+T{ 2 2 -1 */mod -> 2 2 -1 t*/mod }T
+T{ -1 2 -1 */mod -> -1 2 -1 t*/mod }T
+T{ -2 2 -1 */mod -> -2 2 -1 t*/mod }T
+T{ 2 2 2 */mod -> 2 2 2 t*/mod }T
+T{ -1 2 -1 */mod -> -1 2 -1 t*/mod }T
+T{ -2 2 -2 */mod -> -2 2 -2 t*/mod }T
+T{ 7 2 3 */mod -> 7 2 3 t*/mod }T
+T{ 7 2 -3 */mod -> 7 2 -3 t*/mod }T
+T{ -7 2 3 */mod -> -7 2 3 t*/mod }T
+T{ -7 2 -3 */mod -> -7 2 -3 t*/mod }T
+T{ max-int 2 max-int */mod -> max-int 2 max-int t*/mod }T
+T{ min-int 2 min-int */mod -> min-int 2 min-int t*/mod }T
 
 \ ------------------------------------------------------------------------
 testing here , @ ! cell+ cells c, c@ c! char+ chars 2@ 2! align aligned +! allot pad unused compile,
@@ -645,51 +645,51 @@ here                        \ to where we started.
 constant 3rda
 constant 2nda
 constant 1sta
-{ 1sta 2nda u< -> <true> }  \ here must grow with allot ...
-{ 1sta 1+ -> 2nda }         \ ... by one address unit
-{ 3rda -> 1sta }            \ and shrink back to the beginning.
+T{ 1sta 2nda u< -> <true> }T  \ here must grow with allot ...
+T{ 1sta 1+ -> 2nda }T         \ ... by one address unit
+T{ 3rda -> 1sta }T            \ and shrink back to the beginning.
 hex
 
 here 1 ,
 here 2 ,
 constant 2nd
 constant 1st
-{ 1st 2nd u< -> <true> } \ here must grow with allot ...
-{ 1st cell+ -> 2nd }     \ ... by one cell (test for char+)
-{ 1st 1 cells + -> 2nd }
-{ 1st @ 2nd @ -> 1 2 }
-{ 5 1st ! -> }
-{ 1st @ 2nd @ -> 5 2 }
-{ 6 2nd ! -> }
-{ 1st @ 2nd @ -> 5 6 }
-{ 1st 2@ -> 6 5 }
-{ 2 1 1st 2! -> }
-{ 1st 2@ -> 2 1 }
-{ 1s 1st !  1st @ -> 1s }  \ can store cell-wide value
+T{ 1st 2nd u< -> <true> }T \ here must grow with allot ...
+T{ 1st cell+ -> 2nd }T     \ ... by one cell (test for char+)
+T{ 1st 1 cells + -> 2nd }T
+T{ 1st @ 2nd @ -> 1 2 }T
+T{ 5 1st ! -> }T
+T{ 1st @ 2nd @ -> 5 2 }T
+T{ 6 2nd ! -> }T
+T{ 1st @ 2nd @ -> 5 6 }T
+T{ 1st 2@ -> 6 5 }T
+T{ 2 1 1st 2! -> }T
+T{ 1st 2@ -> 2 1 }T
+T{ 1s 1st !  1st @ -> 1s }T  \ can store cell-wide value
 
 here 1 c,
 here 2 c,
 constant 2ndc
 constant 1stc
-{ 1stc 2ndc u< -> <true> } \ here must grow with allot
-{ 1stc char+ -> 2ndc }     \ ... by one char
-{ 1stc 1 chars + -> 2ndc }
-{ 1stc c@ 2ndc c@ -> 1 2 }
-{ 3 1stc c! -> }
-{ 1stc c@ 2ndc c@ -> 3 2 }
-{ 4 2ndc c! -> }
-{ 1stc c@ 2ndc c@ -> 3 4 }
+T{ 1stc 2ndc u< -> <true> }T \ here must grow with allot
+T{ 1stc char+ -> 2ndc }T     \ ... by one char
+T{ 1stc 1 chars + -> 2ndc }T
+T{ 1stc c@ 2ndc c@ -> 1 2 }T
+T{ 3 1stc c! -> }T
+T{ 1stc c@ 2ndc c@ -> 3 2 }T
+T{ 4 2ndc c! -> }T
+T{ 1stc c@ 2ndc c@ -> 3 4 }T
 
 align 1 allot here align here 3 cells allot
 constant a-addr  constant ua-addr
-{ ua-addr aligned -> a-addr }
-{ 1 a-addr c!  a-addr c@ -> 1 }
-{ 1234 a-addr  !  a-addr  @ -> 1234 }
-{ 123 456 a-addr 2!  a-addr 2@ -> 123 456 }
-{ 2 a-addr char+ c!  a-addr char+ c@ -> 2 }
-{ 3 a-addr cell+ c!  a-addr cell+ c@ -> 3 }
-{ 1234 a-addr cell+ !  a-addr cell+ @ -> 1234 }
-{ 123 456 a-addr cell+ 2!  a-addr cell+ 2@ -> 123 456 }
+T{ ua-addr aligned -> a-addr }T
+T{ 1 a-addr c!  a-addr c@ -> 1 }T
+T{ 1234 a-addr  !  a-addr  @ -> 1234 }T
+T{ 123 456 a-addr 2!  a-addr 2@ -> 123 456 }T
+T{ 2 a-addr char+ c!  a-addr char+ c@ -> 2 }T
+T{ 3 a-addr cell+ c!  a-addr cell+ c@ -> 3 }T
+T{ 1234 a-addr cell+ !  a-addr cell+ @ -> 1234 }T
+T{ 123 456 a-addr cell+ 2!  a-addr cell+ 2@ -> 123 456 }T
 
 : bits ( x -- u )
    0 swap begin
@@ -701,117 +701,117 @@ constant a-addr  constant ua-addr
    drop ;
 
 ( characters >= 1 au, <= size of cell, >= 8 bits )
-{ 1 chars 1 < -> <false> }
-{ 1 chars 1 cells > -> <false> }
+T{ 1 chars 1 < -> <false> }T
+T{ 1 chars 1 cells > -> <false> }T
 ( TODO how to find number of bits? )
 
 ( cells >= 1 au, integral multiple of char size, >= 16 bits )
-{ 1 cells 1 < -> <false> }
-{ 1 cells 1 chars mod -> 0 }
-{ 1s bits 10 < -> <false> }
+T{ 1 cells 1 < -> <false> }T
+T{ 1 cells 1 chars mod -> 0 }T
+T{ 1s bits 10 < -> <false> }T
 
-{ 0 1st ! -> }
-{ 1 1st +! -> }
-{ 1st @ -> 1 }
-{ -1 1st +! 1st @ -> 0 }
+T{ 0 1st ! -> }T
+T{ 1 1st +! -> }T
+T{ 1st @ -> 1 }T
+T{ -1 1st +! 1st @ -> 0 }T
 
 ( here + unused + buffer size must be total RAM, that is, $7FFF )
-{ pad here - -> FF } \ PAD must have offset of $FF
-{ here unused + 3FF + -> 7FFF }
+T{ pad here - -> FF }T \ PAD must have offset of $FF
+T{ here unused + 3FF + -> 7FFF }T
 
 :noname dup + ; constant dup+ 
-{ : q dup+ compile, ; -> } 
-{ : as [ q ] ; -> } 
-{ 123 as -> 246 }
+T{ : q dup+ compile, ; -> }T 
+T{ : as [ q ] ; -> }T 
+T{ 123 as -> 246 }T
 
 \ ------------------------------------------------------------------------
 testing char [char] [ ] bl s"
 
-{ bl -> 20 }
-{ char X -> 58 }
-{ char HELLO -> 48 }
-{ : gc1 [char] X ; -> }
-{ : gc2 [char] HELLO ; -> }
-{ gc1 -> 58 }
-{ gc2 -> 48 }
-{ : gc3 [ gc1 ] literal ; -> }
-{ gc3 -> 58 }
-{ : gc4 s" XY" ; -> }
-{ gc4 swap drop -> 2 }
-{ gc4 drop dup c@ swap char+ c@ -> 58 59 }
+T{ bl -> 20 }T
+T{ char X -> 58 }T
+T{ char HELLO -> 48 }T
+T{ : gc1 [char] X ; -> }T
+T{ : gc2 [char] HELLO ; -> }T
+T{ gc1 -> 58 }T
+T{ gc2 -> 48 }T
+T{ : gc3 [ gc1 ] literal ; -> }T
+T{ gc3 -> 58 }T
+T{ : gc4 s" XY" ; -> }T
+T{ gc4 swap drop -> 2 }T
+T{ gc4 drop dup c@ swap char+ c@ -> 58 59 }T
 
 \ ------------------------------------------------------------------------
 testing ' ['] find execute immediate count literal postpone state
 
-{ : gt1 123 ; -> }
-{ ' gt1 execute -> 123 }
-{ : gt2 ['] gt1 ; immediate -> }
-{ gt2 execute -> 123 }
+T{ : gt1 123 ; -> }T
+T{ ' gt1 execute -> 123 }T
+T{ : gt2 ['] gt1 ; immediate -> }T
+T{ gt2 execute -> 123 }T
 here 3 c, char g c, char t c, char 1 c, constant gt1string
 here 3 c, char g c, char t c, char 2 c, constant gt2string
-{ gt1string find -> ' gt1 -1 }
-{ gt2string find -> ' gt2 1 }
+T{ gt1string find -> ' gt1 -1 }T
+T{ gt2string find -> ' gt2 1 }T
 ( TODO how to search for non-existent word? )
-{ : gt3 gt2 literal ; -> }
-{ gt3 -> ' gt1 }
-{ gt1string count -> gt1string char+ 3 }
+T{ : gt3 gt2 literal ; -> }T
+T{ gt3 -> ' gt1 }T
+T{ gt1string count -> gt1string char+ 3 }T
 
-{ : gt4 postpone gt1 ; immediate -> }
-{ : gt5 gt4 ; -> }
-{ gt5 -> 123 }
-{ : gt6 345 ; immediate -> }
-{ : gt7 postpone gt6 ; -> }
-{ gt7 -> 345 }
+T{ : gt4 postpone gt1 ; immediate -> }T
+T{ : gt5 gt4 ; -> }T
+T{ gt5 -> 123 }T
+T{ : gt6 345 ; immediate -> }T
+T{ : gt7 postpone gt6 ; -> }T
+T{ gt7 -> 345 }T
 
-{ : gt8 state @ ; immediate -> }
-{ gt8 -> 0 }
-{ : gt9 gt8 literal ; -> }
-{ gt9 0= -> <false> }
+T{ : gt8 state @ ; immediate -> }T
+T{ gt8 -> 0 }T
+T{ : gt9 gt8 literal ; -> }T
+T{ gt9 0= -> <false> }T
 
 \ ------------------------------------------------------------------------
 testing if else then begin while repeat until recurse
 
-{ : gi1 if 123 then ; -> }
-{ : gi2 if 123 else 234 then ; -> }
-{ 0 gi1 -> }
-{ 1 gi1 -> 123 }
-{ -1 gi1 -> 123 }
-{ 0 gi2 -> 234 }
-{ 1 gi2 -> 123 }
-{ -1 gi1 -> 123 }
+T{ : gi1 if 123 then ; -> }T
+T{ : gi2 if 123 else 234 then ; -> }T
+T{ 0 gi1 -> }T
+T{ 1 gi1 -> 123 }T
+T{ -1 gi1 -> 123 }T
+T{ 0 gi2 -> 234 }T
+T{ 1 gi2 -> 123 }T
+T{ -1 gi1 -> 123 }T
 
-{ : gi3 begin dup 5 < while dup 1+ repeat ; -> }
-{ 0 gi3 -> 0 1 2 3 4 5 }
-{ 4 gi3 -> 4 5 }
-{ 5 gi3 -> 5 }
-{ 6 gi3 -> 6 }
+T{ : gi3 begin dup 5 < while dup 1+ repeat ; -> }T
+T{ 0 gi3 -> 0 1 2 3 4 5 }T
+T{ 4 gi3 -> 4 5 }T
+T{ 5 gi3 -> 5 }T
+T{ 6 gi3 -> 6 }T
 
-{ : gi4 begin dup 1+ dup 5 > until ; -> }
-{ 3 gi4 -> 3 4 5 6 }
-{ 5 gi4 -> 5 6 }
-{ 6 gi4 -> 6 7 }
+T{ : gi4 begin dup 1+ dup 5 > until ; -> }T
+T{ 3 gi4 -> 3 4 5 6 }T
+T{ 5 gi4 -> 5 6 }T
+T{ 6 gi4 -> 6 7 }T
 
-{ : gi5 begin dup 2 > while dup 5 < while dup 1+ repeat 123 else 345 then ; -> }
-{ 1 gi5 -> 1 345 }
-{ 2 gi5 -> 2 345 }
-{ 3 gi5 -> 3 4 5 123 }
-{ 4 gi5 -> 4 5 123 }
-{ 5 gi5 -> 5 123 }
+T{ : gi5 begin dup 2 > while dup 5 < while dup 1+ repeat 123 else 345 then ; -> }T
+T{ 1 gi5 -> 1 345 }T
+T{ 2 gi5 -> 2 345 }T
+T{ 3 gi5 -> 3 4 5 123 }T
+T{ 4 gi5 -> 4 5 123 }T
+T{ 5 gi5 -> 5 123 }T
 
-{ : gi6 ( n -- 0,1,..n ) dup if dup >r 1- recurse r> then ; -> }
-{ 0 gi6 -> 0 }
-{ 1 gi6 -> 0 1 }
-{ 2 gi6 -> 0 1 2 }
-{ 3 gi6 -> 0 1 2 3 }
-{ 4 gi6 -> 0 1 2 3 4 }
+T{ : gi6 ( n -- 0,1,..n ) dup if dup >r 1- recurse r> then ; -> }T
+T{ 0 gi6 -> 0 }T
+T{ 1 gi6 -> 0 1 }T
+T{ 2 gi6 -> 0 1 2 }T
+T{ 3 gi6 -> 0 1 2 3 }T
+T{ 4 gi6 -> 0 1 2 3 4 }T
 
 decimal
-{ :noname ( n -- 0, 1, .., n ) 
+T{ :noname ( n -- 0, 1, .., n ) 
      dup if dup >r 1- recurse r> then 
    ; 
-   constant rn1 -> }
-{ 0 rn1 execute -> 0 }
-{ 4 rn1 execute -> 0 1 2 3 4 }
+   constant rn1 -> }T
+T{ 0 rn1 execute -> 0 }T
+T{ 4 rn1 execute -> 0 1 2 3 4 }T
 
 :noname ( n -- n1 )
    1- dup
@@ -823,10 +823,10 @@ decimal
    endcase
 ; constant rn2
 
-{  1 rn2 execute -> 0 }
-{  2 rn2 execute -> 11 0 }
-{  4 rn2 execute -> 33 22 11 0 }
-{ 25 rn2 execute -> 33 22 11 0 }
+T{  1 rn2 execute -> 0 }T
+T{  2 rn2 execute -> 11 0 }T
+T{  4 rn2 execute -> 33 22 11 0 }T
+T{ 25 rn2 execute -> 33 22 11 0 }T
 hex
 
 \ ------------------------------------------------------------------------
@@ -844,14 +844,14 @@ testing case of endof endcase
    endcase
 ;
 
-{ 1 cs1 -> 111 }
-{ 2 cs1 -> 222 }
-{ 3 cs1 -> 333 }
-{ 4 cs1 -> 444 }
-{ 5 cs1 -> 555 }
-{ 6 cs1 -> 666 }
-{ 7 cs1 -> 777 }
-{ 8 cs1 -> 999 } \ default
+T{ 1 cs1 -> 111 }T
+T{ 2 cs1 -> 222 }T
+T{ 3 cs1 -> 333 }T
+T{ 4 cs1 -> 444 }T
+T{ 5 cs1 -> 555 }T
+T{ 6 cs1 -> 666 }T
+T{ 7 cs1 -> 777 }T
+T{ 8 cs1 -> 999 }T \ default
 
 : cs2 >r case
 
@@ -867,75 +867,75 @@ testing case of endof endcase
      >r 299 r>
    endcase r> drop ;
 
-{ -1 1 cs2 ->  100 }
-{ -1 2 cs2 ->  200 }
-{ -1 3 cs2 -> -300 }
-{ -2 1 cs2 ->  -99 }
-{ -2 2 cs2 -> -199 }
-{  0 2 cs2 ->  299 }
+T{ -1 1 cs2 ->  100 }T
+T{ -1 2 cs2 ->  200 }T
+T{ -1 3 cs2 -> -300 }T
+T{ -2 1 cs2 ->  -99 }T
+T{ -2 2 cs2 -> -199 }T
+T{  0 2 cs2 ->  299 }T
 
 \ ------------------------------------------------------------------------
 testing do loop +loop i j unloop leave exit ?do
 
-{ : gd1 do i loop ; -> }
-{ 4 1 gd1 -> 1 2 3 }
-{ 2 -1 gd1 -> -1 0 1 }
-{ mid-uint+1 mid-uint gd1 -> mid-uint }
+T{ : gd1 do i loop ; -> }T
+T{ 4 1 gd1 -> 1 2 3 }T
+T{ 2 -1 gd1 -> -1 0 1 }T
+T{ mid-uint+1 mid-uint gd1 -> mid-uint }T
 
-{ : gd2 do i -1 +loop ; -> }
-{ 1 4 gd2 -> 4 3 2 1 }
-{ -1 2 gd2 -> 2 1 0 -1 }
-{ mid-uint mid-uint+1 gd2 -> mid-uint+1 mid-uint }
+T{ : gd2 do i -1 +loop ; -> }T
+T{ 1 4 gd2 -> 4 3 2 1 }T
+T{ -1 2 gd2 -> 2 1 0 -1 }T
+T{ mid-uint mid-uint+1 gd2 -> mid-uint+1 mid-uint }T
 
-{ : gd3 do 1 0 do j loop loop ; -> }
-{ 4 1 gd3 -> 1 2 3 }
-{ 2 -1 gd3 -> -1 0 1 }
-{ mid-uint+1 mid-uint gd3 -> mid-uint }
+T{ : gd3 do 1 0 do j loop loop ; -> }T
+T{ 4 1 gd3 -> 1 2 3 }T
+T{ 2 -1 gd3 -> -1 0 1 }T
+T{ mid-uint+1 mid-uint gd3 -> mid-uint }T
 
-{ : gd4 do 1 0 do j loop -1 +loop ; -> }
-{ 1 4 gd4 -> 4 3 2 1 }
-{ -1 2 gd4 -> 2 1 0 -1 }
-{ mid-uint mid-uint+1 gd4 -> mid-uint+1 mid-uint }
+T{ : gd4 do 1 0 do j loop -1 +loop ; -> }T
+T{ 1 4 gd4 -> 4 3 2 1 }T
+T{ -1 2 gd4 -> 2 1 0 -1 }T
+T{ mid-uint mid-uint+1 gd4 -> mid-uint+1 mid-uint }T
 
-{ : gd5 123 swap 0 do i 4 > if drop 234 leave then loop ; -> }
-{ 1 gd5 -> 123 }
-{ 5 gd5 -> 123 }
-{ 6 gd5 -> 234 }
+T{ : gd5 123 swap 0 do i 4 > if drop 234 leave then loop ; -> }T
+T{ 1 gd5 -> 123 }T
+T{ 5 gd5 -> 123 }T
+T{ 6 gd5 -> 234 }T
 
-{ : gd6  ( pat: {0 0},{0 0}{1 0}{1 1},{0 0}{1 0}{1 1}{2 0}{2 1}{2 2} )
+T{ : gd6  ( pat: T{0 0}T,T{0 0}TT{1 0}TT{1 1}T,T{0 0}TT{1 0}TT{1 1}TT{2 0}TT{2 1}TT{2 2}T )
    0 swap 0 do
       i 1+ 0 do i j + 3 = if i unloop i unloop exit then 1+ loop
-    loop ; -> }
-{ 1 gd6 -> 1 }
-{ 2 gd6 -> 3 }
-{ 3 gd6 -> 4 1 2 }
+    loop ; -> }T
+T{ 1 gd6 -> 1 }T
+T{ 2 gd6 -> 3 }T
+T{ 3 gd6 -> 4 1 2 }T
 
 : qd ?do i loop ; 
-{   789   789 qd -> } 
-{ -9876 -9876 qd -> } 
-{     5     0 qd -> 0 1 2 3 4 }
+T{   789   789 qd -> }T 
+T{ -9876 -9876 qd -> }T 
+T{     5     0 qd -> 0 1 2 3 4 }T
 
 : qd1 ?do i 10 +loop ; 
-{ 50 1 qd1 -> 1 11 21 31 41 } 
-{ 50 0 qd1 -> 0 10 20 30 40 }
+T{ 50 1 qd1 -> 1 11 21 31 41 }T 
+T{ 50 0 qd1 -> 0 10 20 30 40 }T
 
 : qd2 ?do i 3 > if leave else i then loop ; 
-{ 5 -1 qd2 -> -1 0 1 2 3 }
+T{ 5 -1 qd2 -> -1 0 1 2 3 }T
 
 : qd3 ?do i 1 +loop ; 
-{ 4  4 qd3 -> } 
-{ 4  1 qd3 ->  1 2 3 }
-{ 2 -1 qd3 -> -1 0 1 }
+T{ 4  4 qd3 -> }T 
+T{ 4  1 qd3 ->  1 2 3 }T
+T{ 2 -1 qd3 -> -1 0 1 }T
 
 : qd4 ?do i -1 +loop ; 
-{  4 4 qd4 -> }
-{  1 4 qd4 -> 4 3 2  1 } 
-{ -1 2 qd4 -> 2 1 0 -1 }
+T{  4 4 qd4 -> }T
+T{  1 4 qd4 -> 4 3 2  1 }T 
+T{ -1 2 qd4 -> 2 1 0 -1 }T
 
 : qd5 ?do i -10 +loop ; 
-{   1 50 qd5 -> 50 40 30 20 10   } 
-{   0 50 qd5 -> 50 40 30 20 10 0 } 
-{ -25 10 qd5 -> 10 0 -10 -20     }
+T{   1 50 qd5 -> 50 40 30 20 10   }T 
+T{   0 50 qd5 -> 50 40 30 20 10 0 }T 
+T{ -25 10 qd5 -> 10 0 -10 -20     }T
 
 variable qditerations 
 variable qdincrement
@@ -950,80 +950,80 @@ variable qdincrement
    +loop qditerations @ 
 ;
 
-{  4  4 -1 qd6 ->                   0  } 
-{  1  4 -1 qd6 ->  4  3  2  1       4  } 
-{  4  1 -1 qd6 ->  1  0 -1 -2 -3 -4 6  } 
-{  4  1  0 qd6 ->  1  1  1  1  1  1 6  } 
-{  0  0  0 qd6 ->                   0  } 
-{  1  4  0 qd6 ->  4  4  4  4  4  4 6  } 
-{  1  4  1 qd6 ->  4  5  6  7  8  9 6  } 
-{  4  1  1 qd6 ->  1  2  3          3  } 
-{  4  4  1 qd6 ->                   0  } 
-{  2 -1 -1 qd6 -> -1 -2 -3 -4 -5 -6 6  } 
-{ -1  2 -1 qd6 ->  2  1  0 -1       4  } 
-{  2 -1  0 qd6 -> -1 -1 -1 -1 -1 -1 6  } 
-{ -1  2  0 qd6 ->  2  2  2  2  2  2 6  } 
-{ -1  2  1 qd6 ->  2  3  4  5  6  7 6  } 
-{  2 -1  1 qd6 -> -1  0  1          3  }
+T{  4  4 -1 qd6 ->                   0  }T 
+T{  1  4 -1 qd6 ->  4  3  2  1       4  }T 
+T{  4  1 -1 qd6 ->  1  0 -1 -2 -3 -4 6  }T 
+T{  4  1  0 qd6 ->  1  1  1  1  1  1 6  }T 
+T{  0  0  0 qd6 ->                   0  }T 
+T{  1  4  0 qd6 ->  4  4  4  4  4  4 6  }T 
+T{  1  4  1 qd6 ->  4  5  6  7  8  9 6  }T 
+T{  4  1  1 qd6 ->  1  2  3          3  }T 
+T{  4  4  1 qd6 ->                   0  }T 
+T{  2 -1 -1 qd6 -> -1 -2 -3 -4 -5 -6 6  }T 
+T{ -1  2 -1 qd6 ->  2  1  0 -1       4  }T 
+T{  2 -1  0 qd6 -> -1 -1 -1 -1 -1 -1 6  }T 
+T{ -1  2  0 qd6 ->  2  2  2  2  2  2 6  }T 
+T{ -1  2  1 qd6 ->  2  3  4  5  6  7 6  }T 
+T{  2 -1  1 qd6 -> -1  0  1          3  }T
 
 \ ------------------------------------------------------------------------
 testing defining words: : ; constant variable create does> >body value to
 
-{ 123 constant x123 -> }
-{ x123 -> 123 }
-{ : equ constant ; -> }
-{ x123 equ y123 -> }
-{ y123 -> 123 }
+T{ 123 constant x123 -> }T
+T{ x123 -> 123 }T
+T{ : equ constant ; -> }T
+T{ x123 equ y123 -> }T
+T{ y123 -> 123 }T
 
-{ variable v1 -> }
-{ 123 v1 ! -> }
-{ v1 @ -> 123 }
+T{ variable v1 -> }T
+T{ 123 v1 ! -> }T
+T{ v1 @ -> 123 }T
 
-{ : nop : postpone ; ; -> }
-{ nop nop1 nop nop2 -> }
-{ nop1 -> }
-{ nop2 -> }
+T{ : nop : postpone ; ; -> }T
+T{ nop nop1 nop nop2 -> }T
+T{ nop1 -> }T
+T{ nop2 -> }T
 
-{ : does1 does> @ 1 + ; -> }
-{ : does2 does> @ 2 + ; -> }
-{ create cr1 -> }
-{ cr1 -> here }
-{ ' cr1 >body -> here }
-{ 1 , -> }
-{ cr1 @ -> 1 }
-{ does1 -> }
-{ cr1 -> 2 }
-{ does2 -> }
-{ cr1 -> 3 }
+T{ : does1 does> @ 1 + ; -> }T
+T{ : does2 does> @ 2 + ; -> }T
+T{ create cr1 -> }T
+T{ cr1 -> here }T
+T{ ' cr1 >body -> here }T
+T{ 1 , -> }T
+T{ cr1 @ -> 1 }T
+T{ does1 -> }T
+T{ cr1 -> 2 }T
+T{ does2 -> }T
+T{ cr1 -> 3 }T
 
 \ The following test is not part of the original suite, but belongs
 \ to the "weird:" test following it. See discussion at
 \ https://github.com/scotws/TaliForth2/issues/61
-{ : odd: create does> 1 + ; -> }
-{ odd: o1 -> }
-{ ' o1 >body -> here }
-{ o1 -> here 1 + }
+T{ : odd: create does> 1 + ; -> }T
+T{ odd: o1 -> }T
+T{ ' o1 >body -> here }T
+T{ o1 -> here 1 + }T
 
-{ : weird: create does> 1 + does> 2 + ; -> }
-{ weird: w1 -> }
-{ ' w1 >body -> here }
-{ w1 -> here 1 + }
-{ w1 -> here 2 + }
+T{ : weird: create does> 1 + does> 2 + ; -> }T
+T{ weird: w1 -> }T
+T{ ' w1 >body -> here }T
+T{ w1 -> here 1 + }T
+T{ w1 -> here 2 + }T
 
-{  111 value v1 -> }
-{ -999 value v2 -> }
-{ v1 ->  111 }
-{ v2 -> -999 } 
-{ 222 to v1 -> } 
-{ v1 -> 222 }
-{ : vd1 v1 ; -> }
-{ vd1 -> 222 }
+T{  111 value v1 -> }T
+T{ -999 value v2 -> }T
+T{ v1 ->  111 }T
+T{ v2 -> -999 }T 
+T{ 222 to v1 -> }T 
+T{ v1 -> 222 }T
+T{ : vd1 v1 ; -> }T
+T{ vd1 -> 222 }T
 
-{ : vd2 to v2 ; -> }
-{ v2 -> -999 }
-{ -333 vd2 -> }
-{ v2 -> -333 }
-{ v1 ->  222 }
+T{ : vd2 to v2 ; -> }T
+T{ v2 -> -999 }T
+T{ -333 vd2 -> }T
+T{ v2 -> -333 }T
+T{ v1 ->  222 }T
 
 \ ------------------------------------------------------------------------
 testing evaluate
@@ -1033,22 +1033,22 @@ testing evaluate
 : ge3 s" : ge4 345 ;" ;
 : ge5 evaluate ; immediate
 
-{ ge1 evaluate -> 123 } \ test evaluate in interp. state
-{ ge2 evaluate -> 124 }
-{ ge3 evaluate -> }
-{ ge4 -> 345 }
+T{ ge1 evaluate -> 123 }T \ test evaluate in interp. state
+T{ ge2 evaluate -> 124 }T
+T{ ge3 evaluate -> }T
+T{ ge4 -> 345 }T
 
-{ : ge6 ge1 ge5 ; -> }  \ test evaluate in compile state
-{ ge6 -> 123 }
-{ : ge7 ge2 ge5 ; -> }
-{ ge7 -> 124 }
+T{ : ge6 ge1 ge5 ; -> }T  \ test evaluate in compile state
+T{ ge6 -> 123 }T
+T{ : ge7 ge2 ge5 ; -> }T
+T{ ge7 -> 124 }T
 
 \ ------------------------------------------------------------------------
 testing source >in word
 
 : gs1 s" source" 2dup evaluate 
        >r swap >r = r> r> = ;
-{ gs1 -> <true> <true> }
+T{ gs1 -> <true> <true> }T
 
 variable scans
 : rescan?  -1 scans +!
@@ -1056,22 +1056,22 @@ variable scans
       0 >in !
    then ;
 
-{ 2 scans !  
+T{ 2 scans !  
 345 rescan?  
--> 345 345 }
+-> 345 345 }T
 
 : gs2  5 scans ! s" 123 rescan?" evaluate ;
-{ gs2 -> 123 123 123 123 123 }
+T{ gs2 -> 123 123 123 123 123 }T
 
 : gs3 word count swap c@ ;
-{ bl gs3 hello -> 5 char h }
-{ char " gs3 goodbye" -> 7 char g }
-{ bl gs3 
-drop -> 0 } \ blank line return zero-length string
+T{ bl gs3 hello -> 5 char h }T
+T{ char " gs3 goodbye" -> 7 char g }T
+T{ bl gs3 
+drop -> 0 }T \ blank line return zero-length string
 
 : gs4 source >in ! drop ;
-{ gs4 123 456 
--> }
+T{ gs4 123 456 
+-> }T
 
 \ ------------------------------------------------------------------------
 testing <# # #s #> hold sign base >number hex decimal
@@ -1094,16 +1094,16 @@ hex
    then ;
 
 : gp1  <# 41 hold 42 hold 0 0 #> s" BA" s= ;
-{ gp1 -> <true> }
+T{ gp1 -> <true> }T
 
 : gp2  <# -1 sign 0 sign -1 sign 0 0 #> s" --" s= ;
-{ gp2 -> <true> }
+T{ gp2 -> <true> }T
 
 : gp3  <# 1 0 # # #> s" 01" s= ;
-{ gp3 -> <true> }
+T{ gp3 -> <true> }T
 
 : gp4  <# 1 0 #s #> s" 1" s= ;
-{ gp4 -> <true> }
+T{ gp4 -> <true> }T
 
 24 constant max-base   \ base 2 .. 36
 max-base .( max-base post def: ) . cr  ( TODO TEST )
@@ -1124,7 +1124,7 @@ count-bits 2* constant #bits-ud  \ number of bits in ud
       i 0 <# #s #> s" 10" s= and
    loop
    swap base ! ;
-{ gp5 -> <true> }
+T{ gp5 -> <true> }T
 
 : gp6
    base @ >r  2 base !
@@ -1135,7 +1135,7 @@ count-bits 2* constant #bits-ud  \ number of bits in ud
       over c@ [char] 1 = and  \ all ones
       >r char+ r>
    loop swap drop ;
-{ gp6 -> <true> }
+T{ gp6 -> <true> }T
 
 
 \ Split up long testing word from ANS Forth in two parts
@@ -1154,7 +1154,7 @@ count-bits 2* constant #bits-ud  \ number of bits in ud
    
    r> base ! ;
 
-{ gp7-1 -> <true> }
+T{ gp7-1 -> <true> }T
 
 \ Test the numbers 16 to max-base in max-base
 : gp7-2
@@ -1171,7 +1171,7 @@ count-bits 2* constant #bits-ud  \ number of bits in ud
 
    r> base ! ;
 
-{ gp7-2 -> <true> }
+T{ gp7-2 -> <true> }T
 
 \ >number tests
 create gn-buf 0 c,
@@ -1179,21 +1179,21 @@ create gn-buf 0 c,
 : gn-consumed gn-buf char+ 0 ;
 : gn'  [char] ' word char+ c@ gn-buf c!  gn-string ;
 
-{ 0 0 gn' 0' >number -> 0 0 gn-consumed }
-{ 0 0 gn' 1' >number -> 1 0 gn-consumed }
-{ 1 0 gn' 1' >number -> base @ 1+ 0 gn-consumed }
-{ 0 0 gn' -' >number -> 0 0 gn-string } \ should fail to convert these
-{ 0 0 gn' +' >number -> 0 0 gn-string }
-{ 0 0 gn' .' >number -> 0 0 gn-string }
+T{ 0 0 gn' 0' >number -> 0 0 gn-consumed }T
+T{ 0 0 gn' 1' >number -> 1 0 gn-consumed }T
+T{ 1 0 gn' 1' >number -> base @ 1+ 0 gn-consumed }T
+T{ 0 0 gn' -' >number -> 0 0 gn-string }T \ should fail to convert these
+T{ 0 0 gn' +' >number -> 0 0 gn-string }T
+T{ 0 0 gn' .' >number -> 0 0 gn-string }T
 
 : >number-based  base @ >r base ! >number r> base ! ;
 
-{ 0 0 gn' 2' 10 >number-based -> 2 0 gn-consumed }
-{ 0 0 gn' 2'  2 >number-based -> 0 0 gn-string }
-{ 0 0 gn' f' 10 >number-based -> f 0 gn-consumed }
-{ 0 0 gn' g' 10 >number-based -> 0 0 gn-string }
-{ 0 0 gn' g' max-base >number-based -> 10 0 gn-consumed }
-{ 0 0 gn' z' max-base >number-based -> 23 0 gn-consumed }
+T{ 0 0 gn' 2' 10 >number-based -> 2 0 gn-consumed }T
+T{ 0 0 gn' 2'  2 >number-based -> 0 0 gn-string }T
+T{ 0 0 gn' f' 10 >number-based -> f 0 gn-consumed }T
+T{ 0 0 gn' g' 10 >number-based -> 0 0 gn-string }T
+T{ 0 0 gn' g' max-base >number-based -> 10 0 gn-consumed }T
+T{ 0 0 gn' z' max-base >number-based -> 23 0 gn-consumed }T
 
 \ ud should equal ud' and len should be zero.
 : gn1  ( ud base -- ud' len ) 
@@ -1202,61 +1202,61 @@ create gn-buf 0 c,
    0 0 2swap >number swap drop  \ return length only
    r> base ! ;
 
-{ 0 0 2 gn1 -> 0 0 0 }
-{ max-uint 0 2 gn1 -> max-uint 0 0 }
-{ max-uint dup 2 gn1 -> max-uint dup 0 }
+T{ 0 0 2 gn1 -> 0 0 0 }T
+T{ max-uint 0 2 gn1 -> max-uint 0 0 }T
+T{ max-uint dup 2 gn1 -> max-uint dup 0 }T
 
-{ 0 0 max-base gn1 -> 0 0 0 }
-{ max-uint 0 max-base gn1 -> max-uint 0 0 }
-{ max-uint dup max-base gn1 -> max-uint dup 0 }
+T{ 0 0 max-base gn1 -> 0 0 0 }T
+T{ max-uint 0 max-base gn1 -> max-uint 0 0 }T
+T{ max-uint dup max-base gn1 -> max-uint dup 0 }T
 
 : gn2 ( -- 16 10 )
    base @ >r  hex base @  decimal base @  r> base ! ;
 
-{ gn2 -> 10 a }
+T{ gn2 -> 10 a }T
 
 \ ------------------------------------------------------------------------
 testing action-of defer defer! defer@ is
 
-{ defer defer1 -> }
-{ : action-defer1 action-of defer1 ; -> }
-{ ' * ' defer1 defer! ->   }
-{          2 3 defer1 -> 6 }
-{ action-of defer1 -> ' * } 
-{    action-defer1 -> ' * }
+T{ defer defer1 -> }T
+T{ : action-defer1 action-of defer1 ; -> }T
+T{ ' * ' defer1 defer! ->   }T
+T{          2 3 defer1 -> 6 }T
+T{ action-of defer1 -> ' * }T 
+T{    action-defer1 -> ' * }T
 
-{ ' + is defer1 ->   }
-{    1 2 defer1 -> 3 } 
-{ action-of defer1 -> ' + }
-{    action-defer1 -> ' + }
+T{ ' + is defer1 ->   }T
+T{    1 2 defer1 -> 3 }T 
+T{ action-of defer1 -> ' + }T
+T{    action-defer1 -> ' + }T
 
-{ defer defer2 ->   } 
-{ ' * ' defer2 defer! -> }
-{   2 3 defer2 -> 6 }
-{ ' + is defer2 ->   }
-{    1 2 defer2 -> 3 }
+T{ defer defer2 ->   }T 
+T{ ' * ' defer2 defer! -> }T
+T{   2 3 defer2 -> 6 }T
+T{ ' + is defer2 ->   }T
+T{    1 2 defer2 -> 3 }T
 
-{ defer defer3 -> }
-{ ' * ' defer3 defer! -> }
-{ 2 3 defer3 -> 6 }
-{ ' + ' defer3 defer! -> }
-{ 1 2 defer3 -> 3 }
+T{ defer defer3 -> }T
+T{ ' * ' defer3 defer! -> }T
+T{ 2 3 defer3 -> 6 }T
+T{ ' + ' defer3 defer! -> }T
+T{ 1 2 defer3 -> 3 }T
 
-{ defer defer4 -> }
-{ ' * ' defer4 defer! -> }
-{ 2 3 defer4 -> 6 }
-{ ' defer4 defer@ -> ' * }
+T{ defer defer4 -> }T
+T{ ' * ' defer4 defer! -> }T
+T{ 2 3 defer4 -> 6 }T
+T{ ' defer4 defer@ -> ' * }T
 
-{ ' + is defer4 -> } 
-{ 1 2 defer4 -> 3 } 
-{ ' defer4 defer@ -> ' + }
+T{ ' + is defer4 -> }T 
+T{ 1 2 defer4 -> 3 }T 
+T{ ' defer4 defer@ -> ' + }T
 
-{ defer defer5 -> }
-{ : is-defer5 is defer5 ; -> }
-{ ' * is defer5 -> }
-{ 2 3 defer5 -> 6 }
-{ ' + is-defer5 -> } 
-{ 1 2 defer5 -> 3 }
+T{ defer defer5 -> }T
+T{ : is-defer5 is defer5 ; -> }T
+T{ ' * is defer5 -> }T
+T{ 2 3 defer5 -> 6 }T
+T{ ' + is-defer5 -> }T 
+T{ 1 2 defer5 -> 3 }T
 
 \ ------------------------------------------------------------------------
 testing fill move
@@ -1265,45 +1265,45 @@ create fbuf 00 c, 00 c, 00 c,
 create sbuf 12 c, 34 c, 56 c,
 : seebuf fbuf c@  fbuf char+ c@  fbuf char+ char+ c@ ;
 
-{ fbuf 0 20 fill -> }
-{ seebuf -> 00 00 00 }
+T{ fbuf 0 20 fill -> }T
+T{ seebuf -> 00 00 00 }T
 
-{ fbuf 1 20 fill -> }
-{ seebuf -> 20 00 00 }
+T{ fbuf 1 20 fill -> }T
+T{ seebuf -> 20 00 00 }T
 
-{ fbuf 3 20 fill -> }
-{ seebuf -> 20 20 20 }
+T{ fbuf 3 20 fill -> }T
+T{ seebuf -> 20 20 20 }T
 
-{ fbuf fbuf 3 chars move -> }  \ bizarre special case
-{ seebuf -> 20 20 20 }
+T{ fbuf fbuf 3 chars move -> }T  \ bizarre special case
+T{ seebuf -> 20 20 20 }T
 
-{ sbuf fbuf 0 chars move -> }
-{ seebuf -> 20 20 20 }
+T{ sbuf fbuf 0 chars move -> }T
+T{ seebuf -> 20 20 20 }T
 
-{ sbuf fbuf 1 chars move -> }
-{ seebuf -> 12 20 20 }
+T{ sbuf fbuf 1 chars move -> }T
+T{ seebuf -> 12 20 20 }T
 
-{ sbuf fbuf 3 chars move -> }
-{ seebuf -> 12 34 56 }
+T{ sbuf fbuf 3 chars move -> }T
+T{ seebuf -> 12 34 56 }T
 
-{ fbuf fbuf char+ 2 chars move -> }
-{ seebuf -> 12 12 34 }
+T{ fbuf fbuf char+ 2 chars move -> }T
+T{ seebuf -> 12 12 34 }T
 
-{ fbuf char+ fbuf 2 chars move -> }
-{ seebuf -> 12 34 34 }
+T{ fbuf char+ fbuf 2 chars move -> }T
+T{ seebuf -> 12 34 34 }T
 
 \ CMOVE and CMOVE> propogation tests taken from 
 \ https://forth-standard.org/standard/string/CMOVE and .../CMOVEtop
 decimal
 create cmbuf  97 c, 98 c, 99 c, 100 c, \ "abcd"
 : seecmbuf  cmbuf c@  cmbuf char+ c@  cmbuf char+ char+ c@  cmbuf char+ char+ char+ c@ ;
-{ cmbuf dup char+ 3 cmove -> }
-{ seecmbuf -> 97 97 97 97 } \ "aaaa"
+T{ cmbuf dup char+ 3 cmove -> }T
+T{ seecmbuf -> 97 97 97 97 }T \ "aaaa"
 
 create cmubuf  97 c, 98 c, 99 c, 100 c, \ "abcd"
 : seecmubuf  cmubuf c@  cmubuf char+ c@  cmubuf char+ char+ c@  cmubuf char+ char+ char+ c@ ;
-{ cmubuf dup char+ swap 3 cmove> -> }
-{ seecmubuf -> 100 100 100 100 } \ "dddd"
+T{ cmubuf dup char+ swap 3 cmove> -> }T
+T{ seecmubuf -> 100 100 100 100 }T \ "dddd"
 
 \ ------------------------------------------------------------------------
 testing output: . ." cr emit space spaces type u.
@@ -1329,49 +1329,49 @@ hex
    ." unsigned: " 0 u. max-uint u. cr
 ;
 
-{ output-test -> }
+T{ output-test -> }T
 
 \ ------------------------------------------------------------------------
 testing parse-name marker erase
 
 \ Careful editing these, whitespace is significant
-{ parse-name abcd s" abcd" s= -> <true> } 
-{ parse-name   abcde   s" abcde" s= -> <true> } \ test empty parse area 
-{ parse-name 
-   nip -> 0 }    \ empty line 
-{ parse-name    
-   nip -> 0 }    \ line with white space
-{ : parse-name-test ( "name1" "name2" -- n ) 
-   parse-name parse-name s= ; -> }
-{ parse-name-test abcd abcd -> <true> } 
-{ parse-name-test  abcd   abcd   -> <true> } 
-{ parse-name-test abcde abcdf -> <false> } 
-{ parse-name-test abcdf abcde -> <false> } 
-{ parse-name-test abcde abcde 
-    -> <true> } 
-{ parse-name-test abcde abcde  
-    -> <true> }    \ line with white space
+T{ parse-name abcd s" abcd" s= -> <true> }T 
+T{ parse-name   abcde   s" abcde" s= -> <true> }T \ test empty parse area 
+T{ parse-name 
+   nip -> 0 }T    \ empty line 
+T{ parse-name    
+   nip -> 0 }T    \ line with white space
+T{ : parse-name-test ( "name1" "name2" -- n ) 
+   parse-name parse-name s= ; -> }T
+T{ parse-name-test abcd abcd -> <true> }T 
+T{ parse-name-test  abcd   abcd   -> <true> }T 
+T{ parse-name-test abcde abcdf -> <false> }T 
+T{ parse-name-test abcdf abcde -> <false> }T 
+T{ parse-name-test abcde abcde 
+    -> <true> }T 
+T{ parse-name-test abcde abcde  
+    -> <true> }T    \ line with white space
 
 \ There is no official ANS test for MARKER, added 22. June 2018
 \ TODO There is currently no test for FIND-NAME, taking it on faith here
-{ variable marker_size -> }
-{ unused marker_size ! -> }
-{ marker quarian -> }
+T{ variable marker_size -> }T
+T{ unused marker_size ! -> }T
+T{ marker quarian -> }T
 : marker_test ." Bosh'tet!" ;
-{ marker_test -> } \ should print "Bosh'tet!"
-{ quarian -> } 
-{ parse-name marker_test find-name -> 0 } 
-{ marker_size @ unused = -> <true> }
+T{ marker_test -> }T \ should print "Bosh'tet!"
+T{ quarian -> }T 
+T{ parse-name marker_test find-name -> 0 }T 
+T{ marker_size @ unused = -> <true> }T
 
 \ There is no official ANS test of ERASE, added 01. July 2018
-{ create erase_test -> }
-{ 9 c, 1 c, 2 c, 3 c, 9 c, -> }
-{ erase_test 1+ 3 erase -> }  \ Erase bytes between 9 
-{ erase_test            c@ 9 = -> <true> }
-{ erase_test 1 chars +  c@ 0 = -> <true> }
-{ erase_test 2 chars +  c@ 0 = -> <true> }
-{ erase_test 3 chars +  c@ 0 = -> <true> }
-{ erase_test 4 chars +  c@ 9 = -> <true> }
+T{ create erase_test -> }T
+T{ 9 c, 1 c, 2 c, 3 c, 9 c, -> }T
+T{ erase_test 1+ 3 erase -> }T  \ Erase bytes between 9 
+T{ erase_test            c@ 9 = -> <true> }T
+T{ erase_test 1 chars +  c@ 0 = -> <true> }T
+T{ erase_test 2 chars +  c@ 0 = -> <true> }T
+T{ erase_test 3 chars +  c@ 0 = -> <true> }T
+T{ erase_test 4 chars +  c@ 9 = -> <true> }T
 
 
 \ ------------------------------------------------------------------------
@@ -1380,24 +1380,24 @@ testing environment
 \ This is from the ANS Forth specification at 
 \ https://forth-standard.org/standard/core/ENVIRONMENTq but the first
 \ test is commented out because it doesn't seem to make sense
-\ { s" x:deferred" environment? dup 0= xor invert -> <true>  } ( Huh? Why true? )
-{ s" x:notfound" environment? dup 0= xor invert -> <false> }
+\ T{ s" x:deferred" environment? dup 0= xor invert -> <true>  }T ( Huh? Why true? )
+T{ s" x:notfound" environment? dup 0= xor invert -> <false> }T
 
 \ These were added for Tali Forth 10. Aug 2018
 hex
-{ s" /COUNTED-STRING"    environment? ->    7FFF <true> }
-{ s" /HOLD"              environment? ->      FF <true> }
-{ s" /PAD"               environment? ->      54 <true> }
-{ s" ADDRESS-UNIT-BITS"  environment? ->       8 <true> }
-{ s" FLOORED"            environment? -> <false> <true> }
-{ s" MAX-CHAR"           environment? ->      FF <true> }
-{ s" MAX-N"              environment? ->    7FFF <true> }
-{ s" MAX-U"              environment? ->    FFFF <true> }
-{ s" RETURN-STACK-CELLS" environment? ->      80 <true> }
-{ s" STACK-CELLS"        environment? ->      20 <true> }
+T{ s" /COUNTED-STRING"    environment? ->    7FFF <true> }T
+T{ s" /HOLD"              environment? ->      FF <true> }T
+T{ s" /PAD"               environment? ->      54 <true> }T
+T{ s" ADDRESS-UNIT-BITS"  environment? ->       8 <true> }T
+T{ s" FLOORED"            environment? -> <false> <true> }T
+T{ s" MAX-CHAR"           environment? ->      FF <true> }T
+T{ s" MAX-N"              environment? ->    7FFF <true> }T
+T{ s" MAX-U"              environment? ->    FFFF <true> }T
+T{ s" RETURN-STACK-CELLS" environment? ->      80 <true> }T
+T{ s" STACK-CELLS"        environment? ->      20 <true> }T
 
-{ s" MAX-D"  environment? -> 7FFFFFFF. <true> } 
-{ s" MAX-UD" environment? -> FFFFFFFF. <true> }
+T{ s" MAX-D"  environment? -> 7FFFFFFF. <true> }T 
+T{ s" MAX-UD" environment? -> FFFFFFFF. <true> }T
 decimal
 
 \ ------------------------------------------------------------------------
@@ -1412,14 +1412,14 @@ create abuf 80 chars allot
    abuf swap type [char] " emit cr
 ;
 
-{ accept-test -> }
+T{ accept-test -> }T
 Here is some text for accept.
 
 \ ------------------------------------------------------------------------
 testing dictionary search rules
 
-{ : gdx   123 ; : gdx   gdx 234 ; -> }
-{ gdx -> 123 234 }
+T{ : gdx   123 ; : gdx   gdx 234 ; -> }T
+T{ gdx -> 123 234 }T
 
 hex
 \ Free memory used for these tests

--- a/tests/double.fs
+++ b/tests/double.fs
@@ -5,18 +5,18 @@ marker double_tests
 
 decimal
 
-{ 2variable 2v1 -> }
-{ 0. 2v1 2! -> }
-{ 2v1 2@ -> 0. }
-{ -1 -2 2v1 2! -> }
-{ 2v1 2@ -> -1 -2 }
-{ : cd2 2variable ; -> }
-{ cd2 2v2 -> }
-{ : cd3 2v2 2! ; -> }
-{ -2 -1 cd3 -> }
-{ 2v2 2@ -> -2 -1 }
-{ 2variable 2v3 immediate 5 6 2v3 2! -> }
-{ 2v3 2@ -> 5 6 }
+T{ 2variable 2v1 -> }T
+T{ 0. 2v1 2! -> }T
+T{ 2v1 2@ -> 0. }T
+T{ -1 -2 2v1 2! -> }T
+T{ 2v1 2@ -> -1 -2 }T
+T{ : cd2 2variable ; -> }T
+T{ cd2 2v2 -> }T
+T{ : cd3 2v2 2! ; -> }T
+T{ -2 -1 cd3 -> }T
+T{ 2v2 2@ -> -2 -1 }T
+T{ 2variable 2v3 immediate 5 6 2v3 2! -> }T
+T{ 2v3 2@ -> 5 6 }T
 
 \ Repeats in case we call this test alone
 0 constant 0s
@@ -24,35 +24,35 @@ decimal
 0 invert 1 rshift  constant max-int
 0 invert 1 rshift invert  constant min-int
 
-{  0.  5. d+ ->  5. }                         \ small integers 
-{ -5.  0. d+ -> -5. } 
-{  1.  2. d+ ->  3. } 
-{  1. -2. d+ -> -1. } 
-{ -1.  2. d+ ->  1. } 
-{ -1. -2. d+ -> -3. } 
-{ -1.  1. d+ ->  0. }
-{  0  0  0  5 d+ ->  0  5 }                  \ mid range integers 
-{ -1  5  0  0 d+ -> -1  5 } 
-{  0  0  0 -5 d+ ->  0 -5 } 
-{  0 -5 -1  0 d+ -> -1 -5 } 
-{  0  1  0  2 d+ ->  0  3 } 
-{ -1  1  0 -2 d+ -> -1 -1 } 
-{  0 -1  0  2 d+ ->  0  1 } 
-{  0 -1 -1 -2 d+ -> -1 -3 } 
-{ -1 -1  0  1 d+ -> -1  0 }
+T{  0.  5. d+ ->  5. }T                         \ small integers 
+T{ -5.  0. d+ -> -5. }T 
+T{  1.  2. d+ ->  3. }T 
+T{  1. -2. d+ -> -1. }T 
+T{ -1.  2. d+ ->  1. }T 
+T{ -1. -2. d+ -> -3. }T 
+T{ -1.  1. d+ ->  0. }T
+T{  0  0  0  5 d+ ->  0  5 }T                  \ mid range integers 
+T{ -1  5  0  0 d+ -> -1  5 }T 
+T{  0  0  0 -5 d+ ->  0 -5 }T 
+T{  0 -5 -1  0 d+ -> -1 -5 }T 
+T{  0  1  0  2 d+ ->  0  3 }T 
+T{ -1  1  0 -2 d+ -> -1 -1 }T 
+T{  0 -1  0  2 d+ ->  0  1 }T 
+T{  0 -1 -1 -2 d+ -> -1 -3 }T 
+T{ -1 -1  0  1 d+ -> -1  0 }T
 
-{ min-int 0 2dup d+ -> 0 1 }
-{ min-int s>d min-int 0 d+ -> 0 0 }
+T{ min-int 0 2dup d+ -> 0 1 }T
+T{ min-int s>d min-int 0 d+ -> 0 0 }T
 
-{ 1 2 2constant 2c1 -> }
-{ 2c1 -> 1 2 }
-{ : cd1 2c1 ; -> }
-{ cd1 -> 1 2 }
-{ : cd2 2constant ; -> }
-{ -1 -2 cd2 2c2 -> }
-{ 2c2 -> -1 -2 }
-{ 4 5 2constant 2c3 immediate 2c3 -> 4 5 }
-{ : cd6 2c3 2literal ; cd6 -> 4 5 }
+T{ 1 2 2constant 2c1 -> }T
+T{ 2c1 -> 1 2 }T
+T{ : cd1 2c1 ; -> }T
+T{ cd1 -> 1 2 }T
+T{ : cd2 2constant ; -> }T
+T{ -1 -2 cd2 2c2 -> }T
+T{ 2c2 -> -1 -2 }T
+T{ 4 5 2constant 2c3 immediate 2c3 -> 4 5 }T
+T{ : cd6 2c3 2literal ; cd6 -> 4 5 }T
 
 max-int 2/ constant hi-int \ 001...1 
 min-int 2/ constant lo-int \ 110...1
@@ -62,46 +62,46 @@ min-int 2/ constant lo-int \ 110...1
 max-2int 2/ 2constant hi-2int  \ 001...1 
 min-2int 2/ 2constant lo-2int  \ 110...0
 
-{ : cd1 [ max-2int ] 2literal ; -> }
-{ cd1 -> max-2int }
-{ 2variable 2v4 immediate 5 6 2v4 2! -> }
-{ : cd7 2v4 [ 2@ ] 2literal ; cd7 -> 5 6 }
-{ : cd8 [ 6 7 ] 2v4 [ 2! ] ; 2v4 2@ -> 6 7 }
+T{ : cd1 [ max-2int ] 2literal ; -> }T
+T{ cd1 -> max-2int }T
+T{ 2variable 2v4 immediate 5 6 2v4 2! -> }T
+T{ : cd7 2v4 [ 2@ ] 2literal ; cd7 -> 5 6 }T
+T{ : cd8 [ 6 7 ] 2v4 [ 2! ] ; 2v4 2@ -> 6 7 }T
 
-{  hi-2int       1. d+ -> 0 hi-int 1+ }     \ large double integers 
-{  hi-2int     2dup d+ -> 1s 1- max-int }
-{ max-2int min-2int d+ -> -1. }
-{ max-2int  lo-2int d+ -> hi-2int }
-{  lo-2int     2dup d+ -> min-2int }
-{  hi-2int min-2int d+ 1. d+ -> lo-2int }
+T{  hi-2int       1. d+ -> 0 hi-int 1+ }T     \ large double integers 
+T{  hi-2int     2dup d+ -> 1s 1- max-int }T
+T{ max-2int min-2int d+ -> -1. }T
+T{ max-2int  lo-2int d+ -> hi-2int }T
+T{  lo-2int     2dup d+ -> min-2int }T
+T{  hi-2int min-2int d+ 1. d+ -> lo-2int }T
 
-{  0.  5. d- -> -5. }              \ small integers 
-{  5.  0. d- ->  5. } 
-{  0. -5. d- ->  5. } 
-{  1.  2. d- -> -1. } 
-{  1. -2. d- ->  3. } 
-{ -1.  2. d- -> -3. } 
-{ -1. -2. d- ->  1. } 
-{ -1. -1. d- ->  0. } 
-{  0  0  0  5 d- ->  0 -5 }        \ mid-range integers 
-{ -1  5  0  0 d- -> -1  5 } 
-{  0  0 -1 -5 d- ->  1  4 } 
-{  0 -5  0  0 d- ->  0 -5 } 
-{ -1  1  0  2 d- -> -1 -1 } 
-{  0  1 -1 -2 d- ->  1  2 } 
-{  0 -1  0  2 d- ->  0 -3 } 
-{  0 -1  0 -2 d- ->  0  1 } 
-{  0  0  0  1 d- ->  0 -1 }
-{ min-int 0 2dup d- -> 0. } 
-{ min-int s>d max-int 0 d- -> 1 1s } 
+T{  0.  5. d- -> -5. }T              \ small integers 
+T{  5.  0. d- ->  5. }T 
+T{  0. -5. d- ->  5. }T 
+T{  1.  2. d- -> -1. }T 
+T{  1. -2. d- ->  3. }T 
+T{ -1.  2. d- -> -3. }T 
+T{ -1. -2. d- ->  1. }T 
+T{ -1. -1. d- ->  0. }T 
+T{  0  0  0  5 d- ->  0 -5 }T        \ mid-range integers 
+T{ -1  5  0  0 d- -> -1  5 }T 
+T{  0  0 -1 -5 d- ->  1  4 }T 
+T{  0 -5  0  0 d- ->  0 -5 }T 
+T{ -1  1  0  2 d- -> -1 -1 }T 
+T{  0  1 -1 -2 d- ->  1  2 }T 
+T{  0 -1  0  2 d- ->  0 -3 }T 
+T{  0 -1  0 -2 d- ->  0  1 }T 
+T{  0  0  0  1 d- ->  0 -1 }T
+T{ min-int 0 2dup d- -> 0. }T 
+T{ min-int s>d max-int 0 d- -> 1 1s }T 
 
-{ max-2int max-2int d- -> 0. }    \ large integers 
-{ min-2int min-2int d- -> 0. }
-{ max-2int  hi-2int d- -> lo-2int dnegate } 
-{  hi-2int  lo-2int d- -> max-2int }
-{  lo-2int  hi-2int d- -> min-2int 1. d+ }
-{ min-2int min-2int d- -> 0. }
-{ min-2int  lo-2int d- -> lo-2int }
+T{ max-2int max-2int d- -> 0. }T    \ large integers 
+T{ min-2int min-2int d- -> 0. }T
+T{ max-2int  hi-2int d- -> lo-2int dnegate }T 
+T{  hi-2int  lo-2int d- -> max-2int }T
+T{  lo-2int  hi-2int d- -> min-2int 1. d+ }T
+T{ min-2int min-2int d- -> 0. }T
+T{ min-2int  lo-2int d- -> lo-2int }T
 
 ( TODO m*/ not implemented ) 
 
@@ -127,7 +127,7 @@ min-2int 2/ 2constant lo-2int  \ 110...0
    \ 5 spaces dbl2 r> 5 + d.r cr 
 \ ;
 
-\ { doubleoutput -> }
+\ T{ doubleoutput -> }T
 
 ( TODO D0< not implemented yet )
 ( TODO D0= not implemented yet )
@@ -136,24 +136,24 @@ min-2int 2/ 2constant lo-2int  \ 110...0
 ( TODO D< not implemented yet )
 ( TODO D= not implemented yet )
 
-{    1234  0 d>s ->  1234   } 
-{   -1234 -1 d>s -> -1234   } 
-{ max-int  0 d>s -> max-int } 
-{ min-int -1 d>s -> min-int }
+T{    1234  0 d>s ->  1234   }T 
+T{   -1234 -1 d>s -> -1234   }T 
+T{ max-int  0 d>s -> max-int }T 
+T{ min-int -1 d>s -> min-int }T
 
-{       1. dabs -> 1.       } 
-{      -1. dabs -> 1.       } 
-{ max-2int dabs -> max-2int } 
-{ min-2int 1. d+ dabs -> max-2int }
+T{       1. dabs -> 1.       }T 
+T{      -1. dabs -> 1.       }T 
+T{ max-2int dabs -> max-2int }T 
+T{ min-2int 1. d+ dabs -> max-2int }T
 
 ( TODO DMAX not implemented yet )
 ( TODO DMIN not implemented yet )
 
-{ 0. dnegate -> 0. }
-{ 1. dnegate -> -1. }
-{ -1. dnegate -> 1. }
-{ max-2int dnegate -> min-2int swap 1+ swap }
-{ min-2int swap 1+ swap dnegate -> max-2int }
+T{ 0. dnegate -> 0. }T
+T{ 1. dnegate -> -1. }T
+T{ -1. dnegate -> 1. }T
+T{ max-2int dnegate -> min-2int swap 1+ swap }T
+T{ min-2int swap 1+ swap dnegate -> max-2int }T
 
 ( TODO M*/ not implemented yet )
 ( TODO M+ not implemented yet )

--- a/tests/results.txt
+++ b/tests/results.txt
@@ -14,6 +14,9 @@ Type 'bye' to exit
 \ The main change is lowercasing all of the words as Tali  ok
 \ is case sensitive, as well as replacing tabs with spaces.  ok
 \ A word to display the actual (erroneous) results was also added.  ok
+\ Modified by SamCo 2018-10 to facilitate using standard ANS tests.  ok
+\ The testing words were changed from { and } to T{ and }T to  ok
+\ match the testing words currently being used by ANS standard tests.  ok
   ok
 \ (C) 1995 JOHNS HOPKINS UNIVERSITY / APPLIED PHYSICS LABORATORY  ok
 \ MAY BE DISTRIBUTED FREELY AS LONG AS THIS COPYRIGHT NOTICE REMAINS.  ok
@@ -54,7 +57,7 @@ create actual-results  20 cells allot  ok
    show-results ;   \ added by SamCo to show what actually happened  ok
   ok
 \ Syntactic sugar  ok
-: {  ( -- ) ;  ok
+: T{  ( -- ) ;  ok
   ok
 \ Record depth and content of stack  ok
 : ->  ( ... -- )   compiled
@@ -66,7 +69,7 @@ create actual-results  20 cells allot  ok
    then ;  ok
   ok
 \ Compare stack (expected) contents with saved (actual) contents  ok
-: }  ( ... -- )   compiled
+: }T  ( ... -- )   compiled
    depth actual-depth @ = if     \ if depths match  compiled
       depth ?dup if              \ if there is something on the stack  compiled
          0 do                    \ for each stack item  compiled
@@ -113,79 +116,79 @@ marker core_tests  ok
 \ ------------------------------------------------------------------------  ok
 testing basic assumptions  ok
   ok
-{ -> }     \ Start with clean slate  ok
+T{ -> }T     \ Start with clean slate  ok
 ( test if any bits are set; answer in base 1 )  ok
-{ : bitsset? if 0 0 else 0 then ; -> }  ok
-{  0 bitsset? -> 0 }   \ zero is all bits clear  ok
-{  1 bitsset? -> 0 0 } \ other number have at least one bit  ok
-{ -1 bitsset? -> 0 0 }  ok
+T{ : bitsset? if 0 0 else 0 then ; -> }T  ok
+T{  0 bitsset? -> 0 }T   \ zero is all bits clear  ok
+T{  1 bitsset? -> 0 0 }T \ other number have at least one bit  ok
+T{ -1 bitsset? -> 0 0 }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing booleans: and invert or xor  ok
   ok
-{ 0 0 and -> 0 }  ok
-{ 0 1 and -> 0 }  ok
-{ 1 0 and -> 0 }  ok
-{ 1 1 and -> 1 }  ok
+T{ 0 0 and -> 0 }T  ok
+T{ 0 1 and -> 0 }T  ok
+T{ 1 0 and -> 0 }T  ok
+T{ 1 1 and -> 1 }T  ok
   ok
-{ 0 invert 1 and -> 1 }  ok
-{ 1 invert 1 and -> 0 }  ok
+T{ 0 invert 1 and -> 1 }T  ok
+T{ 1 invert 1 and -> 0 }T  ok
   ok
 0 constant 0s  ok
 0 invert constant 1s  ok
   ok
-{ 0s invert -> 1s }  ok
-{ 1s invert -> 0s }  ok
+T{ 0s invert -> 1s }T  ok
+T{ 1s invert -> 0s }T  ok
   ok
-{ 0s 0s and -> 0s }  ok
-{ 0s 1s and -> 0s }  ok
-{ 1s 0s and -> 0s }  ok
-{ 1s 1s and -> 1s }  ok
+T{ 0s 0s and -> 0s }T  ok
+T{ 0s 1s and -> 0s }T  ok
+T{ 1s 0s and -> 0s }T  ok
+T{ 1s 1s and -> 1s }T  ok
   ok
-{ 0s 0s or -> 0s }  ok
-{ 0s 1s or -> 1s }  ok
-{ 1s 0s or -> 1s }  ok
-{ 1s 1s or -> 1s }  ok
+T{ 0s 0s or -> 0s }T  ok
+T{ 0s 1s or -> 1s }T  ok
+T{ 1s 0s or -> 1s }T  ok
+T{ 1s 1s or -> 1s }T  ok
   ok
-{ 0s 0s xor -> 0s }  ok
-{ 0s 1s xor -> 1s }  ok
-{ 1s 0s xor -> 1s }  ok
-{ 1s 1s xor -> 0s }  ok
+T{ 0s 0s xor -> 0s }T  ok
+T{ 0s 1s xor -> 1s }T  ok
+T{ 1s 0s xor -> 1s }T  ok
+T{ 1s 1s xor -> 0s }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing 2* 2/ lshift rshift  ok
   ok
 ( we trust 1s, invert, and bitsset?; we will confirm rshift later )  ok
 1s 1 rshift invert constant msb  ok
-{ msb bitsset? -> 0 0 }  ok
+T{ msb bitsset? -> 0 0 }T  ok
   ok
-{ 0s 2* -> 0s }  ok
-{ 1 2* -> 2 }  ok
-{ 4000 2* -> 8000 }  ok
-{ 1s 2* 1 xor -> 1s }  ok
-{ msb 2* -> 0s }  ok
+T{ 0s 2* -> 0s }T  ok
+T{ 1 2* -> 2 }T  ok
+T{ 4000 2* -> 8000 }T  ok
+T{ 1s 2* 1 xor -> 1s }T  ok
+T{ msb 2* -> 0s }T  ok
   ok
-{ 0s 2/ -> 0s }  ok
-{ 1 2/ -> 0 }  ok
-{ 4000 2/ -> 2000 }  ok
-{ 1s 2/ -> 1s } \ msb propogated  ok
-{ 1s 1 xor 2/ -> 1s }  ok
-{ msb 2/ msb and -> msb }  ok
+T{ 0s 2/ -> 0s }T  ok
+T{ 1 2/ -> 0 }T  ok
+T{ 4000 2/ -> 2000 }T  ok
+T{ 1s 2/ -> 1s }T \ msb propogated  ok
+T{ 1s 1 xor 2/ -> 1s }T  ok
+T{ msb 2/ msb and -> msb }T  ok
   ok
-{ 1 0 lshift -> 1 }  ok
-{ 1 1 lshift -> 2 }  ok
-{ 1 2 lshift -> 4 }  ok
-{ 1 f lshift -> 8000 } \ biggest guaranteed shift  ok
-{ 1s 1 lshift 1 xor -> 1s }  ok
-{ msb 1 lshift -> 0 }  ok
+T{ 1 0 lshift -> 1 }T  ok
+T{ 1 1 lshift -> 2 }T  ok
+T{ 1 2 lshift -> 4 }T  ok
+T{ 1 f lshift -> 8000 }T \ biggest guaranteed shift  ok
+T{ 1s 1 lshift 1 xor -> 1s }T  ok
+T{ msb 1 lshift -> 0 }T  ok
   ok
-{ 1 0 rshift -> 1 }  ok
-{ 1 1 rshift -> 0 }  ok
-{ 2 1 rshift -> 1 }  ok
-{ 4 2 rshift -> 1 }  ok
-{ 8000 f rshift -> 1 } \ biggest  ok
-{ msb 1 rshift msb and -> 0 }  \ rshift zero fills msbs  ok
-{ msb 1 rshift 2* -> msb }  ok
+T{ 1 0 rshift -> 1 }T  ok
+T{ 1 1 rshift -> 0 }T  ok
+T{ 2 1 rshift -> 1 }T  ok
+T{ 4 2 rshift -> 1 }T  ok
+T{ 8000 f rshift -> 1 }T \ biggest  ok
+T{ msb 1 rshift msb and -> 0 }T  \ rshift zero fills msbs  ok
+T{ msb 1 rshift 2* -> msb }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing comparisons: true false 0= 0<> = <> 0< 0> < > u< min max within  ok
@@ -198,406 +201,406 @@ testing comparisons: true false 0= 0<> = <> 0< 0> < > u< min max within  ok
 0s constant <false>  ok
 1s constant <true>  ok
   ok
-{ false -> 0 }  ok
-{ false -> <false> }  ok
+T{ false -> 0 }T  ok
+T{ false -> <false> }T  ok
   ok
-{ true -> <true> }  ok
-{ true -> 0 invert }  ok
+T{ true -> <true> }T  ok
+T{ true -> 0 invert }T  ok
   ok
-{ 0 0= -> <true> }  ok
-{ 1 0= -> <false> }  ok
-{ 2 0= -> <false> }  ok
-{ -1 0= -> <false> }  ok
-{ max-uint 0= -> <false> }  ok
-{ min-int 0= -> <false> }  ok
-{ max-int 0= -> <false> }  ok
+T{ 0 0= -> <true> }T  ok
+T{ 1 0= -> <false> }T  ok
+T{ 2 0= -> <false> }T  ok
+T{ -1 0= -> <false> }T  ok
+T{ max-uint 0= -> <false> }T  ok
+T{ min-int 0= -> <false> }T  ok
+T{ max-int 0= -> <false> }T  ok
   ok
-{ 0 0<> -> <false> }  ok
-{ 1 0<> -> <true> }  ok
-{ 2 0<> -> <true> }  ok
-{ -1 0<> -> <true> }  ok
-{ max-uint 0<> -> <true> }  ok
-{ min-int 0<> -> <true> }  ok
-{ max-int 0<> -> <true> }  ok
+T{ 0 0<> -> <false> }T  ok
+T{ 1 0<> -> <true> }T  ok
+T{ 2 0<> -> <true> }T  ok
+T{ -1 0<> -> <true> }T  ok
+T{ max-uint 0<> -> <true> }T  ok
+T{ min-int 0<> -> <true> }T  ok
+T{ max-int 0<> -> <true> }T  ok
   ok
-{ 0 0 = -> <true> }  ok
-{ 1 1 = -> <true> }  ok
-{ -1 -1 = -> <true> }  ok
-{ 1 0 = -> <false> }  ok
-{ -1 0 = -> <false> }  ok
-{ 0 1 = -> <false> }  ok
-{ 0 -1 = -> <false> }  ok
+T{ 0 0 = -> <true> }T  ok
+T{ 1 1 = -> <true> }T  ok
+T{ -1 -1 = -> <true> }T  ok
+T{ 1 0 = -> <false> }T  ok
+T{ -1 0 = -> <false> }T  ok
+T{ 0 1 = -> <false> }T  ok
+T{ 0 -1 = -> <false> }T  ok
   ok
-{ 0 0 <> -> <false> }  ok
-{ 1 1 <> -> <false> }  ok
-{ -1 -1 <> -> <false> }  ok
-{ 1 0 <> -> <true> }  ok
-{ -1 0 <> -> <true> }  ok
-{ 0 1 <> -> <true> }  ok
-{ 0 -1 <> -> <true> }  ok
+T{ 0 0 <> -> <false> }T  ok
+T{ 1 1 <> -> <false> }T  ok
+T{ -1 -1 <> -> <false> }T  ok
+T{ 1 0 <> -> <true> }T  ok
+T{ -1 0 <> -> <true> }T  ok
+T{ 0 1 <> -> <true> }T  ok
+T{ 0 -1 <> -> <true> }T  ok
   ok
-{ 0 0< -> <false> }  ok
-{ -1 0< -> <true> }  ok
-{ min-int 0< -> <true> }  ok
-{ 1 0< -> <false> }  ok
-{ max-int 0< -> <false> }  ok
+T{ 0 0< -> <false> }T  ok
+T{ -1 0< -> <true> }T  ok
+T{ min-int 0< -> <true> }T  ok
+T{ 1 0< -> <false> }T  ok
+T{ max-int 0< -> <false> }T  ok
   ok
-{ 0 0> -> <false> }  ok
-{ -1 0> -> <false> }  ok
-{ min-int 0> -> <false> }  ok
-{ 1 0> -> <true> }  ok
-{ max-int 0> -> <true> }  ok
+T{ 0 0> -> <false> }T  ok
+T{ -1 0> -> <false> }T  ok
+T{ min-int 0> -> <false> }T  ok
+T{ 1 0> -> <true> }T  ok
+T{ max-int 0> -> <true> }T  ok
   ok
-{ 0 1 < -> <true> }  ok
-{ 1 2 < -> <true> }  ok
-{ -1 0 < -> <true> }  ok
-{ -1 1 < -> <true> }  ok
-{ min-int 0 < -> <true> }  ok
-{ min-int max-int < -> <true> }  ok
-{ 0 max-int < -> <true> }  ok
-{ 0 0 < -> <false> }  ok
-{ 1 1 < -> <false> }  ok
-{ 1 0 < -> <false> }  ok
-{ 2 1 < -> <false> }  ok
-{ 0 -1 < -> <false> }  ok
-{ 1 -1 < -> <false> }  ok
-{ 0 min-int < -> <false> }  ok
-{ max-int min-int < -> <false> }  ok
-{ max-int 0 < -> <false> }  ok
+T{ 0 1 < -> <true> }T  ok
+T{ 1 2 < -> <true> }T  ok
+T{ -1 0 < -> <true> }T  ok
+T{ -1 1 < -> <true> }T  ok
+T{ min-int 0 < -> <true> }T  ok
+T{ min-int max-int < -> <true> }T  ok
+T{ 0 max-int < -> <true> }T  ok
+T{ 0 0 < -> <false> }T  ok
+T{ 1 1 < -> <false> }T  ok
+T{ 1 0 < -> <false> }T  ok
+T{ 2 1 < -> <false> }T  ok
+T{ 0 -1 < -> <false> }T  ok
+T{ 1 -1 < -> <false> }T  ok
+T{ 0 min-int < -> <false> }T  ok
+T{ max-int min-int < -> <false> }T  ok
+T{ max-int 0 < -> <false> }T  ok
   ok
-{ 0 1 > -> <false> }  ok
-{ 1 2 > -> <false> }  ok
-{ -1 0 > -> <false> }  ok
-{ -1 1 > -> <false> }  ok
-{ min-int 0 > -> <false> }  ok
-{ min-int max-int > -> <false> }  ok
-{ 0 max-int > -> <false> }  ok
-{ 0 0 > -> <false> }  ok
-{ 1 1 > -> <false> }  ok
-{ 1 0 > -> <true> }  ok
-{ 2 1 > -> <true> }  ok
-{ 0 -1 > -> <true> }  ok
-{ 1 -1 > -> <true> }  ok
-{ 0 min-int > -> <true> }  ok
-{ max-int min-int > -> <true> }  ok
-{ max-int 0 > -> <true> }  ok
+T{ 0 1 > -> <false> }T  ok
+T{ 1 2 > -> <false> }T  ok
+T{ -1 0 > -> <false> }T  ok
+T{ -1 1 > -> <false> }T  ok
+T{ min-int 0 > -> <false> }T  ok
+T{ min-int max-int > -> <false> }T  ok
+T{ 0 max-int > -> <false> }T  ok
+T{ 0 0 > -> <false> }T  ok
+T{ 1 1 > -> <false> }T  ok
+T{ 1 0 > -> <true> }T  ok
+T{ 2 1 > -> <true> }T  ok
+T{ 0 -1 > -> <true> }T  ok
+T{ 1 -1 > -> <true> }T  ok
+T{ 0 min-int > -> <true> }T  ok
+T{ max-int min-int > -> <true> }T  ok
+T{ max-int 0 > -> <true> }T  ok
   ok
-{ 0 1 u< -> <true> }  ok
-{ 1 2 u< -> <true> }  ok
-{ 0 mid-uint u< -> <true> }  ok
-{ 0 max-uint u< -> <true> }  ok
-{ mid-uint max-uint u< -> <true> }  ok
-{ 0 0 u< -> <false> }  ok
-{ 1 1 u< -> <false> }  ok
-{ 1 0 u< -> <false> }  ok
-{ 2 1 u< -> <false> }  ok
-{ mid-uint 0 u< -> <false> }  ok
-{ max-uint 0 u< -> <false> }  ok
-{ max-uint mid-uint u< -> <false> }  ok
+T{ 0 1 u< -> <true> }T  ok
+T{ 1 2 u< -> <true> }T  ok
+T{ 0 mid-uint u< -> <true> }T  ok
+T{ 0 max-uint u< -> <true> }T  ok
+T{ mid-uint max-uint u< -> <true> }T  ok
+T{ 0 0 u< -> <false> }T  ok
+T{ 1 1 u< -> <false> }T  ok
+T{ 1 0 u< -> <false> }T  ok
+T{ 2 1 u< -> <false> }T  ok
+T{ mid-uint 0 u< -> <false> }T  ok
+T{ max-uint 0 u< -> <false> }T  ok
+T{ max-uint mid-uint u< -> <false> }T  ok
   ok
-{ 1 0 u> -> <true> }  ok
-{ 2 1 u> -> <true> }  ok
-{ mid-uint 0 u> -> <true> }  ok
-{ max-uint 0 u> -> <true> }  ok
-{ max-uint mid-uint u> -> <true> }  ok
-{ 0 0 u> -> <false> }  ok
-{ 1 1 u> -> <false> }  ok
-{ 0 1 u> -> <false> }  ok
-{ 1 2 u> -> <false> }  ok
-{ 0 mid-uint u> -> <false> }  ok
-{ 0 max-uint u> -> <false> }  ok
-{ mid-uint max-uint u> -> <false> }  ok
+T{ 1 0 u> -> <true> }T  ok
+T{ 2 1 u> -> <true> }T  ok
+T{ mid-uint 0 u> -> <true> }T  ok
+T{ max-uint 0 u> -> <true> }T  ok
+T{ max-uint mid-uint u> -> <true> }T  ok
+T{ 0 0 u> -> <false> }T  ok
+T{ 1 1 u> -> <false> }T  ok
+T{ 0 1 u> -> <false> }T  ok
+T{ 1 2 u> -> <false> }T  ok
+T{ 0 mid-uint u> -> <false> }T  ok
+T{ 0 max-uint u> -> <false> }T  ok
+T{ mid-uint max-uint u> -> <false> }T  ok
   ok
-{ 0 1 min -> 0 }  ok
-{ 1 2 min -> 1 }  ok
-{ -1 0 min -> -1 }  ok
-{ -1 1 min -> -1 }  ok
-{ min-int 0 min -> min-int }  ok
-{ min-int max-int min -> min-int }  ok
-{ 0 max-int min -> 0 }  ok
-{ 0 0 min -> 0 }  ok
-{ 1 1 min -> 1 }  ok
-{ 1 0 min -> 0 }  ok
-{ 2 1 min -> 1 }  ok
-{ 0 -1 min -> -1 }  ok
-{ 1 -1 min -> -1 }  ok
-{ 0 min-int min -> min-int }  ok
-{ max-int min-int min -> min-int }  ok
-{ max-int 0 min -> 0 }  ok
+T{ 0 1 min -> 0 }T  ok
+T{ 1 2 min -> 1 }T  ok
+T{ -1 0 min -> -1 }T  ok
+T{ -1 1 min -> -1 }T  ok
+T{ min-int 0 min -> min-int }T  ok
+T{ min-int max-int min -> min-int }T  ok
+T{ 0 max-int min -> 0 }T  ok
+T{ 0 0 min -> 0 }T  ok
+T{ 1 1 min -> 1 }T  ok
+T{ 1 0 min -> 0 }T  ok
+T{ 2 1 min -> 1 }T  ok
+T{ 0 -1 min -> -1 }T  ok
+T{ 1 -1 min -> -1 }T  ok
+T{ 0 min-int min -> min-int }T  ok
+T{ max-int min-int min -> min-int }T  ok
+T{ max-int 0 min -> 0 }T  ok
   ok
-{ 0 1 max -> 1 }  ok
-{ 1 2 max -> 2 }  ok
-{ -1 0 max -> 0 }  ok
-{ -1 1 max -> 1 }  ok
-{ min-int 0 max -> 0 }  ok
-{ min-int max-int max -> max-int }  ok
-{ 0 max-int max -> max-int }  ok
-{ 0 0 max -> 0 }  ok
-{ 1 1 max -> 1 }  ok
-{ 1 0 max -> 1 }  ok
-{ 2 1 max -> 2 }  ok
-{ 0 -1 max -> 0 }  ok
-{ 1 -1 max -> 1 }  ok
-{ 0 min-int max -> 0 }  ok
-{ max-int min-int max -> max-int }  ok
-{ max-int 0 max -> max-int }  ok
+T{ 0 1 max -> 1 }T  ok
+T{ 1 2 max -> 2 }T  ok
+T{ -1 0 max -> 0 }T  ok
+T{ -1 1 max -> 1 }T  ok
+T{ min-int 0 max -> 0 }T  ok
+T{ min-int max-int max -> max-int }T  ok
+T{ 0 max-int max -> max-int }T  ok
+T{ 0 0 max -> 0 }T  ok
+T{ 1 1 max -> 1 }T  ok
+T{ 1 0 max -> 1 }T  ok
+T{ 2 1 max -> 2 }T  ok
+T{ 0 -1 max -> 0 }T  ok
+T{ 1 -1 max -> 1 }T  ok
+T{ 0 min-int max -> 0 }T  ok
+T{ max-int min-int max -> max-int }T  ok
+T{ max-int 0 max -> max-int }T  ok
   ok
-{ 1 2 4 within -> <false> }  ok
-{ 2 2 4 within -> <true> }  ok
-{ 3 2 4 within -> <true> }  ok
-{ 4 2 4 within -> <false> }  ok
-{ 5 2 4 within -> <false> }  ok
+T{ 1 2 4 within -> <false> }T  ok
+T{ 2 2 4 within -> <true> }T  ok
+T{ 3 2 4 within -> <true> }T  ok
+T{ 4 2 4 within -> <false> }T  ok
+T{ 5 2 4 within -> <false> }T  ok
   ok
-{ 0 2 4 within -> <false> }  ok
-{ 1 0 4 within -> <true> }  ok
-{ 0 0 4 within -> <true> }  ok
-{ 4 0 4 within -> <false> }  ok
-{ 5 0 4 within -> <false> }  ok
+T{ 0 2 4 within -> <false> }T  ok
+T{ 1 0 4 within -> <true> }T  ok
+T{ 0 0 4 within -> <true> }T  ok
+T{ 4 0 4 within -> <false> }T  ok
+T{ 5 0 4 within -> <false> }T  ok
   ok
-{ -1 -3 -1 within -> <false> }  ok
-{ -2 -3 -1 within -> <true> }  ok
-{ -3 -3 -1 within -> <true> }  ok
-{ -4 -3 -1 within -> <false> }  ok
+T{ -1 -3 -1 within -> <false> }T  ok
+T{ -2 -3 -1 within -> <true> }T  ok
+T{ -3 -3 -1 within -> <true> }T  ok
+T{ -4 -3 -1 within -> <false> }T  ok
   ok
-{ -2 -2 0 within -> <true> }  ok
-{ -1 -2 0 within -> <true> }  ok
-{ 0 -2 0 within -> <false> }  ok
-{ 1 -2 0 within -> <false> }  ok
+T{ -2 -2 0 within -> <true> }T  ok
+T{ -1 -2 0 within -> <true> }T  ok
+T{ 0 -2 0 within -> <false> }T  ok
+T{ 1 -2 0 within -> <false> }T  ok
   ok
-{ 0 min-int max-int within -> <true> }  ok
-{ 1 min-int max-int within -> <true> }  ok
-{ -1 min-int max-int within -> <true> }  ok
-{ min-int min-int max-int within -> <true> }  ok
-{ max-int min-int max-int within -> <false> }  ok
+T{ 0 min-int max-int within -> <true> }T  ok
+T{ 1 min-int max-int within -> <true> }T  ok
+T{ -1 min-int max-int within -> <true> }T  ok
+T{ min-int min-int max-int within -> <true> }T  ok
+T{ max-int min-int max-int within -> <false> }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing stack ops: 2drop 2dup 2over 2swap ?dup depth drop dup nip over rot -rot   ok
 testing stack ops: swap tuck pick  ok
   ok
-{ 1 2 2drop -> }  ok
-{ 1 2 2dup -> 1 2 1 2 }  ok
-{ 1 2 3 4 2over -> 1 2 3 4 1 2 }  ok
-{ 1 2 3 4 2swap -> 3 4 1 2 }  ok
-{ 0 ?dup -> 0 }  ok
-{ 1 ?dup -> 1 1 }  ok
-{ -1 ?dup -> -1 -1 }  ok
-{ depth -> 0 }  ok
-{ 0 depth -> 0 1 }  ok
-{ 0 1 depth -> 0 1 2 }  ok
-{ 0 drop -> }  ok
-{ 1 2 drop -> 1 }  ok
-{ 1 dup -> 1 1 }  ok
-{ 1 2 nip -> 2 }  ok
-{ 1 2 over -> 1 2 1 }  ok
-{ 1 2 3 rot -> 2 3 1 }  ok
-{ 1 2 3 -rot -> 3 1 2 }  ok
-{ 1 2 swap -> 2 1 }  ok
+T{ 1 2 2drop -> }T  ok
+T{ 1 2 2dup -> 1 2 1 2 }T  ok
+T{ 1 2 3 4 2over -> 1 2 3 4 1 2 }T  ok
+T{ 1 2 3 4 2swap -> 3 4 1 2 }T  ok
+T{ 0 ?dup -> 0 }T  ok
+T{ 1 ?dup -> 1 1 }T  ok
+T{ -1 ?dup -> -1 -1 }T  ok
+T{ depth -> 0 }T  ok
+T{ 0 depth -> 0 1 }T  ok
+T{ 0 1 depth -> 0 1 2 }T  ok
+T{ 0 drop -> }T  ok
+T{ 1 2 drop -> 1 }T  ok
+T{ 1 dup -> 1 1 }T  ok
+T{ 1 2 nip -> 2 }T  ok
+T{ 1 2 over -> 1 2 1 }T  ok
+T{ 1 2 3 rot -> 2 3 1 }T  ok
+T{ 1 2 3 -rot -> 3 1 2 }T  ok
+T{ 1 2 swap -> 2 1 }T  ok
   ok
 \ There is no formal ANS test for TUCK, this added 01. July 2018  ok
-{ 2 1 tuck -> 1 2 1 }  ok
+T{ 2 1 tuck -> 1 2 1 }T  ok
   ok
 \ There is no formal ANS test for PICK, this added 01. July 2018  ok
 \ Note that ANS's PICK is different from FIG Forth PICK  ok
-{ 1      0 pick -> 1 1 }    \ Defined by standard: 0 PICK is same as DUP  ok
-{ 1 2    1 pick -> 1 2 1 }  \ Defined by standard: 1 PICK is same as OVER  ok
-{ 1 2 3  2 pick -> 1 2 3 1 }  ok
+T{ 1      0 pick -> 1 1 }T    \ Defined by standard: 0 PICK is same as DUP  ok
+T{ 1 2    1 pick -> 1 2 1 }T  \ Defined by standard: 1 PICK is same as OVER  ok
+T{ 1 2 3  2 pick -> 1 2 3 1 }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing >r r> r@ 2>r 2r> 2r@  ok
   ok
-{ : gr1 >r r> ; -> }  ok
-{ : gr2 >r r@ r> drop ; -> }  ok
-{ 123 gr1 -> 123 }  ok
-{ 123 gr2 -> 123 }  ok
-{ 1s gr1 -> 1s } \ return stack holds cells  ok
+T{ : gr1 >r r> ; -> }T  ok
+T{ : gr2 >r r@ r> drop ; -> }T  ok
+T{ 123 gr1 -> 123 }T  ok
+T{ 123 gr2 -> 123 }T  ok
+T{ 1s gr1 -> 1s }T \ return stack holds cells  ok
   ok
 \ There are no official ANS tests for 2>R, 2R>, or 2R@, added 22. June 2018  ok
-{ : gr3 2>r 2r> ; -> }  ok
-{ : gr4 2>r 2r@ 2r> 2drop ; -> }  ok
-{ : gr5 2>r r> r> ; } \ must reverse sequence, as 2r> is not r> r>   ok
-{ 123. gr3 -> 123. }  ok
-{ 123. gr4 -> 123. }  ok
-{ 123. gr5 -> 0 123 }  ok
+T{ : gr3 2>r 2r> ; -> }T  ok
+T{ : gr4 2>r 2r@ 2r> 2drop ; -> }T  ok
+T{ : gr5 2>r r> r> ; }T \ must reverse sequence, as 2r> is not r> r>   ok
+T{ 123. gr3 -> 123. }T  ok
+T{ 123. gr4 -> 123. }T  ok
+T{ 123. gr5 -> 0 123 }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing add/subtract: + - 1+ 1- abs negate   ok
   ok
-{ 0 5 + -> 5 }  ok
-{ 5 0 + -> 5 }  ok
-{ 0 -5 + -> -5 }  ok
-{ -5 0 + -> -5 }  ok
-{ 1 2 + -> 3 }  ok
-{ 1 -2 + -> -1 }  ok
-{ -1 2 + -> 1 }  ok
-{ -1 -2 + -> -3 }  ok
-{ -1 1 + -> 0 }  ok
-{ mid-uint 1 + -> mid-uint+1 }  ok
+T{ 0 5 + -> 5 }T  ok
+T{ 5 0 + -> 5 }T  ok
+T{ 0 -5 + -> -5 }T  ok
+T{ -5 0 + -> -5 }T  ok
+T{ 1 2 + -> 3 }T  ok
+T{ 1 -2 + -> -1 }T  ok
+T{ -1 2 + -> 1 }T  ok
+T{ -1 -2 + -> -3 }T  ok
+T{ -1 1 + -> 0 }T  ok
+T{ mid-uint 1 + -> mid-uint+1 }T  ok
   ok
-{ 0 5 - -> -5 }  ok
-{ 5 0 - -> 5 }  ok
-{ 0 -5 - -> 5 }  ok
-{ -5 0 - -> -5 }  ok
-{ 1 2 - -> -1 }  ok
-{ 1 -2 - -> 3 }  ok
-{ -1 2 - -> -3 }  ok
-{ -1 -2 - -> 1 }  ok
-{ 0 1 - -> -1 }  ok
-{ mid-uint+1 1 - -> mid-uint }  ok
+T{ 0 5 - -> -5 }T  ok
+T{ 5 0 - -> 5 }T  ok
+T{ 0 -5 - -> 5 }T  ok
+T{ -5 0 - -> -5 }T  ok
+T{ 1 2 - -> -1 }T  ok
+T{ 1 -2 - -> 3 }T  ok
+T{ -1 2 - -> -3 }T  ok
+T{ -1 -2 - -> 1 }T  ok
+T{ 0 1 - -> -1 }T  ok
+T{ mid-uint+1 1 - -> mid-uint }T  ok
   ok
-{ 0 1+ -> 1 }  ok
-{ -1 1+ -> 0 }  ok
-{ 1 1+ -> 2 }  ok
-{ mid-uint 1+ -> mid-uint+1 }  ok
+T{ 0 1+ -> 1 }T  ok
+T{ -1 1+ -> 0 }T  ok
+T{ 1 1+ -> 2 }T  ok
+T{ mid-uint 1+ -> mid-uint+1 }T  ok
   ok
-{ 2 1- -> 1 }  ok
-{ 1 1- -> 0 }  ok
-{ 0 1- -> -1 }  ok
-{ mid-uint+1 1- -> mid-uint }  ok
+T{ 2 1- -> 1 }T  ok
+T{ 1 1- -> 0 }T  ok
+T{ 0 1- -> -1 }T  ok
+T{ mid-uint+1 1- -> mid-uint }T  ok
   ok
-{ 0 negate -> 0 }  ok
-{ 1 negate -> -1 }  ok
-{ -1 negate -> 1 }  ok
-{ 2 negate -> -2 }  ok
-{ -2 negate -> 2 }  ok
+T{ 0 negate -> 0 }T  ok
+T{ 1 negate -> -1 }T  ok
+T{ -1 negate -> 1 }T  ok
+T{ 2 negate -> -2 }T  ok
+T{ -2 negate -> 2 }T  ok
   ok
-{ 0 abs -> 0 }  ok
-{ 1 abs -> 1 }  ok
-{ -1 abs -> 1 }  ok
-{ min-int abs -> mid-uint+1 }  ok
+T{ 0 abs -> 0 }T  ok
+T{ 1 abs -> 1 }T  ok
+T{ -1 abs -> 1 }T  ok
+T{ min-int abs -> mid-uint+1 }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing multiply: s>d * m* um*  ok
   ok
-{ 0 s>d -> 0 0 }  ok
-{ 1 s>d -> 1 0 }  ok
-{ 2 s>d -> 2 0 }  ok
-{ -1 s>d -> -1 -1 }  ok
-{ -2 s>d -> -2 -1 }  ok
-{ min-int s>d -> min-int -1 }  ok
-{ max-int s>d -> max-int 0 }  ok
+T{ 0 s>d -> 0 0 }T  ok
+T{ 1 s>d -> 1 0 }T  ok
+T{ 2 s>d -> 2 0 }T  ok
+T{ -1 s>d -> -1 -1 }T  ok
+T{ -2 s>d -> -2 -1 }T  ok
+T{ min-int s>d -> min-int -1 }T  ok
+T{ max-int s>d -> max-int 0 }T  ok
   ok
-{ 0 0 m* -> 0 s>d }  ok
-{ 0 1 m* -> 0 s>d }  ok
-{ 1 0 m* -> 0 s>d }  ok
-{ 1 2 m* -> 2 s>d }  ok
-{ 2 1 m* -> 2 s>d }  ok
-{ 3 3 m* -> 9 s>d }  ok
-{ -3 3 m* -> -9 s>d }  ok
-{ 3 -3 m* -> -9 s>d }  ok
-{ -3 -3 m* -> 9 s>d }  ok
-{ 0 min-int m* -> 0 s>d }  ok
-{ 1 min-int m* -> min-int s>d }  ok
-{ 2 min-int m* -> 0 1s }  ok
-{ 0 max-int m* -> 0 s>d }  ok
-{ 1 max-int m* -> max-int s>d }  ok
-{ 2 max-int m* -> max-int 1 lshift 0 }  ok
-{ min-int min-int m* -> 0 msb 1 rshift }  ok
-{ max-int min-int m* -> msb msb 2/ }  ok
-{ max-int max-int m* -> 1 msb 2/ invert }  ok
+T{ 0 0 m* -> 0 s>d }T  ok
+T{ 0 1 m* -> 0 s>d }T  ok
+T{ 1 0 m* -> 0 s>d }T  ok
+T{ 1 2 m* -> 2 s>d }T  ok
+T{ 2 1 m* -> 2 s>d }T  ok
+T{ 3 3 m* -> 9 s>d }T  ok
+T{ -3 3 m* -> -9 s>d }T  ok
+T{ 3 -3 m* -> -9 s>d }T  ok
+T{ -3 -3 m* -> 9 s>d }T  ok
+T{ 0 min-int m* -> 0 s>d }T  ok
+T{ 1 min-int m* -> min-int s>d }T  ok
+T{ 2 min-int m* -> 0 1s }T  ok
+T{ 0 max-int m* -> 0 s>d }T  ok
+T{ 1 max-int m* -> max-int s>d }T  ok
+T{ 2 max-int m* -> max-int 1 lshift 0 }T  ok
+T{ min-int min-int m* -> 0 msb 1 rshift }T  ok
+T{ max-int min-int m* -> msb msb 2/ }T  ok
+T{ max-int max-int m* -> 1 msb 2/ invert }T  ok
   ok
-{ 0 0 * -> 0 } \ test identities  ok
-{ 0 1 * -> 0 }  ok
-{ 1 0 * -> 0 }  ok
-{ 1 2 * -> 2 }  ok
-{ 2 1 * -> 2 }  ok
-{ 3 3 * -> 9 }  ok
-{ -3 3 * -> -9 }  ok
-{ 3 -3 * -> -9 }  ok
-{ -3 -3 * -> 9 }  ok
+T{ 0 0 * -> 0 }T \ test identities  ok
+T{ 0 1 * -> 0 }T  ok
+T{ 1 0 * -> 0 }T  ok
+T{ 1 2 * -> 2 }T  ok
+T{ 2 1 * -> 2 }T  ok
+T{ 3 3 * -> 9 }T  ok
+T{ -3 3 * -> -9 }T  ok
+T{ 3 -3 * -> -9 }T  ok
+T{ -3 -3 * -> 9 }T  ok
   ok
-{ mid-uint+1 1 rshift 2 * -> mid-uint+1 }  ok
-{ mid-uint+1 2 rshift 4 * -> mid-uint+1 }  ok
-{ mid-uint+1 1 rshift mid-uint+1 or 2 * -> mid-uint+1 }  ok
+T{ mid-uint+1 1 rshift 2 * -> mid-uint+1 }T  ok
+T{ mid-uint+1 2 rshift 4 * -> mid-uint+1 }T  ok
+T{ mid-uint+1 1 rshift mid-uint+1 or 2 * -> mid-uint+1 }T  ok
   ok
-{ 0 0 um* -> 0 0 }  ok
-{ 0 1 um* -> 0 0 }  ok
-{ 1 0 um* -> 0 0 }  ok
-{ 1 2 um* -> 2 0 }  ok
-{ 2 1 um* -> 2 0 }  ok
-{ 3 3 um* -> 9 0 }  ok
+T{ 0 0 um* -> 0 0 }T  ok
+T{ 0 1 um* -> 0 0 }T  ok
+T{ 1 0 um* -> 0 0 }T  ok
+T{ 1 2 um* -> 2 0 }T  ok
+T{ 2 1 um* -> 2 0 }T  ok
+T{ 3 3 um* -> 9 0 }T  ok
   ok
-{ mid-uint+1 1 rshift 2 um* -> mid-uint+1 0 }  ok
-{ mid-uint+1 2 um* -> 0 1 }  ok
-{ mid-uint+1 4 um* -> 0 2 }  ok
-{ 1s 2 um* -> 1s 1 lshift 1 }  ok
-{ max-uint max-uint um* -> 1 1 invert }  ok
+T{ mid-uint+1 1 rshift 2 um* -> mid-uint+1 0 }T  ok
+T{ mid-uint+1 2 um* -> 0 1 }T  ok
+T{ mid-uint+1 4 um* -> 0 2 }T  ok
+T{ 1s 2 um* -> 1s 1 lshift 1 }T  ok
+T{ max-uint max-uint um* -> 1 1 invert }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing divide: fm/mod sm/rem um/mod */ */mod / /mod mod  ok
   ok
-{ 0 s>d 1 fm/mod -> 0 0 }  ok
-{ 1 s>d 1 fm/mod -> 0 1 }  ok
-{ 2 s>d 1 fm/mod -> 0 2 }  ok
-{ -1 s>d 1 fm/mod -> 0 -1 }  ok
-{ -2 s>d 1 fm/mod -> 0 -2 }  ok
-{ 0 s>d -1 fm/mod -> 0 0 }  ok
-{ 1 s>d -1 fm/mod -> 0 -1 }  ok
-{ 2 s>d -1 fm/mod -> 0 -2 }  ok
-{ -1 s>d -1 fm/mod -> 0 1 }  ok
-{ -2 s>d -1 fm/mod -> 0 2 }  ok
-{ 2 s>d 2 fm/mod -> 0 1 }  ok
-{ -1 s>d -1 fm/mod -> 0 1 }  ok
-{ -2 s>d -2 fm/mod -> 0 1 }  ok
-{  7 s>d  3 fm/mod -> 1 2 }  ok
-{  7 s>d -3 fm/mod -> -2 -3 }  ok
-{ -7 s>d  3 fm/mod -> 2 -3 }  ok
-{ -7 s>d -3 fm/mod -> -1 2 }  ok
-{ max-int s>d 1 fm/mod -> 0 max-int }  ok
-{ min-int s>d 1 fm/mod -> 0 min-int }  ok
-{ max-int s>d max-int fm/mod -> 0 1 }  ok
-{ min-int s>d min-int fm/mod -> 0 1 }  ok
-{ 1s 1 4 fm/mod -> 3 max-int }  ok
-{ 1 min-int m* 1 fm/mod -> 0 min-int }  ok
-{ 1 min-int m* min-int fm/mod -> 0 1 }  ok
-{ 2 min-int m* 2 fm/mod -> 0 min-int }  ok
-{ 2 min-int m* min-int fm/mod -> 0 2 }  ok
-{ 1 max-int m* 1 fm/mod -> 0 max-int }  ok
-{ 1 max-int m* max-int fm/mod -> 0 1 }  ok
-{ 2 max-int m* 2 fm/mod -> 0 max-int }  ok
-{ 2 max-int m* max-int fm/mod -> 0 2 }  ok
-{ min-int min-int m* min-int fm/mod -> 0 min-int }  ok
-{ min-int max-int m* min-int fm/mod -> 0 max-int }  ok
-{ min-int max-int m* max-int fm/mod -> 0 min-int }  ok
-{ max-int max-int m* max-int fm/mod -> 0 max-int }  ok
+T{ 0 s>d 1 fm/mod -> 0 0 }T  ok
+T{ 1 s>d 1 fm/mod -> 0 1 }T  ok
+T{ 2 s>d 1 fm/mod -> 0 2 }T  ok
+T{ -1 s>d 1 fm/mod -> 0 -1 }T  ok
+T{ -2 s>d 1 fm/mod -> 0 -2 }T  ok
+T{ 0 s>d -1 fm/mod -> 0 0 }T  ok
+T{ 1 s>d -1 fm/mod -> 0 -1 }T  ok
+T{ 2 s>d -1 fm/mod -> 0 -2 }T  ok
+T{ -1 s>d -1 fm/mod -> 0 1 }T  ok
+T{ -2 s>d -1 fm/mod -> 0 2 }T  ok
+T{ 2 s>d 2 fm/mod -> 0 1 }T  ok
+T{ -1 s>d -1 fm/mod -> 0 1 }T  ok
+T{ -2 s>d -2 fm/mod -> 0 1 }T  ok
+T{  7 s>d  3 fm/mod -> 1 2 }T  ok
+T{  7 s>d -3 fm/mod -> -2 -3 }T  ok
+T{ -7 s>d  3 fm/mod -> 2 -3 }T  ok
+T{ -7 s>d -3 fm/mod -> -1 2 }T  ok
+T{ max-int s>d 1 fm/mod -> 0 max-int }T  ok
+T{ min-int s>d 1 fm/mod -> 0 min-int }T  ok
+T{ max-int s>d max-int fm/mod -> 0 1 }T  ok
+T{ min-int s>d min-int fm/mod -> 0 1 }T  ok
+T{ 1s 1 4 fm/mod -> 3 max-int }T  ok
+T{ 1 min-int m* 1 fm/mod -> 0 min-int }T  ok
+T{ 1 min-int m* min-int fm/mod -> 0 1 }T  ok
+T{ 2 min-int m* 2 fm/mod -> 0 min-int }T  ok
+T{ 2 min-int m* min-int fm/mod -> 0 2 }T  ok
+T{ 1 max-int m* 1 fm/mod -> 0 max-int }T  ok
+T{ 1 max-int m* max-int fm/mod -> 0 1 }T  ok
+T{ 2 max-int m* 2 fm/mod -> 0 max-int }T  ok
+T{ 2 max-int m* max-int fm/mod -> 0 2 }T  ok
+T{ min-int min-int m* min-int fm/mod -> 0 min-int }T  ok
+T{ min-int max-int m* min-int fm/mod -> 0 max-int }T  ok
+T{ min-int max-int m* max-int fm/mod -> 0 min-int }T  ok
+T{ max-int max-int m* max-int fm/mod -> 0 max-int }T  ok
   ok
-{ 0 s>d 1 sm/rem -> 0 0 }  ok
-{ 1 s>d 1 sm/rem -> 0 1 }  ok
-{ 2 s>d 1 sm/rem -> 0 2 }  ok
-{ -1 s>d 1 sm/rem -> 0 -1 }  ok
-{ -2 s>d 1 sm/rem -> 0 -2 }  ok
-{ 0 s>d -1 sm/rem -> 0 0 }  ok
-{ 1 s>d -1 sm/rem -> 0 -1 }  ok
-{ 2 s>d -1 sm/rem -> 0 -2 }  ok
-{ -1 s>d -1 sm/rem -> 0 1 }  ok
-{ -2 s>d -1 sm/rem -> 0 2 }  ok
-{ 2 s>d 2 sm/rem -> 0 1 }  ok
-{ -1 s>d -1 sm/rem -> 0 1 }  ok
-{ -2 s>d -2 sm/rem -> 0 1 }  ok
-{  7 s>d  3 sm/rem -> 1 2 }  ok
-{  7 s>d -3 sm/rem -> 1 -2 }  ok
-{ -7 s>d  3 sm/rem -> -1 -2 }  ok
-{ -7 s>d -3 sm/rem -> -1 2 }  ok
-{ max-int s>d 1 sm/rem -> 0 max-int }  ok
-{ min-int s>d 1 sm/rem -> 0 min-int }  ok
-{ max-int s>d max-int sm/rem -> 0 1 }  ok
-{ min-int s>d min-int sm/rem -> 0 1 }  ok
-{ 1s 1 4 sm/rem -> 3 max-int }  ok
-{ 2 min-int m* 2 sm/rem -> 0 min-int }  ok
-{ 2 min-int m* min-int sm/rem -> 0 2 }  ok
-{ 2 max-int m* 2 sm/rem -> 0 max-int }  ok
-{ 2 max-int m* max-int sm/rem -> 0 2 }  ok
-{ min-int min-int m* min-int sm/rem -> 0 min-int }  ok
-{ min-int max-int m* min-int sm/rem -> 0 max-int }  ok
-{ min-int max-int m* max-int sm/rem -> 0 min-int }  ok
-{ max-int max-int m* max-int sm/rem -> 0 max-int }  ok
+T{ 0 s>d 1 sm/rem -> 0 0 }T  ok
+T{ 1 s>d 1 sm/rem -> 0 1 }T  ok
+T{ 2 s>d 1 sm/rem -> 0 2 }T  ok
+T{ -1 s>d 1 sm/rem -> 0 -1 }T  ok
+T{ -2 s>d 1 sm/rem -> 0 -2 }T  ok
+T{ 0 s>d -1 sm/rem -> 0 0 }T  ok
+T{ 1 s>d -1 sm/rem -> 0 -1 }T  ok
+T{ 2 s>d -1 sm/rem -> 0 -2 }T  ok
+T{ -1 s>d -1 sm/rem -> 0 1 }T  ok
+T{ -2 s>d -1 sm/rem -> 0 2 }T  ok
+T{ 2 s>d 2 sm/rem -> 0 1 }T  ok
+T{ -1 s>d -1 sm/rem -> 0 1 }T  ok
+T{ -2 s>d -2 sm/rem -> 0 1 }T  ok
+T{  7 s>d  3 sm/rem -> 1 2 }T  ok
+T{  7 s>d -3 sm/rem -> 1 -2 }T  ok
+T{ -7 s>d  3 sm/rem -> -1 -2 }T  ok
+T{ -7 s>d -3 sm/rem -> -1 2 }T  ok
+T{ max-int s>d 1 sm/rem -> 0 max-int }T  ok
+T{ min-int s>d 1 sm/rem -> 0 min-int }T  ok
+T{ max-int s>d max-int sm/rem -> 0 1 }T  ok
+T{ min-int s>d min-int sm/rem -> 0 1 }T  ok
+T{ 1s 1 4 sm/rem -> 3 max-int }T  ok
+T{ 2 min-int m* 2 sm/rem -> 0 min-int }T  ok
+T{ 2 min-int m* min-int sm/rem -> 0 2 }T  ok
+T{ 2 max-int m* 2 sm/rem -> 0 max-int }T  ok
+T{ 2 max-int m* max-int sm/rem -> 0 2 }T  ok
+T{ min-int min-int m* min-int sm/rem -> 0 min-int }T  ok
+T{ min-int max-int m* min-int sm/rem -> 0 max-int }T  ok
+T{ min-int max-int m* max-int sm/rem -> 0 min-int }T  ok
+T{ max-int max-int m* max-int sm/rem -> 0 max-int }T  ok
   ok
-{ 0 0 1 um/mod -> 0 0 }  ok
-{ 1 0 1 um/mod -> 0 1 }  ok
-{ 1 0 2 um/mod -> 1 0 }  ok
-{ 3 0 2 um/mod -> 1 1 }  ok
-{ max-uint 2 um* 2 um/mod -> 0 max-uint }  ok
-{ max-uint 2 um* max-uint um/mod -> 0 2 }  ok
-{ max-uint max-uint um* max-uint um/mod -> 0 max-uint }  ok
+T{ 0 0 1 um/mod -> 0 0 }T  ok
+T{ 1 0 1 um/mod -> 0 1 }T  ok
+T{ 1 0 2 um/mod -> 1 0 }T  ok
+T{ 3 0 2 um/mod -> 1 1 }T  ok
+T{ max-uint 2 um* 2 um/mod -> 0 max-uint }T  ok
+T{ max-uint 2 um* max-uint um/mod -> 0 2 }T  ok
+T{ max-uint max-uint um* max-uint um/mod -> 0 max-uint }T  ok
   ok
 : iffloored  compiled
    [ -3 2 / -2 = invert ] literal if postpone \ then ;  ok
@@ -617,111 +620,111 @@ ifsym     : tmod   t/mod drop ;  ok
 ifsym     : t*/mod >r m* r> sm/rem ;  ok
 ifsym     : t*/    t*/mod swap drop ;  ok
   ok
-{ 0 1 /mod -> 0 1 t/mod }  ok
-{ 1 1 /mod -> 1 1 t/mod }  ok
-{ 2 1 /mod -> 2 1 t/mod }  ok
-{ -1 1 /mod -> -1 1 t/mod }  ok
-{ -2 1 /mod -> -2 1 t/mod }  ok
-{ 0 -1 /mod -> 0 -1 t/mod }  ok
-{ 1 -1 /mod -> 1 -1 t/mod }  ok
-{ 2 -1 /mod -> 2 -1 t/mod }  ok
-{ -1 -1 /mod -> -1 -1 t/mod }  ok
-{ -2 -1 /mod -> -2 -1 t/mod }  ok
-{ 2 2 /mod -> 2 2 t/mod }  ok
-{ -1 -1 /mod -> -1 -1 t/mod }  ok
-{ -2 -2 /mod -> -2 -2 t/mod }  ok
-{ 7 3 /mod -> 7 3 t/mod }  ok
-{ 7 -3 /mod -> 7 -3 t/mod }  ok
-{ -7 3 /mod -> -7 3 t/mod }  ok
-{ -7 -3 /mod -> -7 -3 t/mod }  ok
-{ max-int 1 /mod -> max-int 1 t/mod }  ok
-{ min-int 1 /mod -> min-int 1 t/mod }  ok
-{ max-int max-int /mod -> max-int max-int t/mod }  ok
-{ min-int min-int /mod -> min-int min-int t/mod }  ok
+T{ 0 1 /mod -> 0 1 t/mod }T  ok
+T{ 1 1 /mod -> 1 1 t/mod }T  ok
+T{ 2 1 /mod -> 2 1 t/mod }T  ok
+T{ -1 1 /mod -> -1 1 t/mod }T  ok
+T{ -2 1 /mod -> -2 1 t/mod }T  ok
+T{ 0 -1 /mod -> 0 -1 t/mod }T  ok
+T{ 1 -1 /mod -> 1 -1 t/mod }T  ok
+T{ 2 -1 /mod -> 2 -1 t/mod }T  ok
+T{ -1 -1 /mod -> -1 -1 t/mod }T  ok
+T{ -2 -1 /mod -> -2 -1 t/mod }T  ok
+T{ 2 2 /mod -> 2 2 t/mod }T  ok
+T{ -1 -1 /mod -> -1 -1 t/mod }T  ok
+T{ -2 -2 /mod -> -2 -2 t/mod }T  ok
+T{ 7 3 /mod -> 7 3 t/mod }T  ok
+T{ 7 -3 /mod -> 7 -3 t/mod }T  ok
+T{ -7 3 /mod -> -7 3 t/mod }T  ok
+T{ -7 -3 /mod -> -7 -3 t/mod }T  ok
+T{ max-int 1 /mod -> max-int 1 t/mod }T  ok
+T{ min-int 1 /mod -> min-int 1 t/mod }T  ok
+T{ max-int max-int /mod -> max-int max-int t/mod }T  ok
+T{ min-int min-int /mod -> min-int min-int t/mod }T  ok
   ok
-{ 0 1 / -> 0 1 t/ }  ok
-{ 1 1 / -> 1 1 t/ }  ok
-{ 2 1 / -> 2 1 t/ }  ok
-{ -1 1 / -> -1 1 t/ }  ok
-{ -2 1 / -> -2 1 t/ }  ok
-{ 0 -1 / -> 0 -1 t/ }  ok
-{ 1 -1 / -> 1 -1 t/ }  ok
-{ 2 -1 / -> 2 -1 t/ }  ok
-{ -1 -1 / -> -1 -1 t/ }  ok
-{ -2 -1 / -> -2 -1 t/ }  ok
-{ 2 2 / -> 2 2 t/ }  ok
-{ -1 -1 / -> -1 -1 t/ }  ok
-{ -2 -2 / -> -2 -2 t/ }  ok
-{ 7 3 / -> 7 3 t/ }  ok
-{ 7 -3 / -> 7 -3 t/ }  ok
-{ -7 3 / -> -7 3 t/ }  ok
-{ -7 -3 / -> -7 -3 t/ }  ok
-{ max-int 1 / -> max-int 1 t/ }  ok
-{ min-int 1 / -> min-int 1 t/ }  ok
-{ max-int max-int / -> max-int max-int t/ }  ok
-{ min-int min-int / -> min-int min-int t/ }  ok
+T{ 0 1 / -> 0 1 t/ }T  ok
+T{ 1 1 / -> 1 1 t/ }T  ok
+T{ 2 1 / -> 2 1 t/ }T  ok
+T{ -1 1 / -> -1 1 t/ }T  ok
+T{ -2 1 / -> -2 1 t/ }T  ok
+T{ 0 -1 / -> 0 -1 t/ }T  ok
+T{ 1 -1 / -> 1 -1 t/ }T  ok
+T{ 2 -1 / -> 2 -1 t/ }T  ok
+T{ -1 -1 / -> -1 -1 t/ }T  ok
+T{ -2 -1 / -> -2 -1 t/ }T  ok
+T{ 2 2 / -> 2 2 t/ }T  ok
+T{ -1 -1 / -> -1 -1 t/ }T  ok
+T{ -2 -2 / -> -2 -2 t/ }T  ok
+T{ 7 3 / -> 7 3 t/ }T  ok
+T{ 7 -3 / -> 7 -3 t/ }T  ok
+T{ -7 3 / -> -7 3 t/ }T  ok
+T{ -7 -3 / -> -7 -3 t/ }T  ok
+T{ max-int 1 / -> max-int 1 t/ }T  ok
+T{ min-int 1 / -> min-int 1 t/ }T  ok
+T{ max-int max-int / -> max-int max-int t/ }T  ok
+T{ min-int min-int / -> min-int min-int t/ }T  ok
   ok
-{ 0 1 mod -> 0 1 tmod }  ok
-{ 1 1 mod -> 1 1 tmod }  ok
-{ 2 1 mod -> 2 1 tmod }  ok
-{ -1 1 mod -> -1 1 tmod }  ok
-{ -2 1 mod -> -2 1 tmod }  ok
-{ 0 -1 mod -> 0 -1 tmod }  ok
-{ 1 -1 mod -> 1 -1 tmod }  ok
-{ 2 -1 mod -> 2 -1 tmod }  ok
-{ -1 -1 mod -> -1 -1 tmod }  ok
-{ -2 -1 mod -> -2 -1 tmod }  ok
-{ 2 2 mod -> 2 2 tmod }  ok
-{ -1 -1 mod -> -1 -1 tmod }  ok
-{ -2 -2 mod -> -2 -2 tmod }  ok
-{ 7 3 mod -> 7 3 tmod }  ok
-{ 7 -3 mod -> 7 -3 tmod }  ok
-{ -7 3 mod -> -7 3 tmod }  ok
-{ -7 -3 mod -> -7 -3 tmod }  ok
-{ max-int 1 mod -> max-int 1 tmod }  ok
-{ min-int 1 mod -> min-int 1 tmod }  ok
-{ max-int max-int mod -> max-int max-int tmod }  ok
-{ min-int min-int mod -> min-int min-int tmod }  ok
+T{ 0 1 mod -> 0 1 tmod }T  ok
+T{ 1 1 mod -> 1 1 tmod }T  ok
+T{ 2 1 mod -> 2 1 tmod }T  ok
+T{ -1 1 mod -> -1 1 tmod }T  ok
+T{ -2 1 mod -> -2 1 tmod }T  ok
+T{ 0 -1 mod -> 0 -1 tmod }T  ok
+T{ 1 -1 mod -> 1 -1 tmod }T  ok
+T{ 2 -1 mod -> 2 -1 tmod }T  ok
+T{ -1 -1 mod -> -1 -1 tmod }T  ok
+T{ -2 -1 mod -> -2 -1 tmod }T  ok
+T{ 2 2 mod -> 2 2 tmod }T  ok
+T{ -1 -1 mod -> -1 -1 tmod }T  ok
+T{ -2 -2 mod -> -2 -2 tmod }T  ok
+T{ 7 3 mod -> 7 3 tmod }T  ok
+T{ 7 -3 mod -> 7 -3 tmod }T  ok
+T{ -7 3 mod -> -7 3 tmod }T  ok
+T{ -7 -3 mod -> -7 -3 tmod }T  ok
+T{ max-int 1 mod -> max-int 1 tmod }T  ok
+T{ min-int 1 mod -> min-int 1 tmod }T  ok
+T{ max-int max-int mod -> max-int max-int tmod }T  ok
+T{ min-int min-int mod -> min-int min-int tmod }T  ok
   ok
-{ 0 2 1 */ -> 0 2 1 t*/ }  ok
-{ 1 2 1 */ -> 1 2 1 t*/ }  ok
-{ 2 2 1 */ -> 2 2 1 t*/ }  ok
-{ -1 2 1 */ -> -1 2 1 t*/ }  ok
-{ -2 2 1 */ -> -2 2 1 t*/ }  ok
-{ 0 2 -1 */ -> 0 2 -1 t*/ }  ok
-{ 1 2 -1 */ -> 1 2 -1 t*/ }  ok
-{ 2 2 -1 */ -> 2 2 -1 t*/ }  ok
-{ -1 2 -1 */ -> -1 2 -1 t*/ }  ok
-{ -2 2 -1 */ -> -2 2 -1 t*/ }  ok
-{ 2 2 2 */ -> 2 2 2 t*/ }  ok
-{ -1 2 -1 */ -> -1 2 -1 t*/ }  ok
-{ -2 2 -2 */ -> -2 2 -2 t*/ }  ok
-{ 7 2 3 */ -> 7 2 3 t*/ }  ok
-{ 7 2 -3 */ -> 7 2 -3 t*/ }  ok
-{ -7 2 3 */ -> -7 2 3 t*/ }  ok
-{ -7 2 -3 */ -> -7 2 -3 t*/ }  ok
-{ max-int 2 max-int */ -> max-int 2 max-int t*/ }  ok
-{ min-int 2 min-int */ -> min-int 2 min-int t*/ }  ok
+T{ 0 2 1 */ -> 0 2 1 t*/ }T  ok
+T{ 1 2 1 */ -> 1 2 1 t*/ }T  ok
+T{ 2 2 1 */ -> 2 2 1 t*/ }T  ok
+T{ -1 2 1 */ -> -1 2 1 t*/ }T  ok
+T{ -2 2 1 */ -> -2 2 1 t*/ }T  ok
+T{ 0 2 -1 */ -> 0 2 -1 t*/ }T  ok
+T{ 1 2 -1 */ -> 1 2 -1 t*/ }T  ok
+T{ 2 2 -1 */ -> 2 2 -1 t*/ }T  ok
+T{ -1 2 -1 */ -> -1 2 -1 t*/ }T  ok
+T{ -2 2 -1 */ -> -2 2 -1 t*/ }T  ok
+T{ 2 2 2 */ -> 2 2 2 t*/ }T  ok
+T{ -1 2 -1 */ -> -1 2 -1 t*/ }T  ok
+T{ -2 2 -2 */ -> -2 2 -2 t*/ }T  ok
+T{ 7 2 3 */ -> 7 2 3 t*/ }T  ok
+T{ 7 2 -3 */ -> 7 2 -3 t*/ }T  ok
+T{ -7 2 3 */ -> -7 2 3 t*/ }T  ok
+T{ -7 2 -3 */ -> -7 2 -3 t*/ }T  ok
+T{ max-int 2 max-int */ -> max-int 2 max-int t*/ }T  ok
+T{ min-int 2 min-int */ -> min-int 2 min-int t*/ }T  ok
   ok
-{ 0 2 1 */mod -> 0 2 1 t*/mod }  ok
-{ 1 2 1 */mod -> 1 2 1 t*/mod }  ok
-{ 2 2 1 */mod -> 2 2 1 t*/mod }  ok
-{ -1 2 1 */mod -> -1 2 1 t*/mod }  ok
-{ -2 2 1 */mod -> -2 2 1 t*/mod }  ok
-{ 0 2 -1 */mod -> 0 2 -1 t*/mod }  ok
-{ 1 2 -1 */mod -> 1 2 -1 t*/mod }  ok
-{ 2 2 -1 */mod -> 2 2 -1 t*/mod }  ok
-{ -1 2 -1 */mod -> -1 2 -1 t*/mod }  ok
-{ -2 2 -1 */mod -> -2 2 -1 t*/mod }  ok
-{ 2 2 2 */mod -> 2 2 2 t*/mod }  ok
-{ -1 2 -1 */mod -> -1 2 -1 t*/mod }  ok
-{ -2 2 -2 */mod -> -2 2 -2 t*/mod }  ok
-{ 7 2 3 */mod -> 7 2 3 t*/mod }  ok
-{ 7 2 -3 */mod -> 7 2 -3 t*/mod }  ok
-{ -7 2 3 */mod -> -7 2 3 t*/mod }  ok
-{ -7 2 -3 */mod -> -7 2 -3 t*/mod }  ok
-{ max-int 2 max-int */mod -> max-int 2 max-int t*/mod }  ok
-{ min-int 2 min-int */mod -> min-int 2 min-int t*/mod }  ok
+T{ 0 2 1 */mod -> 0 2 1 t*/mod }T  ok
+T{ 1 2 1 */mod -> 1 2 1 t*/mod }T  ok
+T{ 2 2 1 */mod -> 2 2 1 t*/mod }T  ok
+T{ -1 2 1 */mod -> -1 2 1 t*/mod }T  ok
+T{ -2 2 1 */mod -> -2 2 1 t*/mod }T  ok
+T{ 0 2 -1 */mod -> 0 2 -1 t*/mod }T  ok
+T{ 1 2 -1 */mod -> 1 2 -1 t*/mod }T  ok
+T{ 2 2 -1 */mod -> 2 2 -1 t*/mod }T  ok
+T{ -1 2 -1 */mod -> -1 2 -1 t*/mod }T  ok
+T{ -2 2 -1 */mod -> -2 2 -1 t*/mod }T  ok
+T{ 2 2 2 */mod -> 2 2 2 t*/mod }T  ok
+T{ -1 2 -1 */mod -> -1 2 -1 t*/mod }T  ok
+T{ -2 2 -2 */mod -> -2 2 -2 t*/mod }T  ok
+T{ 7 2 3 */mod -> 7 2 3 t*/mod }T  ok
+T{ 7 2 -3 */mod -> 7 2 -3 t*/mod }T  ok
+T{ -7 2 3 */mod -> -7 2 3 t*/mod }T  ok
+T{ -7 2 -3 */mod -> -7 2 -3 t*/mod }T  ok
+T{ max-int 2 max-int */mod -> max-int 2 max-int t*/mod }T  ok
+T{ min-int 2 min-int */mod -> min-int 2 min-int t*/mod }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing here , @ ! cell+ cells c, c@ c! char+ chars 2@ 2! align aligned +! allot pad unused compile,  ok
@@ -735,51 +738,51 @@ here                        \ to where we started.  ok
 constant 3rda  ok
 constant 2nda  ok
 constant 1sta  ok
-{ 1sta 2nda u< -> <true> }  \ here must grow with allot ...  ok
-{ 1sta 1+ -> 2nda }         \ ... by one address unit  ok
-{ 3rda -> 1sta }            \ and shrink back to the beginning.  ok
+T{ 1sta 2nda u< -> <true> }T  \ here must grow with allot ...  ok
+T{ 1sta 1+ -> 2nda }T         \ ... by one address unit  ok
+T{ 3rda -> 1sta }T            \ and shrink back to the beginning.  ok
 hex  ok
   ok
 here 1 ,  ok
 here 2 ,  ok
 constant 2nd  ok
 constant 1st  ok
-{ 1st 2nd u< -> <true> } \ here must grow with allot ...  ok
-{ 1st cell+ -> 2nd }     \ ... by one cell (test for char+)  ok
-{ 1st 1 cells + -> 2nd }  ok
-{ 1st @ 2nd @ -> 1 2 }  ok
-{ 5 1st ! -> }  ok
-{ 1st @ 2nd @ -> 5 2 }  ok
-{ 6 2nd ! -> }  ok
-{ 1st @ 2nd @ -> 5 6 }  ok
-{ 1st 2@ -> 6 5 }  ok
-{ 2 1 1st 2! -> }  ok
-{ 1st 2@ -> 2 1 }  ok
-{ 1s 1st !  1st @ -> 1s }  \ can store cell-wide value  ok
+T{ 1st 2nd u< -> <true> }T \ here must grow with allot ...  ok
+T{ 1st cell+ -> 2nd }T     \ ... by one cell (test for char+)  ok
+T{ 1st 1 cells + -> 2nd }T  ok
+T{ 1st @ 2nd @ -> 1 2 }T  ok
+T{ 5 1st ! -> }T  ok
+T{ 1st @ 2nd @ -> 5 2 }T  ok
+T{ 6 2nd ! -> }T  ok
+T{ 1st @ 2nd @ -> 5 6 }T  ok
+T{ 1st 2@ -> 6 5 }T  ok
+T{ 2 1 1st 2! -> }T  ok
+T{ 1st 2@ -> 2 1 }T  ok
+T{ 1s 1st !  1st @ -> 1s }T  \ can store cell-wide value  ok
   ok
 here 1 c,  ok
 here 2 c,  ok
 constant 2ndc  ok
 constant 1stc  ok
-{ 1stc 2ndc u< -> <true> } \ here must grow with allot  ok
-{ 1stc char+ -> 2ndc }     \ ... by one char  ok
-{ 1stc 1 chars + -> 2ndc }  ok
-{ 1stc c@ 2ndc c@ -> 1 2 }  ok
-{ 3 1stc c! -> }  ok
-{ 1stc c@ 2ndc c@ -> 3 2 }  ok
-{ 4 2ndc c! -> }  ok
-{ 1stc c@ 2ndc c@ -> 3 4 }  ok
+T{ 1stc 2ndc u< -> <true> }T \ here must grow with allot  ok
+T{ 1stc char+ -> 2ndc }T     \ ... by one char  ok
+T{ 1stc 1 chars + -> 2ndc }T  ok
+T{ 1stc c@ 2ndc c@ -> 1 2 }T  ok
+T{ 3 1stc c! -> }T  ok
+T{ 1stc c@ 2ndc c@ -> 3 2 }T  ok
+T{ 4 2ndc c! -> }T  ok
+T{ 1stc c@ 2ndc c@ -> 3 4 }T  ok
   ok
 align 1 allot here align here 3 cells allot  ok
 constant a-addr  constant ua-addr  ok
-{ ua-addr aligned -> a-addr }  ok
-{ 1 a-addr c!  a-addr c@ -> 1 }  ok
-{ 1234 a-addr  !  a-addr  @ -> 1234 }  ok
-{ 123 456 a-addr 2!  a-addr 2@ -> 123 456 }  ok
-{ 2 a-addr char+ c!  a-addr char+ c@ -> 2 }  ok
-{ 3 a-addr cell+ c!  a-addr cell+ c@ -> 3 }  ok
-{ 1234 a-addr cell+ !  a-addr cell+ @ -> 1234 }  ok
-{ 123 456 a-addr cell+ 2!  a-addr cell+ 2@ -> 123 456 }  ok
+T{ ua-addr aligned -> a-addr }T  ok
+T{ 1 a-addr c!  a-addr c@ -> 1 }T  ok
+T{ 1234 a-addr  !  a-addr  @ -> 1234 }T  ok
+T{ 123 456 a-addr 2!  a-addr 2@ -> 123 456 }T  ok
+T{ 2 a-addr char+ c!  a-addr char+ c@ -> 2 }T  ok
+T{ 3 a-addr cell+ c!  a-addr cell+ c@ -> 3 }T  ok
+T{ 1234 a-addr cell+ !  a-addr cell+ @ -> 1234 }T  ok
+T{ 123 456 a-addr cell+ 2!  a-addr cell+ 2@ -> 123 456 }T  ok
   ok
 : bits ( x -- u )  compiled
    0 swap begin  compiled
@@ -791,117 +794,117 @@ constant a-addr  constant ua-addr  ok
    drop ;  ok
   ok
 ( characters >= 1 au, <= size of cell, >= 8 bits )  ok
-{ 1 chars 1 < -> <false> }  ok
-{ 1 chars 1 cells > -> <false> }  ok
+T{ 1 chars 1 < -> <false> }T  ok
+T{ 1 chars 1 cells > -> <false> }T  ok
 ( TODO how to find number of bits? )  ok
   ok
 ( cells >= 1 au, integral multiple of char size, >= 16 bits )  ok
-{ 1 cells 1 < -> <false> }  ok
-{ 1 cells 1 chars mod -> 0 }  ok
-{ 1s bits 10 < -> <false> }  ok
+T{ 1 cells 1 < -> <false> }T  ok
+T{ 1 cells 1 chars mod -> 0 }T  ok
+T{ 1s bits 10 < -> <false> }T  ok
   ok
-{ 0 1st ! -> }  ok
-{ 1 1st +! -> }  ok
-{ 1st @ -> 1 }  ok
-{ -1 1st +! 1st @ -> 0 }  ok
+T{ 0 1st ! -> }T  ok
+T{ 1 1st +! -> }T  ok
+T{ 1st @ -> 1 }T  ok
+T{ -1 1st +! 1st @ -> 0 }T  ok
   ok
 ( here + unused + buffer size must be total RAM, that is, $7FFF )  ok
-{ pad here - -> FF } \ PAD must have offset of $FF  ok
-{ here unused + 3FF + -> 7FFF }  ok
+T{ pad here - -> FF }T \ PAD must have offset of $FF  ok
+T{ here unused + 3FF + -> 7FFF }T  ok
   ok
 :noname dup + ; constant dup+   ok
-{ : q dup+ compile, ; -> }   ok
-{ : as [ q ] ; -> }   ok
-{ 123 as -> 246 }  ok
+T{ : q dup+ compile, ; -> }T   ok
+T{ : as [ q ] ; -> }T   ok
+T{ 123 as -> 246 }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing char [char] [ ] bl s"  ok
   ok
-{ bl -> 20 }  ok
-{ char X -> 58 }  ok
-{ char HELLO -> 48 }  ok
-{ : gc1 [char] X ; -> }  ok
-{ : gc2 [char] HELLO ; -> }  ok
-{ gc1 -> 58 }  ok
-{ gc2 -> 48 }  ok
-{ : gc3 [ gc1 ] literal ; -> }  ok
-{ gc3 -> 58 }  ok
-{ : gc4 s" XY" ; -> }  ok
-{ gc4 swap drop -> 2 }  ok
-{ gc4 drop dup c@ swap char+ c@ -> 58 59 }  ok
+T{ bl -> 20 }T  ok
+T{ char X -> 58 }T  ok
+T{ char HELLO -> 48 }T  ok
+T{ : gc1 [char] X ; -> }T  ok
+T{ : gc2 [char] HELLO ; -> }T  ok
+T{ gc1 -> 58 }T  ok
+T{ gc2 -> 48 }T  ok
+T{ : gc3 [ gc1 ] literal ; -> }T  ok
+T{ gc3 -> 58 }T  ok
+T{ : gc4 s" XY" ; -> }T  ok
+T{ gc4 swap drop -> 2 }T  ok
+T{ gc4 drop dup c@ swap char+ c@ -> 58 59 }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing ' ['] find execute immediate count literal postpone state  ok
   ok
-{ : gt1 123 ; -> }  ok
-{ ' gt1 execute -> 123 }  ok
-{ : gt2 ['] gt1 ; immediate -> }  ok
-{ gt2 execute -> 123 }  ok
+T{ : gt1 123 ; -> }T  ok
+T{ ' gt1 execute -> 123 }T  ok
+T{ : gt2 ['] gt1 ; immediate -> }T  ok
+T{ gt2 execute -> 123 }T  ok
 here 3 c, char g c, char t c, char 1 c, constant gt1string  ok
 here 3 c, char g c, char t c, char 2 c, constant gt2string  ok
-{ gt1string find -> ' gt1 -1 }  ok
-{ gt2string find -> ' gt2 1 }  ok
+T{ gt1string find -> ' gt1 -1 }T  ok
+T{ gt2string find -> ' gt2 1 }T  ok
 ( TODO how to search for non-existent word? )  ok
-{ : gt3 gt2 literal ; -> }  ok
-{ gt3 -> ' gt1 }  ok
-{ gt1string count -> gt1string char+ 3 }  ok
+T{ : gt3 gt2 literal ; -> }T  ok
+T{ gt3 -> ' gt1 }T  ok
+T{ gt1string count -> gt1string char+ 3 }T  ok
   ok
-{ : gt4 postpone gt1 ; immediate -> }  ok
-{ : gt5 gt4 ; -> }  ok
-{ gt5 -> 123 }  ok
-{ : gt6 345 ; immediate -> }  ok
-{ : gt7 postpone gt6 ; -> }  ok
-{ gt7 -> 345 }  ok
+T{ : gt4 postpone gt1 ; immediate -> }T  ok
+T{ : gt5 gt4 ; -> }T  ok
+T{ gt5 -> 123 }T  ok
+T{ : gt6 345 ; immediate -> }T  ok
+T{ : gt7 postpone gt6 ; -> }T  ok
+T{ gt7 -> 345 }T  ok
   ok
-{ : gt8 state @ ; immediate -> }  ok
-{ gt8 -> 0 }  ok
-{ : gt9 gt8 literal ; -> }  ok
-{ gt9 0= -> <false> }  ok
+T{ : gt8 state @ ; immediate -> }T  ok
+T{ gt8 -> 0 }T  ok
+T{ : gt9 gt8 literal ; -> }T  ok
+T{ gt9 0= -> <false> }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing if else then begin while repeat until recurse  ok
   ok
-{ : gi1 if 123 then ; -> }  ok
-{ : gi2 if 123 else 234 then ; -> }  ok
-{ 0 gi1 -> }  ok
-{ 1 gi1 -> 123 }  ok
-{ -1 gi1 -> 123 }  ok
-{ 0 gi2 -> 234 }  ok
-{ 1 gi2 -> 123 }  ok
-{ -1 gi1 -> 123 }  ok
+T{ : gi1 if 123 then ; -> }T  ok
+T{ : gi2 if 123 else 234 then ; -> }T  ok
+T{ 0 gi1 -> }T  ok
+T{ 1 gi1 -> 123 }T  ok
+T{ -1 gi1 -> 123 }T  ok
+T{ 0 gi2 -> 234 }T  ok
+T{ 1 gi2 -> 123 }T  ok
+T{ -1 gi1 -> 123 }T  ok
   ok
-{ : gi3 begin dup 5 < while dup 1+ repeat ; -> }  ok
-{ 0 gi3 -> 0 1 2 3 4 5 }  ok
-{ 4 gi3 -> 4 5 }  ok
-{ 5 gi3 -> 5 }  ok
-{ 6 gi3 -> 6 }  ok
+T{ : gi3 begin dup 5 < while dup 1+ repeat ; -> }T  ok
+T{ 0 gi3 -> 0 1 2 3 4 5 }T  ok
+T{ 4 gi3 -> 4 5 }T  ok
+T{ 5 gi3 -> 5 }T  ok
+T{ 6 gi3 -> 6 }T  ok
   ok
-{ : gi4 begin dup 1+ dup 5 > until ; -> }  ok
-{ 3 gi4 -> 3 4 5 6 }  ok
-{ 5 gi4 -> 5 6 }  ok
-{ 6 gi4 -> 6 7 }  ok
+T{ : gi4 begin dup 1+ dup 5 > until ; -> }T  ok
+T{ 3 gi4 -> 3 4 5 6 }T  ok
+T{ 5 gi4 -> 5 6 }T  ok
+T{ 6 gi4 -> 6 7 }T  ok
   ok
-{ : gi5 begin dup 2 > while dup 5 < while dup 1+ repeat 123 else 345 then ; -> }  ok
-{ 1 gi5 -> 1 345 }  ok
-{ 2 gi5 -> 2 345 }  ok
-{ 3 gi5 -> 3 4 5 123 }  ok
-{ 4 gi5 -> 4 5 123 }  ok
-{ 5 gi5 -> 5 123 }  ok
+T{ : gi5 begin dup 2 > while dup 5 < while dup 1+ repeat 123 else 345 then ; -> }T  ok
+T{ 1 gi5 -> 1 345 }T  ok
+T{ 2 gi5 -> 2 345 }T  ok
+T{ 3 gi5 -> 3 4 5 123 }T  ok
+T{ 4 gi5 -> 4 5 123 }T  ok
+T{ 5 gi5 -> 5 123 }T  ok
   ok
-{ : gi6 ( n -- 0,1,..n ) dup if dup >r 1- recurse r> then ; -> }  ok
-{ 0 gi6 -> 0 }  ok
-{ 1 gi6 -> 0 1 }  ok
-{ 2 gi6 -> 0 1 2 }  ok
-{ 3 gi6 -> 0 1 2 3 }  ok
-{ 4 gi6 -> 0 1 2 3 4 }  ok
+T{ : gi6 ( n -- 0,1,..n ) dup if dup >r 1- recurse r> then ; -> }T  ok
+T{ 0 gi6 -> 0 }T  ok
+T{ 1 gi6 -> 0 1 }T  ok
+T{ 2 gi6 -> 0 1 2 }T  ok
+T{ 3 gi6 -> 0 1 2 3 }T  ok
+T{ 4 gi6 -> 0 1 2 3 4 }T  ok
   ok
 decimal  ok
-{ :noname ( n -- 0, 1, .., n )   compiled
+T{ :noname ( n -- 0, 1, .., n )   compiled
      dup if dup >r 1- recurse r> then   compiled
    ;   ok
-   constant rn1 -> }  ok
-{ 0 rn1 execute -> 0 }  ok
-{ 4 rn1 execute -> 0 1 2 3 4 }  ok
+   constant rn1 -> }T  ok
+T{ 0 rn1 execute -> 0 }T  ok
+T{ 4 rn1 execute -> 0 1 2 3 4 }T  ok
   ok
 :noname ( n -- n1 )  compiled
    1- dup  compiled
@@ -913,10 +916,10 @@ decimal  ok
    endcase  compiled
 ; constant rn2  ok
   ok
-{  1 rn2 execute -> 0 }  ok
-{  2 rn2 execute -> 11 0 }  ok
-{  4 rn2 execute -> 33 22 11 0 }  ok
-{ 25 rn2 execute -> 33 22 11 0 }  ok
+T{  1 rn2 execute -> 0 }T  ok
+T{  2 rn2 execute -> 11 0 }T  ok
+T{  4 rn2 execute -> 33 22 11 0 }T  ok
+T{ 25 rn2 execute -> 33 22 11 0 }T  ok
 hex  ok
   ok
 \ ------------------------------------------------------------------------  ok
@@ -934,14 +937,14 @@ testing case of endof endcase  ok
    endcase  compiled
 ;  ok
   ok
-{ 1 cs1 -> 111 }  ok
-{ 2 cs1 -> 222 }  ok
-{ 3 cs1 -> 333 }  ok
-{ 4 cs1 -> 444 }  ok
-{ 5 cs1 -> 555 }  ok
-{ 6 cs1 -> 666 }  ok
-{ 7 cs1 -> 777 }  ok
-{ 8 cs1 -> 999 } \ default  ok
+T{ 1 cs1 -> 111 }T  ok
+T{ 2 cs1 -> 222 }T  ok
+T{ 3 cs1 -> 333 }T  ok
+T{ 4 cs1 -> 444 }T  ok
+T{ 5 cs1 -> 555 }T  ok
+T{ 6 cs1 -> 666 }T  ok
+T{ 7 cs1 -> 777 }T  ok
+T{ 8 cs1 -> 999 }T \ default  ok
   ok
 : cs2 >r case  compiled
   compiled
@@ -957,75 +960,75 @@ testing case of endof endcase  ok
      >r 299 r>  compiled
    endcase r> drop ;  ok
   ok
-{ -1 1 cs2 ->  100 }  ok
-{ -1 2 cs2 ->  200 }  ok
-{ -1 3 cs2 -> -300 }  ok
-{ -2 1 cs2 ->  -99 }  ok
-{ -2 2 cs2 -> -199 }  ok
-{  0 2 cs2 ->  299 }  ok
+T{ -1 1 cs2 ->  100 }T  ok
+T{ -1 2 cs2 ->  200 }T  ok
+T{ -1 3 cs2 -> -300 }T  ok
+T{ -2 1 cs2 ->  -99 }T  ok
+T{ -2 2 cs2 -> -199 }T  ok
+T{  0 2 cs2 ->  299 }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing do loop +loop i j unloop leave exit ?do  ok
   ok
-{ : gd1 do i loop ; -> }  ok
-{ 4 1 gd1 -> 1 2 3 }  ok
-{ 2 -1 gd1 -> -1 0 1 }  ok
-{ mid-uint+1 mid-uint gd1 -> mid-uint }  ok
+T{ : gd1 do i loop ; -> }T  ok
+T{ 4 1 gd1 -> 1 2 3 }T  ok
+T{ 2 -1 gd1 -> -1 0 1 }T  ok
+T{ mid-uint+1 mid-uint gd1 -> mid-uint }T  ok
   ok
-{ : gd2 do i -1 +loop ; -> }  ok
-{ 1 4 gd2 -> 4 3 2 1 }  ok
-{ -1 2 gd2 -> 2 1 0 -1 }  ok
-{ mid-uint mid-uint+1 gd2 -> mid-uint+1 mid-uint }  ok
+T{ : gd2 do i -1 +loop ; -> }T  ok
+T{ 1 4 gd2 -> 4 3 2 1 }T  ok
+T{ -1 2 gd2 -> 2 1 0 -1 }T  ok
+T{ mid-uint mid-uint+1 gd2 -> mid-uint+1 mid-uint }T  ok
   ok
-{ : gd3 do 1 0 do j loop loop ; -> }  ok
-{ 4 1 gd3 -> 1 2 3 }  ok
-{ 2 -1 gd3 -> -1 0 1 }  ok
-{ mid-uint+1 mid-uint gd3 -> mid-uint }  ok
+T{ : gd3 do 1 0 do j loop loop ; -> }T  ok
+T{ 4 1 gd3 -> 1 2 3 }T  ok
+T{ 2 -1 gd3 -> -1 0 1 }T  ok
+T{ mid-uint+1 mid-uint gd3 -> mid-uint }T  ok
   ok
-{ : gd4 do 1 0 do j loop -1 +loop ; -> }  ok
-{ 1 4 gd4 -> 4 3 2 1 }  ok
-{ -1 2 gd4 -> 2 1 0 -1 }  ok
-{ mid-uint mid-uint+1 gd4 -> mid-uint+1 mid-uint }  ok
+T{ : gd4 do 1 0 do j loop -1 +loop ; -> }T  ok
+T{ 1 4 gd4 -> 4 3 2 1 }T  ok
+T{ -1 2 gd4 -> 2 1 0 -1 }T  ok
+T{ mid-uint mid-uint+1 gd4 -> mid-uint+1 mid-uint }T  ok
   ok
-{ : gd5 123 swap 0 do i 4 > if drop 234 leave then loop ; -> }  ok
-{ 1 gd5 -> 123 }  ok
-{ 5 gd5 -> 123 }  ok
-{ 6 gd5 -> 234 }  ok
+T{ : gd5 123 swap 0 do i 4 > if drop 234 leave then loop ; -> }T  ok
+T{ 1 gd5 -> 123 }T  ok
+T{ 5 gd5 -> 123 }T  ok
+T{ 6 gd5 -> 234 }T  ok
   ok
-{ : gd6  ( pat: {0 0},{0 0}{1 0}{1 1},{0 0}{1 0}{1 1}{2 0}{2 1}{2 2} )  compiled
+T{ : gd6  ( pat: T{0 0}T,T{0 0}TT{1 0}TT{1 1}T,T{0 0}TT{1 0}TT{1 1}TT{2 0}TT{2 1}TT{2 2}T )  compiled
    0 swap 0 do  compiled
       i 1+ 0 do i j + 3 = if i unloop i unloop exit then 1+ loop  compiled
-    loop ; -> }  ok
-{ 1 gd6 -> 1 }  ok
-{ 2 gd6 -> 3 }  ok
-{ 3 gd6 -> 4 1 2 }  ok
+    loop ; -> }T  ok
+T{ 1 gd6 -> 1 }T  ok
+T{ 2 gd6 -> 3 }T  ok
+T{ 3 gd6 -> 4 1 2 }T  ok
   ok
 : qd ?do i loop ;   ok
-{   789   789 qd -> }   ok
-{ -9876 -9876 qd -> }   ok
-{     5     0 qd -> 0 1 2 3 4 }  ok
+T{   789   789 qd -> }T   ok
+T{ -9876 -9876 qd -> }T   ok
+T{     5     0 qd -> 0 1 2 3 4 }T  ok
   ok
 : qd1 ?do i 10 +loop ;   ok
-{ 50 1 qd1 -> 1 11 21 31 41 }   ok
-{ 50 0 qd1 -> 0 10 20 30 40 }  ok
+T{ 50 1 qd1 -> 1 11 21 31 41 }T   ok
+T{ 50 0 qd1 -> 0 10 20 30 40 }T  ok
   ok
 : qd2 ?do i 3 > if leave else i then loop ;   ok
-{ 5 -1 qd2 -> -1 0 1 2 3 }  ok
+T{ 5 -1 qd2 -> -1 0 1 2 3 }T  ok
   ok
 : qd3 ?do i 1 +loop ;   ok
-{ 4  4 qd3 -> }   ok
-{ 4  1 qd3 ->  1 2 3 }  ok
-{ 2 -1 qd3 -> -1 0 1 }  ok
+T{ 4  4 qd3 -> }T   ok
+T{ 4  1 qd3 ->  1 2 3 }T  ok
+T{ 2 -1 qd3 -> -1 0 1 }T  ok
   ok
 : qd4 ?do i -1 +loop ;   ok
-{  4 4 qd4 -> }  ok
-{  1 4 qd4 -> 4 3 2  1 }   ok
-{ -1 2 qd4 -> 2 1 0 -1 }  ok
+T{  4 4 qd4 -> }T  ok
+T{  1 4 qd4 -> 4 3 2  1 }T   ok
+T{ -1 2 qd4 -> 2 1 0 -1 }T  ok
   ok
 : qd5 ?do i -10 +loop ;   ok
-{   1 50 qd5 -> 50 40 30 20 10   }   ok
-{   0 50 qd5 -> 50 40 30 20 10 0 }   ok
-{ -25 10 qd5 -> 10 0 -10 -20     }  ok
+T{   1 50 qd5 -> 50 40 30 20 10   }T   ok
+T{   0 50 qd5 -> 50 40 30 20 10 0 }T   ok
+T{ -25 10 qd5 -> 10 0 -10 -20     }T  ok
   ok
 variable qditerations   ok
 variable qdincrement  ok
@@ -1040,80 +1043,80 @@ variable qdincrement  ok
    +loop qditerations @   compiled
 ;  ok
   ok
-{  4  4 -1 qd6 ->                   0  }   ok
-{  1  4 -1 qd6 ->  4  3  2  1       4  }   ok
-{  4  1 -1 qd6 ->  1  0 -1 -2 -3 -4 6  }   ok
-{  4  1  0 qd6 ->  1  1  1  1  1  1 6  }   ok
-{  0  0  0 qd6 ->                   0  }   ok
-{  1  4  0 qd6 ->  4  4  4  4  4  4 6  }   ok
-{  1  4  1 qd6 ->  4  5  6  7  8  9 6  }   ok
-{  4  1  1 qd6 ->  1  2  3          3  }   ok
-{  4  4  1 qd6 ->                   0  }   ok
-{  2 -1 -1 qd6 -> -1 -2 -3 -4 -5 -6 6  }   ok
-{ -1  2 -1 qd6 ->  2  1  0 -1       4  }   ok
-{  2 -1  0 qd6 -> -1 -1 -1 -1 -1 -1 6  }   ok
-{ -1  2  0 qd6 ->  2  2  2  2  2  2 6  }   ok
-{ -1  2  1 qd6 ->  2  3  4  5  6  7 6  }   ok
-{  2 -1  1 qd6 -> -1  0  1          3  }  ok
+T{  4  4 -1 qd6 ->                   0  }T   ok
+T{  1  4 -1 qd6 ->  4  3  2  1       4  }T   ok
+T{  4  1 -1 qd6 ->  1  0 -1 -2 -3 -4 6  }T   ok
+T{  4  1  0 qd6 ->  1  1  1  1  1  1 6  }T   ok
+T{  0  0  0 qd6 ->                   0  }T   ok
+T{  1  4  0 qd6 ->  4  4  4  4  4  4 6  }T   ok
+T{  1  4  1 qd6 ->  4  5  6  7  8  9 6  }T   ok
+T{  4  1  1 qd6 ->  1  2  3          3  }T   ok
+T{  4  4  1 qd6 ->                   0  }T   ok
+T{  2 -1 -1 qd6 -> -1 -2 -3 -4 -5 -6 6  }T   ok
+T{ -1  2 -1 qd6 ->  2  1  0 -1       4  }T   ok
+T{  2 -1  0 qd6 -> -1 -1 -1 -1 -1 -1 6  }T   ok
+T{ -1  2  0 qd6 ->  2  2  2  2  2  2 6  }T   ok
+T{ -1  2  1 qd6 ->  2  3  4  5  6  7 6  }T   ok
+T{  2 -1  1 qd6 -> -1  0  1          3  }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing defining words: : ; constant variable create does> >body value to  ok
   ok
-{ 123 constant x123 -> }  ok
-{ x123 -> 123 }  ok
-{ : equ constant ; -> }  ok
-{ x123 equ y123 -> }  ok
-{ y123 -> 123 }  ok
+T{ 123 constant x123 -> }T  ok
+T{ x123 -> 123 }T  ok
+T{ : equ constant ; -> }T  ok
+T{ x123 equ y123 -> }T  ok
+T{ y123 -> 123 }T  ok
   ok
-{ variable v1 -> }  ok
-{ 123 v1 ! -> }  ok
-{ v1 @ -> 123 }  ok
+T{ variable v1 -> }T  ok
+T{ 123 v1 ! -> }T  ok
+T{ v1 @ -> 123 }T  ok
   ok
-{ : nop : postpone ; ; -> }  ok
-{ nop nop1 nop nop2 -> }  ok
-{ nop1 -> }  ok
-{ nop2 -> }  ok
+T{ : nop : postpone ; ; -> }T  ok
+T{ nop nop1 nop nop2 -> }T  ok
+T{ nop1 -> }T  ok
+T{ nop2 -> }T  ok
   ok
-{ : does1 does> @ 1 + ; -> }  ok
-{ : does2 does> @ 2 + ; -> }  ok
-{ create cr1 -> }  ok
-{ cr1 -> here }  ok
-{ ' cr1 >body -> here }  ok
-{ 1 , -> }  ok
-{ cr1 @ -> 1 }  ok
-{ does1 -> }  ok
-{ cr1 -> 2 }  ok
-{ does2 -> }  ok
-{ cr1 -> 3 }  ok
+T{ : does1 does> @ 1 + ; -> }T  ok
+T{ : does2 does> @ 2 + ; -> }T  ok
+T{ create cr1 -> }T  ok
+T{ cr1 -> here }T  ok
+T{ ' cr1 >body -> here }T  ok
+T{ 1 , -> }T  ok
+T{ cr1 @ -> 1 }T  ok
+T{ does1 -> }T  ok
+T{ cr1 -> 2 }T  ok
+T{ does2 -> }T  ok
+T{ cr1 -> 3 }T  ok
   ok
 \ The following test is not part of the original suite, but belongs  ok
 \ to the "weird:" test following it. See discussion at  ok
 \ https://github.com/scotws/TaliForth2/issues/61  ok
-{ : odd: create does> 1 + ; -> }  ok
-{ odd: o1 -> }  ok
-{ ' o1 >body -> here }  ok
-{ o1 -> here 1 + }  ok
+T{ : odd: create does> 1 + ; -> }T  ok
+T{ odd: o1 -> }T  ok
+T{ ' o1 >body -> here }T  ok
+T{ o1 -> here 1 + }T  ok
   ok
-{ : weird: create does> 1 + does> 2 + ; -> }  ok
-{ weird: w1 -> }  ok
-{ ' w1 >body -> here }  ok
-{ w1 -> here 1 + }  ok
-{ w1 -> here 2 + }  ok
+T{ : weird: create does> 1 + does> 2 + ; -> }T  ok
+T{ weird: w1 -> }T  ok
+T{ ' w1 >body -> here }T  ok
+T{ w1 -> here 1 + }T  ok
+T{ w1 -> here 2 + }T  ok
   ok
-{  111 value v1 -> }  ok
-{ -999 value v2 -> }  ok
-{ v1 ->  111 }  ok
-{ v2 -> -999 }   ok
-{ 222 to v1 -> }   ok
-{ v1 -> 222 }  ok
-{ : vd1 v1 ; -> }  ok
-{ vd1 -> 222 }  ok
+T{  111 value v1 -> }T  ok
+T{ -999 value v2 -> }T  ok
+T{ v1 ->  111 }T  ok
+T{ v2 -> -999 }T   ok
+T{ 222 to v1 -> }T   ok
+T{ v1 -> 222 }T  ok
+T{ : vd1 v1 ; -> }T  ok
+T{ vd1 -> 222 }T  ok
   ok
-{ : vd2 to v2 ; -> }  ok
-{ v2 -> -999 }  ok
-{ -333 vd2 -> }  ok
-{ v2 -> -333 }  ok
-{ v1 ->  222 }  ok
+T{ : vd2 to v2 ; -> }T  ok
+T{ v2 -> -999 }T  ok
+T{ -333 vd2 -> }T  ok
+T{ v2 -> -333 }T  ok
+T{ v1 ->  222 }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing evaluate  ok
@@ -1123,22 +1126,22 @@ testing evaluate  ok
 : ge3 s" : ge4 345 ;" ;  ok
 : ge5 evaluate ; immediate  ok
   ok
-{ ge1 evaluate -> 123 } \ test evaluate in interp. state  ok
-{ ge2 evaluate -> 124 }  ok
-{ ge3 evaluate -> }  ok
-{ ge4 -> 345 }  ok
+T{ ge1 evaluate -> 123 }T \ test evaluate in interp. state  ok
+T{ ge2 evaluate -> 124 }T  ok
+T{ ge3 evaluate -> }T  ok
+T{ ge4 -> 345 }T  ok
   ok
-{ : ge6 ge1 ge5 ; -> }  \ test evaluate in compile state  ok
-{ ge6 -> 123 }  ok
-{ : ge7 ge2 ge5 ; -> }  ok
-{ ge7 -> 124 }  ok
+T{ : ge6 ge1 ge5 ; -> }T  \ test evaluate in compile state  ok
+T{ ge6 -> 123 }T  ok
+T{ : ge7 ge2 ge5 ; -> }T  ok
+T{ ge7 -> 124 }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing source >in word  ok
   ok
 : gs1 s" source" 2dup evaluate   compiled
        >r swap >r = r> r> = ;  ok
-{ gs1 -> <true> <true> }  ok
+T{ gs1 -> <true> <true> }T  ok
   ok
 variable scans  ok
 : rescan?  -1 scans +!  compiled
@@ -1146,22 +1149,22 @@ variable scans  ok
       0 >in !  compiled
    then ;  ok
   ok
-{ 2 scans !    ok
+T{ 2 scans !    ok
 345 rescan?    ok
--> 345 345 }  ok
+-> 345 345 }T  ok
   ok
 : gs2  5 scans ! s" 123 rescan?" evaluate ;  ok
-{ gs2 -> 123 123 123 123 123 }  ok
+T{ gs2 -> 123 123 123 123 123 }T  ok
   ok
 : gs3 word count swap c@ ;  ok
-{ bl gs3 hello -> 5 char h }  ok
-{ char " gs3 goodbye" -> 7 char g }  ok
-{ bl gs3   ok
-drop -> 0 } \ blank line return zero-length string  ok
+T{ bl gs3 hello -> 5 char h }T  ok
+T{ char " gs3 goodbye" -> 7 char g }T  ok
+T{ bl gs3   ok
+drop -> 0 }T \ blank line return zero-length string  ok
   ok
 : gs4 source >in ! drop ;  ok
-{ gs4 123 456   ok
--> }  ok
+T{ gs4 123 456   ok
+-> }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing <# # #s #> hold sign base >number hex decimal  ok
@@ -1184,16 +1187,16 @@ hex  ok
    then ;  ok
   ok
 : gp1  <# 41 hold 42 hold 0 0 #> s" BA" s= ;  ok
-{ gp1 -> <true> }  ok
+T{ gp1 -> <true> }T  ok
   ok
 : gp2  <# -1 sign 0 sign -1 sign 0 0 #> s" --" s= ;  ok
-{ gp2 -> <true> }  ok
+T{ gp2 -> <true> }T  ok
   ok
 : gp3  <# 1 0 # # #> s" 01" s= ;  ok
-{ gp3 -> <true> }  ok
+T{ gp3 -> <true> }T  ok
   ok
 : gp4  <# 1 0 #s #> s" 1" s= ;  ok
-{ gp4 -> <true> }  ok
+T{ gp4 -> <true> }T  ok
   ok
 24 constant max-base   \ base 2 .. 36  ok
 max-base .( max-base post def: ) . cr  ( TODO TEST ) max-base post def: 24 
@@ -1215,7 +1218,7 @@ count-bits 2* constant #bits-ud  \ number of bits in ud  ok
       i 0 <# #s #> s" 10" s= and  compiled
    loop  compiled
    swap base ! ;  ok
-{ gp5 -> <true> }  ok
+T{ gp5 -> <true> }T  ok
   ok
 : gp6  compiled
    base @ >r  2 base !  compiled
@@ -1226,7 +1229,7 @@ count-bits 2* constant #bits-ud  \ number of bits in ud  ok
       over c@ [char] 1 = and  \ all ones  compiled
       >r char+ r>  compiled
    loop swap drop ;  ok
-{ gp6 -> <true> }  ok
+T{ gp6 -> <true> }T  ok
   ok
   ok
 \ Split up long testing word from ANS Forth in two parts  ok
@@ -1245,7 +1248,7 @@ count-bits 2* constant #bits-ud  \ number of bits in ud  ok
      compiled
    r> base ! ;  ok
   ok
-{ gp7-1 -> <true> }  ok
+T{ gp7-1 -> <true> }T  ok
   ok
 \ Test the numbers 16 to max-base in max-base  ok
 : gp7-2  compiled
@@ -1262,7 +1265,7 @@ count-bits 2* constant #bits-ud  \ number of bits in ud  ok
   compiled
    r> base ! ;  ok
   ok
-{ gp7-2 -> <true> } A
+T{ gp7-2 -> <true> }T A
 <1> -1 
 B
 <1> -1 
@@ -1322,21 +1325,21 @@ create gn-buf 0 c,  ok
 : gn-consumed gn-buf char+ 0 ;  ok
 : gn'  [char] ' word char+ c@ gn-buf c!  gn-string ;  ok
   ok
-{ 0 0 gn' 0' >number -> 0 0 gn-consumed }  ok
-{ 0 0 gn' 1' >number -> 1 0 gn-consumed }  ok
-{ 1 0 gn' 1' >number -> base @ 1+ 0 gn-consumed }  ok
-{ 0 0 gn' -' >number -> 0 0 gn-string } \ should fail to convert these  ok
-{ 0 0 gn' +' >number -> 0 0 gn-string }  ok
-{ 0 0 gn' .' >number -> 0 0 gn-string }  ok
+T{ 0 0 gn' 0' >number -> 0 0 gn-consumed }T  ok
+T{ 0 0 gn' 1' >number -> 1 0 gn-consumed }T  ok
+T{ 1 0 gn' 1' >number -> base @ 1+ 0 gn-consumed }T  ok
+T{ 0 0 gn' -' >number -> 0 0 gn-string }T \ should fail to convert these  ok
+T{ 0 0 gn' +' >number -> 0 0 gn-string }T  ok
+T{ 0 0 gn' .' >number -> 0 0 gn-string }T  ok
   ok
 : >number-based  base @ >r base ! >number r> base ! ;  ok
   ok
-{ 0 0 gn' 2' 10 >number-based -> 2 0 gn-consumed }  ok
-{ 0 0 gn' 2'  2 >number-based -> 0 0 gn-string }  ok
-{ 0 0 gn' f' 10 >number-based -> f 0 gn-consumed }  ok
-{ 0 0 gn' g' 10 >number-based -> 0 0 gn-string }  ok
-{ 0 0 gn' g' max-base >number-based -> 10 0 gn-consumed }  ok
-{ 0 0 gn' z' max-base >number-based -> 23 0 gn-consumed }  ok
+T{ 0 0 gn' 2' 10 >number-based -> 2 0 gn-consumed }T  ok
+T{ 0 0 gn' 2'  2 >number-based -> 0 0 gn-string }T  ok
+T{ 0 0 gn' f' 10 >number-based -> f 0 gn-consumed }T  ok
+T{ 0 0 gn' g' 10 >number-based -> 0 0 gn-string }T  ok
+T{ 0 0 gn' g' max-base >number-based -> 10 0 gn-consumed }T  ok
+T{ 0 0 gn' z' max-base >number-based -> 23 0 gn-consumed }T  ok
   ok
 \ ud should equal ud' and len should be zero.  ok
 : gn1  ( ud base -- ud' len )   compiled
@@ -1345,61 +1348,61 @@ create gn-buf 0 c,  ok
    0 0 2swap >number swap drop  \ return length only  compiled
    r> base ! ;  ok
   ok
-{ 0 0 2 gn1 -> 0 0 0 }  ok
-{ max-uint 0 2 gn1 -> max-uint 0 0 }  ok
-{ max-uint dup 2 gn1 -> max-uint dup 0 }  ok
+T{ 0 0 2 gn1 -> 0 0 0 }T  ok
+T{ max-uint 0 2 gn1 -> max-uint 0 0 }T  ok
+T{ max-uint dup 2 gn1 -> max-uint dup 0 }T  ok
   ok
-{ 0 0 max-base gn1 -> 0 0 0 }  ok
-{ max-uint 0 max-base gn1 -> max-uint 0 0 }  ok
-{ max-uint dup max-base gn1 -> max-uint dup 0 }  ok
+T{ 0 0 max-base gn1 -> 0 0 0 }T  ok
+T{ max-uint 0 max-base gn1 -> max-uint 0 0 }T  ok
+T{ max-uint dup max-base gn1 -> max-uint dup 0 }T  ok
   ok
 : gn2 ( -- 16 10 )  compiled
    base @ >r  hex base @  decimal base @  r> base ! ;  ok
   ok
-{ gn2 -> 10 a }  ok
+T{ gn2 -> 10 a }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing action-of defer defer! defer@ is  ok
   ok
-{ defer defer1 -> }  ok
-{ : action-defer1 action-of defer1 ; -> }  ok
-{ ' * ' defer1 defer! ->   }  ok
-{          2 3 defer1 -> 6 }  ok
-{ action-of defer1 -> ' * }   ok
-{    action-defer1 -> ' * }  ok
+T{ defer defer1 -> }T  ok
+T{ : action-defer1 action-of defer1 ; -> }T  ok
+T{ ' * ' defer1 defer! ->   }T  ok
+T{          2 3 defer1 -> 6 }T  ok
+T{ action-of defer1 -> ' * }T   ok
+T{    action-defer1 -> ' * }T  ok
   ok
-{ ' + is defer1 ->   }  ok
-{    1 2 defer1 -> 3 }   ok
-{ action-of defer1 -> ' + }  ok
-{    action-defer1 -> ' + }  ok
+T{ ' + is defer1 ->   }T  ok
+T{    1 2 defer1 -> 3 }T   ok
+T{ action-of defer1 -> ' + }T  ok
+T{    action-defer1 -> ' + }T  ok
   ok
-{ defer defer2 ->   }   ok
-{ ' * ' defer2 defer! -> }  ok
-{   2 3 defer2 -> 6 }  ok
-{ ' + is defer2 ->   }  ok
-{    1 2 defer2 -> 3 }  ok
+T{ defer defer2 ->   }T   ok
+T{ ' * ' defer2 defer! -> }T  ok
+T{   2 3 defer2 -> 6 }T  ok
+T{ ' + is defer2 ->   }T  ok
+T{    1 2 defer2 -> 3 }T  ok
   ok
-{ defer defer3 -> }  ok
-{ ' * ' defer3 defer! -> }  ok
-{ 2 3 defer3 -> 6 }  ok
-{ ' + ' defer3 defer! -> }  ok
-{ 1 2 defer3 -> 3 }  ok
+T{ defer defer3 -> }T  ok
+T{ ' * ' defer3 defer! -> }T  ok
+T{ 2 3 defer3 -> 6 }T  ok
+T{ ' + ' defer3 defer! -> }T  ok
+T{ 1 2 defer3 -> 3 }T  ok
   ok
-{ defer defer4 -> }  ok
-{ ' * ' defer4 defer! -> }  ok
-{ 2 3 defer4 -> 6 }  ok
-{ ' defer4 defer@ -> ' * }  ok
+T{ defer defer4 -> }T  ok
+T{ ' * ' defer4 defer! -> }T  ok
+T{ 2 3 defer4 -> 6 }T  ok
+T{ ' defer4 defer@ -> ' * }T  ok
   ok
-{ ' + is defer4 -> }   ok
-{ 1 2 defer4 -> 3 }   ok
-{ ' defer4 defer@ -> ' + }  ok
+T{ ' + is defer4 -> }T   ok
+T{ 1 2 defer4 -> 3 }T   ok
+T{ ' defer4 defer@ -> ' + }T  ok
   ok
-{ defer defer5 -> }  ok
-{ : is-defer5 is defer5 ; -> }  ok
-{ ' * is defer5 -> }  ok
-{ 2 3 defer5 -> 6 }  ok
-{ ' + is-defer5 -> }   ok
-{ 1 2 defer5 -> 3 }  ok
+T{ defer defer5 -> }T  ok
+T{ : is-defer5 is defer5 ; -> }T  ok
+T{ ' * is defer5 -> }T  ok
+T{ 2 3 defer5 -> 6 }T  ok
+T{ ' + is-defer5 -> }T   ok
+T{ 1 2 defer5 -> 3 }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing fill move  ok
@@ -1408,45 +1411,45 @@ create fbuf 00 c, 00 c, 00 c,  ok
 create sbuf 12 c, 34 c, 56 c,  ok
 : seebuf fbuf c@  fbuf char+ c@  fbuf char+ char+ c@ ;  ok
   ok
-{ fbuf 0 20 fill -> }  ok
-{ seebuf -> 00 00 00 }  ok
+T{ fbuf 0 20 fill -> }T  ok
+T{ seebuf -> 00 00 00 }T  ok
   ok
-{ fbuf 1 20 fill -> }  ok
-{ seebuf -> 20 00 00 }  ok
+T{ fbuf 1 20 fill -> }T  ok
+T{ seebuf -> 20 00 00 }T  ok
   ok
-{ fbuf 3 20 fill -> }  ok
-{ seebuf -> 20 20 20 }  ok
+T{ fbuf 3 20 fill -> }T  ok
+T{ seebuf -> 20 20 20 }T  ok
   ok
-{ fbuf fbuf 3 chars move -> }  \ bizarre special case  ok
-{ seebuf -> 20 20 20 }  ok
+T{ fbuf fbuf 3 chars move -> }T  \ bizarre special case  ok
+T{ seebuf -> 20 20 20 }T  ok
   ok
-{ sbuf fbuf 0 chars move -> }  ok
-{ seebuf -> 20 20 20 }  ok
+T{ sbuf fbuf 0 chars move -> }T  ok
+T{ seebuf -> 20 20 20 }T  ok
   ok
-{ sbuf fbuf 1 chars move -> }  ok
-{ seebuf -> 12 20 20 }  ok
+T{ sbuf fbuf 1 chars move -> }T  ok
+T{ seebuf -> 12 20 20 }T  ok
   ok
-{ sbuf fbuf 3 chars move -> }  ok
-{ seebuf -> 12 34 56 }  ok
+T{ sbuf fbuf 3 chars move -> }T  ok
+T{ seebuf -> 12 34 56 }T  ok
   ok
-{ fbuf fbuf char+ 2 chars move -> }  ok
-{ seebuf -> 12 12 34 }  ok
+T{ fbuf fbuf char+ 2 chars move -> }T  ok
+T{ seebuf -> 12 12 34 }T  ok
   ok
-{ fbuf char+ fbuf 2 chars move -> }  ok
-{ seebuf -> 12 34 34 }  ok
+T{ fbuf char+ fbuf 2 chars move -> }T  ok
+T{ seebuf -> 12 34 34 }T  ok
   ok
 \ CMOVE and CMOVE> propogation tests taken from   ok
 \ https://forth-standard.org/standard/string/CMOVE and .../CMOVEtop  ok
 decimal  ok
 create cmbuf  97 c, 98 c, 99 c, 100 c, \ "abcd"  ok
 : seecmbuf  cmbuf c@  cmbuf char+ c@  cmbuf char+ char+ c@  cmbuf char+ char+ char+ c@ ;  ok
-{ cmbuf dup char+ 3 cmove -> }  ok
-{ seecmbuf -> 97 97 97 97 } \ "aaaa"  ok
+T{ cmbuf dup char+ 3 cmove -> }T  ok
+T{ seecmbuf -> 97 97 97 97 }T \ "aaaa"  ok
   ok
 create cmubuf  97 c, 98 c, 99 c, 100 c, \ "abcd"  ok
 : seecmubuf  cmubuf c@  cmubuf char+ c@  cmubuf char+ char+ c@  cmubuf char+ char+ char+ c@ ;  ok
-{ cmubuf dup char+ swap 3 cmove> -> }  ok
-{ seecmubuf -> 100 100 100 100 } \ "dddd"  ok
+T{ cmubuf dup char+ swap 3 cmove> -> }T  ok
+T{ seecmubuf -> 100 100 100 100 }T \ "dddd"  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing output: . ." cr emit space spaces type u.  ok
@@ -1472,7 +1475,7 @@ hex  ok
    ." unsigned: " 0 u. max-uint u. cr  compiled
 ;  ok
   ok
-{ output-test -> } you should see the standard graphic characters:
+T{ output-test -> }T you should see the standard graphic characters:
  !"#$%&'()*+,-./0123456789:;<=>?@
 ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
 abcdefghijklmnopqrstuvwxyz{|}~
@@ -1496,43 +1499,43 @@ unsigned: 0 FFFF
 testing parse-name marker erase  ok
   ok
 \ Careful editing these, whitespace is significant  ok
-{ parse-name abcd s" abcd" s= -> <true> }   ok
-{ parse-name   abcde   s" abcde" s= -> <true> } \ test empty parse area   ok
-{ parse-name   ok
-   nip -> 0 }    \ empty line   ok
-{ parse-name      ok
-   nip -> 0 }    \ line with white space  ok
-{ : parse-name-test ( "name1" "name2" -- n )   compiled
-   parse-name parse-name s= ; -> }  ok
-{ parse-name-test abcd abcd -> <true> }   ok
-{ parse-name-test  abcd   abcd   -> <true> }   ok
-{ parse-name-test abcde abcdf -> <false> }   ok
-{ parse-name-test abcdf abcde -> <false> }   ok
-{ parse-name-test abcde abcde   ok
-    -> <true> }   ok
-{ parse-name-test abcde abcde    ok
-    -> <true> }    \ line with white space  ok
+T{ parse-name abcd s" abcd" s= -> <true> }T   ok
+T{ parse-name   abcde   s" abcde" s= -> <true> }T \ test empty parse area   ok
+T{ parse-name   ok
+   nip -> 0 }T    \ empty line   ok
+T{ parse-name      ok
+   nip -> 0 }T    \ line with white space  ok
+T{ : parse-name-test ( "name1" "name2" -- n )   compiled
+   parse-name parse-name s= ; -> }T  ok
+T{ parse-name-test abcd abcd -> <true> }T   ok
+T{ parse-name-test  abcd   abcd   -> <true> }T   ok
+T{ parse-name-test abcde abcdf -> <false> }T   ok
+T{ parse-name-test abcdf abcde -> <false> }T   ok
+T{ parse-name-test abcde abcde   ok
+    -> <true> }T   ok
+T{ parse-name-test abcde abcde    ok
+    -> <true> }T    \ line with white space  ok
   ok
 \ There is no official ANS test for MARKER, added 22. June 2018  ok
 \ TODO There is currently no test for FIND-NAME, taking it on faith here  ok
-{ variable marker_size -> }  ok
-{ unused marker_size ! -> }  ok
-{ marker quarian -> }  ok
+T{ variable marker_size -> }T  ok
+T{ unused marker_size ! -> }T  ok
+T{ marker quarian -> }T  ok
 : marker_test ." Bosh'tet!" ;  ok
-{ marker_test -> } \ should print "Bosh'tet!" Bosh'tet! ok
-{ quarian -> }   ok
-{ parse-name marker_test find-name -> 0 }   ok
-{ marker_size @ unused = -> <true> }  ok
+T{ marker_test -> }T \ should print "Bosh'tet!" Bosh'tet! ok
+T{ quarian -> }T   ok
+T{ parse-name marker_test find-name -> 0 }T   ok
+T{ marker_size @ unused = -> <true> }T  ok
   ok
 \ There is no official ANS test of ERASE, added 01. July 2018  ok
-{ create erase_test -> }  ok
-{ 9 c, 1 c, 2 c, 3 c, 9 c, -> }  ok
-{ erase_test 1+ 3 erase -> }  \ Erase bytes between 9   ok
-{ erase_test            c@ 9 = -> <true> }  ok
-{ erase_test 1 chars +  c@ 0 = -> <true> }  ok
-{ erase_test 2 chars +  c@ 0 = -> <true> }  ok
-{ erase_test 3 chars +  c@ 0 = -> <true> }  ok
-{ erase_test 4 chars +  c@ 9 = -> <true> }  ok
+T{ create erase_test -> }T  ok
+T{ 9 c, 1 c, 2 c, 3 c, 9 c, -> }T  ok
+T{ erase_test 1+ 3 erase -> }T  \ Erase bytes between 9   ok
+T{ erase_test            c@ 9 = -> <true> }T  ok
+T{ erase_test 1 chars +  c@ 0 = -> <true> }T  ok
+T{ erase_test 2 chars +  c@ 0 = -> <true> }T  ok
+T{ erase_test 3 chars +  c@ 0 = -> <true> }T  ok
+T{ erase_test 4 chars +  c@ 9 = -> <true> }T  ok
   ok
   ok
 \ ------------------------------------------------------------------------  ok
@@ -1541,24 +1544,24 @@ testing environment  ok
 \ This is from the ANS Forth specification at   ok
 \ https://forth-standard.org/standard/core/ENVIRONMENTq but the first  ok
 \ test is commented out because it doesn't seem to make sense  ok
-\ { s" x:deferred" environment? dup 0= xor invert -> <true>  } ( Huh? Why true? )  ok
-{ s" x:notfound" environment? dup 0= xor invert -> <false> }  ok
+\ T{ s" x:deferred" environment? dup 0= xor invert -> <true>  }T ( Huh? Why true? )  ok
+T{ s" x:notfound" environment? dup 0= xor invert -> <false> }T  ok
   ok
 \ These were added for Tali Forth 10. Aug 2018  ok
 hex  ok
-{ s" /COUNTED-STRING"    environment? ->    7FFF <true> }  ok
-{ s" /HOLD"              environment? ->      FF <true> }  ok
-{ s" /PAD"               environment? ->      54 <true> }  ok
-{ s" ADDRESS-UNIT-BITS"  environment? ->       8 <true> }  ok
-{ s" FLOORED"            environment? -> <false> <true> }  ok
-{ s" MAX-CHAR"           environment? ->      FF <true> }  ok
-{ s" MAX-N"              environment? ->    7FFF <true> }  ok
-{ s" MAX-U"              environment? ->    FFFF <true> }  ok
-{ s" RETURN-STACK-CELLS" environment? ->      80 <true> }  ok
-{ s" STACK-CELLS"        environment? ->      20 <true> }  ok
+T{ s" /COUNTED-STRING"    environment? ->    7FFF <true> }T  ok
+T{ s" /HOLD"              environment? ->      FF <true> }T  ok
+T{ s" /PAD"               environment? ->      54 <true> }T  ok
+T{ s" ADDRESS-UNIT-BITS"  environment? ->       8 <true> }T  ok
+T{ s" FLOORED"            environment? -> <false> <true> }T  ok
+T{ s" MAX-CHAR"           environment? ->      FF <true> }T  ok
+T{ s" MAX-N"              environment? ->    7FFF <true> }T  ok
+T{ s" MAX-U"              environment? ->    FFFF <true> }T  ok
+T{ s" RETURN-STACK-CELLS" environment? ->      80 <true> }T  ok
+T{ s" STACK-CELLS"        environment? ->      20 <true> }T  ok
   ok
-{ s" MAX-D"  environment? -> 7FFFFFFF. <true> }   ok
-{ s" MAX-UD" environment? -> FFFFFFFF. <true> }  ok
+T{ s" MAX-D"  environment? -> 7FFFFFFF. <true> }T   ok
+T{ s" MAX-UD" environment? -> FFFFFFFF. <true> }T  ok
 decimal  ok
   ok
 \ ------------------------------------------------------------------------  ok
@@ -1573,7 +1576,7 @@ create abuf 80 chars allot  ok
    abuf swap type [char] " emit cr  compiled
 ;  ok
   ok
-{ accept-test -> } 
+T{ accept-test -> }T 
 please type up to 80 characters:
 Here is some text for accept. 
 received: "Here is some text for accept."
@@ -1582,8 +1585,8 @@ received: "Here is some text for accept."
 \ ------------------------------------------------------------------------  ok
 testing dictionary search rules  ok
   ok
-{ : gdx   123 ; : gdx   gdx 234 ; -> } redefined gdx ok
-{ gdx -> 123 234 }  ok
+T{ : gdx   123 ; : gdx   gdx 234 ; -> }T redefined gdx ok
+T{ gdx -> 123 234 }T  ok
   ok
 hex  ok
 \ Free memory used for these tests  ok
@@ -1600,73 +1603,73 @@ marker string_tests  ok
   ok
 \ Note the sequence of tests is fixed by https://forth-standard.org/standard/testsuite  ok
   ok
-{ : s1 s" abcdefghijklmnopqrstuvwxyz" ; -> }  ok
+T{ : s1 s" abcdefghijklmnopqrstuvwxyz" ; -> }T  ok
    ok
-{ s1  5 /string -> s1 swap 5 + swap 5 - }  ok
-{ s1 10 /string -4 /string -> s1 6 /string }  ok
-{ s1  0 /string -> s1 }  ok
+T{ s1  5 /string -> s1 swap 5 + swap 5 - }T  ok
+T{ s1 10 /string -4 /string -> s1 6 /string }T  ok
+T{ s1  0 /string -> s1 }T  ok
   ok
-{ : s2 s" abc"   ; -> }  ok
-{ : s3 s" jklmn" ; -> }  ok
-{ : s4 s" z"     ; -> }  ok
-{ : s5 s" mnoq"  ; -> }  ok
-{ : s6 s" 12345" ; -> }  ok
-{ : s7 s" "      ; -> }  ok
+T{ : s2 s" abc"   ; -> }T  ok
+T{ : s3 s" jklmn" ; -> }T  ok
+T{ : s4 s" z"     ; -> }T  ok
+T{ : s5 s" mnoq"  ; -> }T  ok
+T{ : s6 s" 12345" ; -> }T  ok
+T{ : s7 s" "      ; -> }T  ok
   ok
-{ s1 s2 search -> s1 -1 ( <true> )  }    ok
-{ s1 s3 search -> s1  9 /string -1 ( <true> )  }  ok
-{ s1 s4 search -> s1 25 /string -1 ( <true> ) }  ok
-{ s1 s5 search -> s1 0 ( <false> ) }  ok
-{ s1 s6 search -> s1 0 ( <false> ) }  ok
-{ s1 s7 search -> s1 -1 ( <true> ) }   ok
+T{ s1 s2 search -> s1 -1 ( <true> )  }T    ok
+T{ s1 s3 search -> s1  9 /string -1 ( <true> )  }T  ok
+T{ s1 s4 search -> s1 25 /string -1 ( <true> ) }T  ok
+T{ s1 s5 search -> s1 0 ( <false> ) }T  ok
+T{ s1 s6 search -> s1 0 ( <false> ) }T  ok
+T{ s1 s7 search -> s1 -1 ( <true> ) }T   ok
   ok
-{ :  s8 s" abc  " ; -> }  ok
-{ :  s9 s"      " ; -> }  ok
-{ : s10 s"    a " ; -> }  ok
+T{ :  s8 s" abc  " ; -> }T  ok
+T{ :  s9 s"      " ; -> }T  ok
+T{ : s10 s"    a " ; -> }T  ok
   ok
-{  s1 -trailing -> s1 }        \ "abcdefghijklmnopqrstuvwxyz"  ok
-{  s8 -trailing -> s8 2 - }    \ "abc "  ok
-{  s7 -trailing -> s7 }        \ " "  ok
-{  s9 -trailing -> s9 drop 0 } \ " "  ok
-{ s10 -trailing -> s10 1- }    \ " a "  ok
+T{  s1 -trailing -> s1 }T        \ "abcdefghijklmnopqrstuvwxyz"  ok
+T{  s8 -trailing -> s8 2 - }T    \ "abc "  ok
+T{  s7 -trailing -> s7 }T        \ " "  ok
+T{  s9 -trailing -> s9 drop 0 }T \ " "  ok
+T{ s10 -trailing -> s10 1- }T    \ " a "  ok
   ok
-{ s1        s1 compare ->  0  }  ok
-{ s1  pad swap cmove   ->     }    \ copy s1 to PAD  ok
-{ s1  pad over compare ->  0  }  ok
-{ s1     pad 6 compare ->  1  }  ok
-{ pad 10    s1 compare -> -1  }  ok
-{ s1     pad 0 compare ->  1  }  ok
-{ pad  0    s1 compare -> -1  }  ok
-{ s1        s6 compare ->  1  }  ok
-{ s6        s1 compare -> -1  }  ok
+T{ s1        s1 compare ->  0  }T  ok
+T{ s1  pad swap cmove   ->     }T    \ copy s1 to PAD  ok
+T{ s1  pad over compare ->  0  }T  ok
+T{ s1     pad 6 compare ->  1  }T  ok
+T{ pad 10    s1 compare -> -1  }T  ok
+T{ s1     pad 0 compare ->  1  }T  ok
+T{ pad  0    s1 compare -> -1  }T  ok
+T{ s1        s6 compare ->  1  }T  ok
+T{ s6        s1 compare -> -1  }T  ok
   ok
 : "abdde" s" abdde" ;  ok
 : "abbde" s" abbde" ;  ok
 : "abcdf" s" abcdf" ;  ok
 : "abcdee" s" abcdee" ;  ok
   ok
-{ s1 "abdde"  compare -> -1 }  ok
-{ s1 "abbde"  compare ->  1 }  ok
-{ s1 "abcdf"  compare -> -1 }  ok
-{ s1 "abcdee" compare ->  1 }  ok
+T{ s1 "abdde"  compare -> -1 }T  ok
+T{ s1 "abbde"  compare ->  1 }T  ok
+T{ s1 "abcdf"  compare -> -1 }T  ok
+T{ s1 "abcdee" compare ->  1 }T  ok
   ok
 : s11 s" 0abc" ;  ok
 : s12 s" 0aBc" ;  ok
   ok
-{ s11 s12 compare ->  1 }  ok
-{ s12 s11 compare -> -1 }  ok
+T{ s11 s12 compare ->  1 }T  ok
+T{ s12 s11 compare -> -1 }T  ok
   ok
 : s13 s" aaaaa      a" ;       \ six spaces  ok
   ok
-{ pad 25 char a fill -> }      \ fill PAD with 25 'a's  ok
-{ pad 5 chars + 6 blank -> }   \ put 6 spaced from character 5  ok
-{ pad 12 s13 compare -> 0 }    \ PAD should now be same as s13 TODO  ok
+T{ pad 25 char a fill -> }T      \ fill PAD with 25 'a's  ok
+T{ pad 5 chars + 6 blank -> }T   \ put 6 spaced from character 5  ok
+T{ pad 12 s13 compare -> 0 }T    \ PAD should now be same as s13 TODO  ok
   ok
 ( CMOVE and CMOVE> are kept together with MOVE )  ok
   ok
-{ : s14 [ s1 ] sliteral ; -> }   ok
-{ s1 s14 compare -> 0 }  ok
-{ s1 s14 rot = rot rot = -> -1 ( <true> ) 0 ( <false> ) }  ok
+T{ : s14 [ s1 ] sliteral ; -> }T   ok
+T{ s1 s14 compare -> 0 }T  ok
+T{ s1 s14 rot = rot rot = -> -1 ( <true> ) 0 ( <false> ) }T  ok
   ok
 ( TODO REPLACES not implemented yet )  ok
 ( TODO SUBSTITUTE not implemented yet )  ok
@@ -1685,18 +1688,18 @@ marker double_tests  ok
   ok
 decimal  ok
   ok
-{ 2variable 2v1 -> }  ok
-{ 0. 2v1 2! -> }  ok
-{ 2v1 2@ -> 0. }  ok
-{ -1 -2 2v1 2! -> }  ok
-{ 2v1 2@ -> -1 -2 }  ok
-{ : cd2 2variable ; -> }  ok
-{ cd2 2v2 -> }  ok
-{ : cd3 2v2 2! ; -> }  ok
-{ -2 -1 cd3 -> }  ok
-{ 2v2 2@ -> -2 -1 }  ok
-{ 2variable 2v3 immediate 5 6 2v3 2! -> }  ok
-{ 2v3 2@ -> 5 6 }  ok
+T{ 2variable 2v1 -> }T  ok
+T{ 0. 2v1 2! -> }T  ok
+T{ 2v1 2@ -> 0. }T  ok
+T{ -1 -2 2v1 2! -> }T  ok
+T{ 2v1 2@ -> -1 -2 }T  ok
+T{ : cd2 2variable ; -> }T  ok
+T{ cd2 2v2 -> }T  ok
+T{ : cd3 2v2 2! ; -> }T  ok
+T{ -2 -1 cd3 -> }T  ok
+T{ 2v2 2@ -> -2 -1 }T  ok
+T{ 2variable 2v3 immediate 5 6 2v3 2! -> }T  ok
+T{ 2v3 2@ -> 5 6 }T  ok
   ok
 \ Repeats in case we call this test alone  ok
 0 constant 0s  ok
@@ -1704,35 +1707,35 @@ decimal  ok
 0 invert 1 rshift  constant max-int  ok
 0 invert 1 rshift invert  constant min-int  ok
   ok
-{  0.  5. d+ ->  5. }                         \ small integers   ok
-{ -5.  0. d+ -> -5. }   ok
-{  1.  2. d+ ->  3. }   ok
-{  1. -2. d+ -> -1. }   ok
-{ -1.  2. d+ ->  1. }   ok
-{ -1. -2. d+ -> -3. }   ok
-{ -1.  1. d+ ->  0. }  ok
-{  0  0  0  5 d+ ->  0  5 }                  \ mid range integers   ok
-{ -1  5  0  0 d+ -> -1  5 }   ok
-{  0  0  0 -5 d+ ->  0 -5 }   ok
-{  0 -5 -1  0 d+ -> -1 -5 }   ok
-{  0  1  0  2 d+ ->  0  3 }   ok
-{ -1  1  0 -2 d+ -> -1 -1 }   ok
-{  0 -1  0  2 d+ ->  0  1 }   ok
-{  0 -1 -1 -2 d+ -> -1 -3 }   ok
-{ -1 -1  0  1 d+ -> -1  0 }  ok
+T{  0.  5. d+ ->  5. }T                         \ small integers   ok
+T{ -5.  0. d+ -> -5. }T   ok
+T{  1.  2. d+ ->  3. }T   ok
+T{  1. -2. d+ -> -1. }T   ok
+T{ -1.  2. d+ ->  1. }T   ok
+T{ -1. -2. d+ -> -3. }T   ok
+T{ -1.  1. d+ ->  0. }T  ok
+T{  0  0  0  5 d+ ->  0  5 }T                  \ mid range integers   ok
+T{ -1  5  0  0 d+ -> -1  5 }T   ok
+T{  0  0  0 -5 d+ ->  0 -5 }T   ok
+T{  0 -5 -1  0 d+ -> -1 -5 }T   ok
+T{  0  1  0  2 d+ ->  0  3 }T   ok
+T{ -1  1  0 -2 d+ -> -1 -1 }T   ok
+T{  0 -1  0  2 d+ ->  0  1 }T   ok
+T{  0 -1 -1 -2 d+ -> -1 -3 }T   ok
+T{ -1 -1  0  1 d+ -> -1  0 }T  ok
   ok
-{ min-int 0 2dup d+ -> 0 1 }  ok
-{ min-int s>d min-int 0 d+ -> 0 0 }  ok
+T{ min-int 0 2dup d+ -> 0 1 }T  ok
+T{ min-int s>d min-int 0 d+ -> 0 0 }T  ok
   ok
-{ 1 2 2constant 2c1 -> }  ok
-{ 2c1 -> 1 2 }  ok
-{ : cd1 2c1 ; -> }  ok
-{ cd1 -> 1 2 }  ok
-{ : cd2 2constant ; -> } redefined cd2 ok
-{ -1 -2 cd2 2c2 -> }  ok
-{ 2c2 -> -1 -2 }  ok
-{ 4 5 2constant 2c3 immediate 2c3 -> 4 5 }  ok
-{ : cd6 2c3 2literal ; cd6 -> 4 5 }  ok
+T{ 1 2 2constant 2c1 -> }T  ok
+T{ 2c1 -> 1 2 }T  ok
+T{ : cd1 2c1 ; -> }T  ok
+T{ cd1 -> 1 2 }T  ok
+T{ : cd2 2constant ; -> }T redefined cd2 ok
+T{ -1 -2 cd2 2c2 -> }T  ok
+T{ 2c2 -> -1 -2 }T  ok
+T{ 4 5 2constant 2c3 immediate 2c3 -> 4 5 }T  ok
+T{ : cd6 2c3 2literal ; cd6 -> 4 5 }T  ok
   ok
 max-int 2/ constant hi-int \ 001...1   ok
 min-int 2/ constant lo-int \ 110...1  ok
@@ -1742,46 +1745,46 @@ min-int 2/ constant lo-int \ 110...1  ok
 max-2int 2/ 2constant hi-2int  \ 001...1   ok
 min-2int 2/ 2constant lo-2int  \ 110...0  ok
   ok
-{ : cd1 [ max-2int ] 2literal ; -> } redefined cd1 ok
-{ cd1 -> max-2int }  ok
-{ 2variable 2v4 immediate 5 6 2v4 2! -> }  ok
-{ : cd7 2v4 [ 2@ ] 2literal ; cd7 -> 5 6 }  ok
-{ : cd8 [ 6 7 ] 2v4 [ 2! ] ; 2v4 2@ -> 6 7 }  ok
+T{ : cd1 [ max-2int ] 2literal ; -> }T redefined cd1 ok
+T{ cd1 -> max-2int }T  ok
+T{ 2variable 2v4 immediate 5 6 2v4 2! -> }T  ok
+T{ : cd7 2v4 [ 2@ ] 2literal ; cd7 -> 5 6 }T  ok
+T{ : cd8 [ 6 7 ] 2v4 [ 2! ] ; 2v4 2@ -> 6 7 }T  ok
   ok
-{  hi-2int       1. d+ -> 0 hi-int 1+ }     \ large double integers   ok
-{  hi-2int     2dup d+ -> 1s 1- max-int }  ok
-{ max-2int min-2int d+ -> -1. }  ok
-{ max-2int  lo-2int d+ -> hi-2int }  ok
-{  lo-2int     2dup d+ -> min-2int }  ok
-{  hi-2int min-2int d+ 1. d+ -> lo-2int }  ok
+T{  hi-2int       1. d+ -> 0 hi-int 1+ }T     \ large double integers   ok
+T{  hi-2int     2dup d+ -> 1s 1- max-int }T  ok
+T{ max-2int min-2int d+ -> -1. }T  ok
+T{ max-2int  lo-2int d+ -> hi-2int }T  ok
+T{  lo-2int     2dup d+ -> min-2int }T  ok
+T{  hi-2int min-2int d+ 1. d+ -> lo-2int }T  ok
   ok
-{  0.  5. d- -> -5. }              \ small integers   ok
-{  5.  0. d- ->  5. }   ok
-{  0. -5. d- ->  5. }   ok
-{  1.  2. d- -> -1. }   ok
-{  1. -2. d- ->  3. }   ok
-{ -1.  2. d- -> -3. }   ok
-{ -1. -2. d- ->  1. }   ok
-{ -1. -1. d- ->  0. }   ok
-{  0  0  0  5 d- ->  0 -5 }        \ mid-range integers   ok
-{ -1  5  0  0 d- -> -1  5 }   ok
-{  0  0 -1 -5 d- ->  1  4 }   ok
-{  0 -5  0  0 d- ->  0 -5 }   ok
-{ -1  1  0  2 d- -> -1 -1 }   ok
-{  0  1 -1 -2 d- ->  1  2 }   ok
-{  0 -1  0  2 d- ->  0 -3 }   ok
-{  0 -1  0 -2 d- ->  0  1 }   ok
-{  0  0  0  1 d- ->  0 -1 }  ok
-{ min-int 0 2dup d- -> 0. }   ok
-{ min-int s>d max-int 0 d- -> 1 1s }   ok
+T{  0.  5. d- -> -5. }T              \ small integers   ok
+T{  5.  0. d- ->  5. }T   ok
+T{  0. -5. d- ->  5. }T   ok
+T{  1.  2. d- -> -1. }T   ok
+T{  1. -2. d- ->  3. }T   ok
+T{ -1.  2. d- -> -3. }T   ok
+T{ -1. -2. d- ->  1. }T   ok
+T{ -1. -1. d- ->  0. }T   ok
+T{  0  0  0  5 d- ->  0 -5 }T        \ mid-range integers   ok
+T{ -1  5  0  0 d- -> -1  5 }T   ok
+T{  0  0 -1 -5 d- ->  1  4 }T   ok
+T{  0 -5  0  0 d- ->  0 -5 }T   ok
+T{ -1  1  0  2 d- -> -1 -1 }T   ok
+T{  0  1 -1 -2 d- ->  1  2 }T   ok
+T{  0 -1  0  2 d- ->  0 -3 }T   ok
+T{  0 -1  0 -2 d- ->  0  1 }T   ok
+T{  0  0  0  1 d- ->  0 -1 }T  ok
+T{ min-int 0 2dup d- -> 0. }T   ok
+T{ min-int s>d max-int 0 d- -> 1 1s }T   ok
   ok
-{ max-2int max-2int d- -> 0. }    \ large integers   ok
-{ min-2int min-2int d- -> 0. }  ok
-{ max-2int  hi-2int d- -> lo-2int dnegate }   ok
-{  hi-2int  lo-2int d- -> max-2int }  ok
-{  lo-2int  hi-2int d- -> min-2int 1. d+ }  ok
-{ min-2int min-2int d- -> 0. }  ok
-{ min-2int  lo-2int d- -> lo-2int }  ok
+T{ max-2int max-2int d- -> 0. }T    \ large integers   ok
+T{ min-2int min-2int d- -> 0. }T  ok
+T{ max-2int  hi-2int d- -> lo-2int dnegate }T   ok
+T{  hi-2int  lo-2int d- -> max-2int }T  ok
+T{  lo-2int  hi-2int d- -> min-2int 1. d+ }T  ok
+T{ min-2int min-2int d- -> 0. }T  ok
+T{ min-2int  lo-2int d- -> lo-2int }T  ok
   ok
 ( TODO m*/ not implemented )   ok
   ok
@@ -1807,7 +1810,7 @@ min-2int 2/ 2constant lo-2int  \ 110...0  ok
    \ 5 spaces dbl2 r> 5 + d.r cr   ok
 \ ;  ok
   ok
-\ { doubleoutput -> }  ok
+\ T{ doubleoutput -> }T  ok
   ok
 ( TODO D0< not implemented yet )  ok
 ( TODO D0= not implemented yet )  ok
@@ -1816,24 +1819,24 @@ min-2int 2/ 2constant lo-2int  \ 110...0  ok
 ( TODO D< not implemented yet )  ok
 ( TODO D= not implemented yet )  ok
   ok
-{    1234  0 d>s ->  1234   }   ok
-{   -1234 -1 d>s -> -1234   }   ok
-{ max-int  0 d>s -> max-int }   ok
-{ min-int -1 d>s -> min-int }  ok
+T{    1234  0 d>s ->  1234   }T   ok
+T{   -1234 -1 d>s -> -1234   }T   ok
+T{ max-int  0 d>s -> max-int }T   ok
+T{ min-int -1 d>s -> min-int }T  ok
   ok
-{       1. dabs -> 1.       }   ok
-{      -1. dabs -> 1.       }   ok
-{ max-2int dabs -> max-2int }   ok
-{ min-2int 1. d+ dabs -> max-2int }  ok
+T{       1. dabs -> 1.       }T   ok
+T{      -1. dabs -> 1.       }T   ok
+T{ max-2int dabs -> max-2int }T   ok
+T{ min-2int 1. d+ dabs -> max-2int }T  ok
   ok
 ( TODO DMAX not implemented yet )  ok
 ( TODO DMIN not implemented yet )  ok
   ok
-{ 0. dnegate -> 0. }  ok
-{ 1. dnegate -> -1. }  ok
-{ -1. dnegate -> 1. }  ok
-{ max-2int dnegate -> min-2int swap 1+ swap }  ok
-{ min-2int swap 1+ swap dnegate -> max-2int }  ok
+T{ 0. dnegate -> 0. }T  ok
+T{ 1. dnegate -> -1. }T  ok
+T{ -1. dnegate -> 1. }T  ok
+T{ max-2int dnegate -> min-2int swap 1+ swap }T  ok
+T{ min-2int swap 1+ swap dnegate -> max-2int }T  ok
   ok
 ( TODO M*/ not implemented yet )  ok
 ( TODO M+ not implemented yet )  ok
@@ -1866,12 +1869,12 @@ marker long_string_tests  ok
 \ Test strings longer than 255 chars (important for 8-bit systems)  ok
 \ 516 character string  ok
 : s14 s" test                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                " ;  ok
-{ s14 swap drop -> 516 }  ok
-{ s14 -trailing -> s14 drop 4 }  ok
+T{ s14 swap drop -> 516 }T  ok
+T{ s14 -trailing -> s14 drop 4 }T  ok
   ok
 : s15 ." abcdefghijklmnopqrstuvwxyz1abcdefghijklmnopqrstuvwxyz2abcdefghijklmnopqrstuvwxyz3abcdefghijklmnopqrstuvwxyz4abcdefghijklmnopqrstuvwxyz5abcdefghijklmnopqrstuvwxyz6abcdefghijklmnopqrstuvwxyz7abcdefghijklmnopqrstuvwxyz8abcdefghijklmnopqrstuvwxyz9abcdefghijklmnopqrstuvwxyz10abcdefghijklmnopqrstuvwxyz11abcdefghijklmnopqrstuvwxyz12abcdefghijklmnopqrstuvwxyz13abcdefghijklmnopqrstuvwxyz14abcdefghijklmnopqrstuvwxyz15abcdefghijklmnopqrstuvwxyz16abcdefghijklmnopqrstuvwxyz17abcdefghijklmnopqrstuvwxyz18abcdefghijklmnopqrstuvwxyz19abcdefghijklmnopqrstuvwxyz20" ;  ok
 \ This should output the alphabet 20 times.  ok
-{ s15 -> } abcdefghijklmnopqrstuvwxyz1abcdefghijklmnopqrstuvwxyz2abcdefghijklmnopqrstuvwxyz3abcdefghijklmnopqrstuvwxyz4abcdefghijklmnopqrstuvwxyz5abcdefghijklmnopqrstuvwxyz6abcdefghijklmnopqrstuvwxyz7abcdefghijklmnopqrstuvwxyz8abcdefghijklmnopqrstuvwxyz9abcdefghijklmnopqrstuvwxyz10abcdefghijklmnopqrstuvwxyz11abcdefghijklmnopqrstuvwxyz12abcdefghijklmnopqrstuvwxyz13abcdefghijklmnopqrstuvwxyz14abcdefghijklmnopqrstuvwxyz15abcdefghijklmnopqrstuvwxyz16abcdefghijklmnopqrstuvwxyz17abcdefghijklmnopqrstuvwxyz18abcdefghijklmnopqrstuvwxyz19abcdefghijklmnopqrstuvwxyz20 ok
+T{ s15 -> }T abcdefghijklmnopqrstuvwxyz1abcdefghijklmnopqrstuvwxyz2abcdefghijklmnopqrstuvwxyz3abcdefghijklmnopqrstuvwxyz4abcdefghijklmnopqrstuvwxyz5abcdefghijklmnopqrstuvwxyz6abcdefghijklmnopqrstuvwxyz7abcdefghijklmnopqrstuvwxyz8abcdefghijklmnopqrstuvwxyz9abcdefghijklmnopqrstuvwxyz10abcdefghijklmnopqrstuvwxyz11abcdefghijklmnopqrstuvwxyz12abcdefghijklmnopqrstuvwxyz13abcdefghijklmnopqrstuvwxyz14abcdefghijklmnopqrstuvwxyz15abcdefghijklmnopqrstuvwxyz16abcdefghijklmnopqrstuvwxyz17abcdefghijklmnopqrstuvwxyz18abcdefghijklmnopqrstuvwxyz19abcdefghijklmnopqrstuvwxyz20 ok
   ok
 \ Free memory used for these tests  ok
 long_string_tests  ok
@@ -1898,13 +1901,13 @@ testing gforth words: bounds find-name latestxt name>int name>string  ok
 ( TODO NAME>STRING test missing)  ok
   ok
 \ Test for FIND-NAME assumes that PARSE-NAME has been tested in core.fs  ok
-{ parse-name drop     find-name  0<> -> <true> } \ need to find any nt  ok
-{ parse-name Chatika  find-name  0=  -> <true> } \ shouldn't find Tali's drone  ok
+T{ parse-name drop     find-name  0<> -> <true> }T \ need to find any nt  ok
+T{ parse-name Chatika  find-name  0=  -> <true> }T \ shouldn't find Tali's drone  ok
   ok
-{ hex -> }  ok
-{ 1000 10 bounds -> 1010 1000 }  ok
-{ ffff 2 bounds -> 0001 ffff }  \ BOUNDS wraps on Tali with 16 bit address space  ok
-{ decimal -> }  ok
+T{ hex -> }T  ok
+T{ 1000 10 bounds -> 1010 1000 }T  ok
+T{ ffff 2 bounds -> 0001 ffff }T  \ BOUNDS wraps on Tali with 16 bit address space  ok
+T{ decimal -> }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing tali-only words: always-native bell compile-only digit? int>name latestnt number 0 1 2  ok
@@ -1929,23 +1932,23 @@ decimal  ok
   ok
   ok
 \ Nothing is too trivial for testing!  ok
-{ 0 -> 0 }  ok
-{ 1 -> 1 }  ok
-{ 2 -> 2 }  ok
+T{ 0 -> 0 }T  ok
+T{ 1 -> 1 }T  ok
+T{ 2 -> 2 }T  ok
   ok
   ok
 \ Test for DIGIT? ( char -- u f | char f )  ok
   ok
-{ 36 constant max-base -> } \ ANS standard says 2 - 36  ok
-{ base @  constant orig-base -> }  ok
-{ s" 0123456789" ( addr u ) drop  constant digit_numeral -> }  ok
-{ s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop  constant digit_lower -> }  ok
-{ s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop  constant digit_upper -> }  ok
+T{ 36 constant max-base -> }T \ ANS standard says 2 - 36  ok
+T{ base @  constant orig-base -> }T  ok
+T{ s" 0123456789" ( addr u ) drop  constant digit_numeral -> }T  ok
+T{ s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop  constant digit_lower -> }T  ok
+T{ s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop  constant digit_upper -> }T  ok
   ok
 \ "/" and ":" are before and after ASCII numbers  ok
 \ "@" and "[" are before and after upper case ASCII letters  ok
 \ "`" and "{" are before and after lower case ASCII letters  ok
-{ s" /:@[`{"  ( addr u )  drop  constant digit_bad -> }  ok
+T{ s" /:@[`{"  ( addr u )  drop  constant digit_bad -> }T  ok
   ok
 : digit_numeral ( -- f )  compiled
    true  compiled
@@ -2015,7 +2018,7 @@ decimal  ok
       dup ."  -> " .  \ uncomment for debugging  compiled
    loop ;  ok
   ok
-{ digit_all -> <true> } 
+T{ digit_all -> <true> }T 
 Numerals, base 2 : 01 -> -1 
 Numerals, base 3 : 012 -> -1 
 Numerals, base 4 : 0123 -> -1 
@@ -2114,31 +2117,31 @@ One-off chars, base 33 : /:@[`{	 -> -1
 One-off chars, base 34 : /:@[`{	 -> -1 
 One-off chars, base 35 : /:@[`{	 -> -1 
 One-off chars, base 36 : /:@[`{	 -> -1  ok
-{ decimal -> }  ok
+T{ decimal -> }T  ok
   ok
   ok
 \ TODO find more edge cases for NUMBER  ok
-{ s" 0" number -> 0 }  ok
-{ s" 10" number -> 10 }  ok
-{ s" 100" number -> 100 }  ok
-{ s" 1." number -> 1 0 }  ok
-{ hex -> }  ok
-{ s" 0" number -> 0 }  ok
-{ s" 10" number -> 10 }  ok
-{ s" ff" number -> FF }  ok
-{ decimal -> }  ok
+T{ s" 0" number -> 0 }T  ok
+T{ s" 10" number -> 10 }T  ok
+T{ s" 100" number -> 100 }T  ok
+T{ s" 1." number -> 1 0 }T  ok
+T{ hex -> }T  ok
+T{ s" 0" number -> 0 }T  ok
+T{ s" 10" number -> 10 }T  ok
+T{ s" ff" number -> FF }T  ok
+T{ decimal -> }T  ok
   ok
 \ ------------------------------------------------------------------------  ok
 testing case-insensitivity in Tali using dup  ok
   ok
-{ 5 dup -> 5 5 }  ok
-{ 5 duP -> 5 5 }  ok
-{ 5 dUp -> 5 5 }  ok
-{ 5 dUP -> 5 5 }  ok
-{ 5 Dup -> 5 5 }  ok
-{ 5 DuP -> 5 5 }  ok
-{ 5 DUp -> 5 5 }  ok
-{ 5 DUP -> 5 5 }  ok
+T{ 5 dup -> 5 5 }T  ok
+T{ 5 duP -> 5 5 }T  ok
+T{ 5 dUp -> 5 5 }T  ok
+T{ 5 dUP -> 5 5 }T  ok
+T{ 5 Dup -> 5 5 }T  ok
+T{ 5 DuP -> 5 5 }T  ok
+T{ 5 DUp -> 5 5 }T  ok
+T{ 5 DUP -> 5 5 }T  ok
   ok
 \ Free memory used for these tests  ok
 tali_tests  ok
@@ -2164,15 +2167,15 @@ testing block words: BLK SCR LOAD THRU BUFFER BLOCK UPDATE FLUSH  ok
 marker block_tests  ok
   ok
 \ Bring in a 4-block ram drive  ok
-{ 4 block-ramdrive-init -> }  ok
+T{ 4 block-ramdrive-init -> }T  ok
   ok
 \ Put a string into the first block.  ok
-{ : teststring s" Testing Blocks!" ; -> }  ok
-{ : teststringlength teststring swap drop ; -> }  ok
-{ teststring 0 block swap move update flush -> }  ok
+T{ : teststring s" Testing Blocks!" ; -> }T  ok
+T{ : teststringlength teststring swap drop ; -> }T  ok
+T{ teststring 0 block swap move update flush -> }T  ok
   ok
 \ See if it's in the ramdrive.  ok
-{ ramdrive teststringlength teststring compare -> 0 }  ok
+T{ ramdrive teststringlength teststring compare -> 0 }T  ok
   ok
 \ We don't have an official editor yet, so bring in just  ok
 \ enough to create some basic screens.  ok
@@ -2213,11 +2216,11 @@ decimal  ok
   dup scr ! buffer 1024 blank update ;  ok
   ok
   ok
-{ 0 erase-screen flush -> }  ok
+T{ 0 erase-screen flush -> }T  ok
   ok
 \ Make sure the test string from before is gone by looking for space  ok
 \ at the beginning of the ramdrive.  ok
-{ s"           " ramdrive 10 compare -> 0 }  ok
+T{ s"           " ramdrive 10 compare -> 0 }T  ok
   ok
 \ Enter screens for testing LOAD and THRU  ok
 1 enter-screen 
@@ -2239,12 +2242,12 @@ decimal  ok
 15 * ( 15 )  ok
   ok
 \ Load screen 1 and then check for the expected side effects.  ok
-{ 1 load -> }  ok
+T{ 1 load -> }T  ok
   ok
 \ BLK should be 0 while in the string and 1 while in the rest of the block.  ok
-{ blkinscreen @  -> 1 }  ok
-{ blkinstring @  -> 0 }  ok
-{ blkinscreenA @ -> 1 }  ok
+T{ blkinscreen @  -> 1 }T  ok
+T{ blkinstring @  -> 0 }T  ok
+T{ blkinscreenA @ -> 1 }T  ok
   ok
 2 enter-screen 
  0 * ( Test screen 2 ) 
@@ -2283,7 +2286,7 @@ decimal  ok
 15 * ( 15 ) ( testing the last line )     blk @ constant blkinscreenC ok
   ok
   ok
-{ 2 list -> } 
+T{ 2 list -> }T 
 Screen #   2
  0 ( Test screen 2 )                                               
  1 ( 1 ) ( Test loading another screen )                           
@@ -2302,16 +2305,16 @@ Screen #   2
 14 ( 14 )                                                          
 15 ( 15 )                                                          
  ok
-{ scr @ -> 2 } \ Screen 2 is the last one we listed.  ok
+T{ scr @ -> 2 }T \ Screen 2 is the last one we listed.  ok
   ok
 \ Load screens 2 and 3 with THRU and check for side effects.  ok
 \ shouldbe19 should be 5 + 7 + 7 because screen 2 loads screen 3.  ok
-{ 2 3 thru -> }  ok
+T{ 2 3 thru -> }T  ok
   ok
-{ blkinscreenB @ -> 2  } \ Note: blkinscreen3 is a variable.  ok
-{ blkinscreenC   -> 3  } \ Note: blkinscreen4 is a constant.  ok
-{ blkinscreenD   -> 2  } \ Note: blkinscreen5 is a constant.  ok
-{ shouldbe19 @   -> 19 }  ok
+T{ blkinscreenB @ -> 2  }T \ Note: blkinscreen3 is a variable.  ok
+T{ blkinscreenC   -> 3  }T \ Note: blkinscreen4 is a constant.  ok
+T{ blkinscreenD   -> 2  }T \ Note: blkinscreen5 is a constant.  ok
+T{ shouldbe19 @   -> 19 }T  ok
   ok
 \ Release all of the memory used.  ok
 block_tests  ok
@@ -2322,9 +2325,9 @@ block_tests  ok
 \ FILE        : user.fs  ok
 \ DESCRIPTION : This file is for users to add their own tests to the  ok
 \ test suite.  To add a test, the syntax is:  ok
-\ { data_for_word word_to_test -> expected_results }  ok
+\ T{ data_for_word word_to_test -> expected_results }T  ok
 \ eg.  ok
-\ { 5 dup -> 5 5 }  ok
+\ T{ 5 dup -> 5 5 }T  ok
 \ If the test passes, Tali will simply report "ok".  If the test does  ok
 \ not pass, an error message will be printed.  Results are logged in  ok
 \ the file results.txt and users can run just this set of tests using  ok
@@ -2457,7 +2460,7 @@ char w       ' digit?        cycle_test 2drop      CYCLES:     75 ok
 5 5          ' =             cycle_test drop       CYCLES:     53 ok
 here 5       ' erase         cycle_test            CYCLES:    310 ok
 here 5 5     ' fill          cycle_test            CYCLES:    298 ok
-s" 5"        ' evaluate      cycle_test drop       CYCLES:  15709 ok
+s" 5"        ' evaluate      cycle_test drop       CYCLES:  15663 ok
 5 ' drop     ' execute       cycle_test            CYCLES:     62 ok
 \ skipping     exit  ok
              ' false         cycle_test drop       CYCLES:     24 ok
@@ -2466,7 +2469,7 @@ here         ' @             cycle_test drop       CYCLES:     48 ok
 here 5 c, char a c, char w c, char o c,  ok
 char r c, char d c,  ok
              ' find          cycle_test 2drop      CYCLES:    667 ok
-s" aword"    ' find-name     cycle_test drop       CYCLES:    392 ok
+s" aword"    ' find-name     cycle_test drop       CYCLES:    389 ok
 5. 5         ' fm/mod        cycle_test 2drop      CYCLES:   1279 ok
 5 5          ' >             cycle_test drop       CYCLES:     70 ok
              ' here          cycle_test drop       CYCLES:     30 ok

--- a/tests/string.fs
+++ b/tests/string.fs
@@ -7,73 +7,73 @@ marker string_tests
 
 \ Note the sequence of tests is fixed by https://forth-standard.org/standard/testsuite
 
-{ : s1 s" abcdefghijklmnopqrstuvwxyz" ; -> }
+T{ : s1 s" abcdefghijklmnopqrstuvwxyz" ; -> }T
  
-{ s1  5 /string -> s1 swap 5 + swap 5 - }
-{ s1 10 /string -4 /string -> s1 6 /string }
-{ s1  0 /string -> s1 }
+T{ s1  5 /string -> s1 swap 5 + swap 5 - }T
+T{ s1 10 /string -4 /string -> s1 6 /string }T
+T{ s1  0 /string -> s1 }T
 
-{ : s2 s" abc"   ; -> }
-{ : s3 s" jklmn" ; -> }
-{ : s4 s" z"     ; -> }
-{ : s5 s" mnoq"  ; -> }
-{ : s6 s" 12345" ; -> }
-{ : s7 s" "      ; -> }
+T{ : s2 s" abc"   ; -> }T
+T{ : s3 s" jklmn" ; -> }T
+T{ : s4 s" z"     ; -> }T
+T{ : s5 s" mnoq"  ; -> }T
+T{ : s6 s" 12345" ; -> }T
+T{ : s7 s" "      ; -> }T
 
-{ s1 s2 search -> s1 -1 ( <true> )  }  
-{ s1 s3 search -> s1  9 /string -1 ( <true> )  }
-{ s1 s4 search -> s1 25 /string -1 ( <true> ) }
-{ s1 s5 search -> s1 0 ( <false> ) }
-{ s1 s6 search -> s1 0 ( <false> ) }
-{ s1 s7 search -> s1 -1 ( <true> ) } 
+T{ s1 s2 search -> s1 -1 ( <true> )  }T  
+T{ s1 s3 search -> s1  9 /string -1 ( <true> )  }T
+T{ s1 s4 search -> s1 25 /string -1 ( <true> ) }T
+T{ s1 s5 search -> s1 0 ( <false> ) }T
+T{ s1 s6 search -> s1 0 ( <false> ) }T
+T{ s1 s7 search -> s1 -1 ( <true> ) }T 
 
-{ :  s8 s" abc  " ; -> }
-{ :  s9 s"      " ; -> }
-{ : s10 s"    a " ; -> }
+T{ :  s8 s" abc  " ; -> }T
+T{ :  s9 s"      " ; -> }T
+T{ : s10 s"    a " ; -> }T
 
-{  s1 -trailing -> s1 }        \ "abcdefghijklmnopqrstuvwxyz"
-{  s8 -trailing -> s8 2 - }    \ "abc "
-{  s7 -trailing -> s7 }        \ " "
-{  s9 -trailing -> s9 drop 0 } \ " "
-{ s10 -trailing -> s10 1- }    \ " a "
+T{  s1 -trailing -> s1 }T        \ "abcdefghijklmnopqrstuvwxyz"
+T{  s8 -trailing -> s8 2 - }T    \ "abc "
+T{  s7 -trailing -> s7 }T        \ " "
+T{  s9 -trailing -> s9 drop 0 }T \ " "
+T{ s10 -trailing -> s10 1- }T    \ " a "
 
-{ s1        s1 compare ->  0  }
-{ s1  pad swap cmove   ->     }    \ copy s1 to PAD
-{ s1  pad over compare ->  0  }
-{ s1     pad 6 compare ->  1  }
-{ pad 10    s1 compare -> -1  }
-{ s1     pad 0 compare ->  1  }
-{ pad  0    s1 compare -> -1  }
-{ s1        s6 compare ->  1  }
-{ s6        s1 compare -> -1  }
+T{ s1        s1 compare ->  0  }T
+T{ s1  pad swap cmove   ->     }T    \ copy s1 to PAD
+T{ s1  pad over compare ->  0  }T
+T{ s1     pad 6 compare ->  1  }T
+T{ pad 10    s1 compare -> -1  }T
+T{ s1     pad 0 compare ->  1  }T
+T{ pad  0    s1 compare -> -1  }T
+T{ s1        s6 compare ->  1  }T
+T{ s6        s1 compare -> -1  }T
 
 : "abdde" s" abdde" ;
 : "abbde" s" abbde" ;
 : "abcdf" s" abcdf" ;
 : "abcdee" s" abcdee" ;
 
-{ s1 "abdde"  compare -> -1 }
-{ s1 "abbde"  compare ->  1 }
-{ s1 "abcdf"  compare -> -1 }
-{ s1 "abcdee" compare ->  1 }
+T{ s1 "abdde"  compare -> -1 }T
+T{ s1 "abbde"  compare ->  1 }T
+T{ s1 "abcdf"  compare -> -1 }T
+T{ s1 "abcdee" compare ->  1 }T
 
 : s11 s" 0abc" ;
 : s12 s" 0aBc" ;
 
-{ s11 s12 compare ->  1 }
-{ s12 s11 compare -> -1 }
+T{ s11 s12 compare ->  1 }T
+T{ s12 s11 compare -> -1 }T
 
 : s13 s" aaaaa      a" ;       \ six spaces
 
-{ pad 25 char a fill -> }      \ fill PAD with 25 'a's
-{ pad 5 chars + 6 blank -> }   \ put 6 spaced from character 5
-{ pad 12 s13 compare -> 0 }    \ PAD should now be same as s13 TODO
+T{ pad 25 char a fill -> }T      \ fill PAD with 25 'a's
+T{ pad 5 chars + 6 blank -> }T   \ put 6 spaced from character 5
+T{ pad 12 s13 compare -> 0 }T    \ PAD should now be same as s13 TODO
 
 ( CMOVE and CMOVE> are kept together with MOVE )
 
-{ : s14 [ s1 ] sliteral ; -> } 
-{ s1 s14 compare -> 0 }
-{ s1 s14 rot = rot rot = -> -1 ( <true> ) 0 ( <false> ) }
+T{ : s14 [ s1 ] sliteral ; -> }T 
+T{ s1 s14 compare -> 0 }T
+T{ s1 s14 rot = rot rot = -> -1 ( <true> ) 0 ( <false> ) }T
 
 ( TODO REPLACES not implemented yet )
 ( TODO SUBSTITUTE not implemented yet )

--- a/tests/stringlong.fs
+++ b/tests/stringlong.fs
@@ -12,12 +12,12 @@ marker long_string_tests
 \ Test strings longer than 255 chars (important for 8-bit systems)
 \ 516 character string
 : s14 s" test                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                " ;
-{ s14 swap drop -> 516 }
-{ s14 -trailing -> s14 drop 4 }
+T{ s14 swap drop -> 516 }T
+T{ s14 -trailing -> s14 drop 4 }T
 
 : s15 ." abcdefghijklmnopqrstuvwxyz1abcdefghijklmnopqrstuvwxyz2abcdefghijklmnopqrstuvwxyz3abcdefghijklmnopqrstuvwxyz4abcdefghijklmnopqrstuvwxyz5abcdefghijklmnopqrstuvwxyz6abcdefghijklmnopqrstuvwxyz7abcdefghijklmnopqrstuvwxyz8abcdefghijklmnopqrstuvwxyz9abcdefghijklmnopqrstuvwxyz10abcdefghijklmnopqrstuvwxyz11abcdefghijklmnopqrstuvwxyz12abcdefghijklmnopqrstuvwxyz13abcdefghijklmnopqrstuvwxyz14abcdefghijklmnopqrstuvwxyz15abcdefghijklmnopqrstuvwxyz16abcdefghijklmnopqrstuvwxyz17abcdefghijklmnopqrstuvwxyz18abcdefghijklmnopqrstuvwxyz19abcdefghijklmnopqrstuvwxyz20" ;
 \ This should output the alphabet 20 times.
-{ s15 -> }
+T{ s15 -> }T
 
 \ Free memory used for these tests
 long_string_tests

--- a/tests/tali.fs
+++ b/tests/tali.fs
@@ -19,13 +19,13 @@ testing gforth words: bounds find-name latestxt name>int name>string
 ( TODO NAME>STRING test missing)
 
 \ Test for FIND-NAME assumes that PARSE-NAME has been tested in core.fs
-{ parse-name drop     find-name  0<> -> <true> } \ need to find any nt
-{ parse-name Chatika  find-name  0=  -> <true> } \ shouldn't find Tali's drone
+T{ parse-name drop     find-name  0<> -> <true> }T \ need to find any nt
+T{ parse-name Chatika  find-name  0=  -> <true> }T \ shouldn't find Tali's drone
 
-{ hex -> }
-{ 1000 10 bounds -> 1010 1000 }
-{ ffff 2 bounds -> 0001 ffff }  \ BOUNDS wraps on Tali with 16 bit address space
-{ decimal -> }
+T{ hex -> }T
+T{ 1000 10 bounds -> 1010 1000 }T
+T{ ffff 2 bounds -> 0001 ffff }T  \ BOUNDS wraps on Tali with 16 bit address space
+T{ decimal -> }T
 
 \ ------------------------------------------------------------------------
 testing tali-only words: always-native bell compile-only digit? int>name latestnt number 0 1 2
@@ -50,23 +50,23 @@ decimal
 
 
 \ Nothing is too trivial for testing!
-{ 0 -> 0 }
-{ 1 -> 1 }
-{ 2 -> 2 }
+T{ 0 -> 0 }T
+T{ 1 -> 1 }T
+T{ 2 -> 2 }T
 
 
 \ Test for DIGIT? ( char -- u f | char f )
 
-{ 36 constant max-base -> } \ ANS standard says 2 - 36
-{ base @  constant orig-base -> }
-{ s" 0123456789" ( addr u ) drop  constant digit_numeral -> }
-{ s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop  constant digit_lower -> }
-{ s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop  constant digit_upper -> }
+T{ 36 constant max-base -> }T \ ANS standard says 2 - 36
+T{ base @  constant orig-base -> }T
+T{ s" 0123456789" ( addr u ) drop  constant digit_numeral -> }T
+T{ s" abcdefghijklmnopqrstuvwxyz" ( addr u ) drop  constant digit_lower -> }T
+T{ s" ABCDEFGHIJKLMNOPQRSTUVWXYZ" ( addr u ) drop  constant digit_upper -> }T
 
 \ "/" and ":" are before and after ASCII numbers
 \ "@" and "[" are before and after upper case ASCII letters
 \ "`" and "{" are before and after lower case ASCII letters
-{ s" /:@[`{"  ( addr u )  drop  constant digit_bad -> }
+T{ s" /:@[`{"  ( addr u )  drop  constant digit_bad -> }T
 
 : digit_numeral ( -- f )
    true
@@ -136,32 +136,32 @@ decimal
       dup ."  -> " .  \ uncomment for debugging
    loop ;
 
-{ digit_all -> <true> }
-{ decimal -> }
+T{ digit_all -> <true> }T
+T{ decimal -> }T
 
 
 \ TODO find more edge cases for NUMBER
-{ s" 0" number -> 0 }
-{ s" 10" number -> 10 }
-{ s" 100" number -> 100 }
-{ s" 1." number -> 1 0 }
-{ hex -> }
-{ s" 0" number -> 0 }
-{ s" 10" number -> 10 }
-{ s" ff" number -> FF }
-{ decimal -> }
+T{ s" 0" number -> 0 }T
+T{ s" 10" number -> 10 }T
+T{ s" 100" number -> 100 }T
+T{ s" 1." number -> 1 0 }T
+T{ hex -> }T
+T{ s" 0" number -> 0 }T
+T{ s" 10" number -> 10 }T
+T{ s" ff" number -> FF }T
+T{ decimal -> }T
 
 \ ------------------------------------------------------------------------
 testing case-insensitivity in Tali using dup
 
-{ 5 dup -> 5 5 }
-{ 5 duP -> 5 5 }
-{ 5 dUp -> 5 5 }
-{ 5 dUP -> 5 5 }
-{ 5 Dup -> 5 5 }
-{ 5 DuP -> 5 5 }
-{ 5 DUp -> 5 5 }
-{ 5 DUP -> 5 5 }
+T{ 5 dup -> 5 5 }T
+T{ 5 duP -> 5 5 }T
+T{ 5 dUp -> 5 5 }T
+T{ 5 dUP -> 5 5 }T
+T{ 5 Dup -> 5 5 }T
+T{ 5 DuP -> 5 5 }T
+T{ 5 DUp -> 5 5 }T
+T{ 5 DUP -> 5 5 }T
 
 \ Free memory used for these tests
 tali_tests

--- a/tests/tester.fs
+++ b/tests/tester.fs
@@ -6,6 +6,9 @@
 \ The main change is lowercasing all of the words as Tali
 \ is case sensitive, as well as replacing tabs with spaces.
 \ A word to display the actual (erroneous) results was also added.
+\ Modified by SamCo 2018-10 to facilitate using standard ANS tests.
+\ The testing words were changed from { and } to T{ and }T to
+\ match the testing words currently being used by ANS standard tests.
 
 \ (C) 1995 JOHNS HOPKINS UNIVERSITY / APPLIED PHYSICS LABORATORY
 \ MAY BE DISTRIBUTED FREELY AS LONG AS THIS COPYRIGHT NOTICE REMAINS.
@@ -46,7 +49,7 @@ create actual-results  20 cells allot
    show-results ;   \ added by SamCo to show what actually happened
 
 \ Syntactic sugar
-: {  ( -- ) ;
+: T{  ( -- ) ;
 
 \ Record depth and content of stack
 : ->  ( ... -- ) 
@@ -58,7 +61,7 @@ create actual-results  20 cells allot
    then ;
 
 \ Compare stack (expected) contents with saved (actual) contents
-: }  ( ... -- ) 
+: }T  ( ... -- ) 
    depth actual-depth @ = if     \ if depths match
       depth ?dup if              \ if there is something on the stack
          0 do                    \ for each stack item

--- a/tests/user.fs
+++ b/tests/user.fs
@@ -3,9 +3,9 @@
 \ FILE        : user.fs
 \ DESCRIPTION : This file is for users to add their own tests to the
 \ test suite.  To add a test, the syntax is:
-\ { data_for_word word_to_test -> expected_results }
+\ T{ data_for_word word_to_test -> expected_results }T
 \ eg.
-\ { 5 dup -> 5 5 }
+\ T{ 5 dup -> 5 5 }T
 \ If the test passes, Tali will simply report "ok".  If the test does
 \ not pass, an error message will be printed.  Results are logged in
 \ the file results.txt and users can run just this set of tests using


### PR DESCRIPTION
Solution for #134.

I also modified the Makefile to list talitest.py, all of the test *.fs files, and the taliforth-py65mon.bin as dependencies for the "tests" target.  This means if any of them change, the command `make tests` will rerun the tests, however if none of them have changed it will just let you know you don't need to re-run the tests.  You can always force it with the -B option (forces make to run the commands even if it thinks it doesn't need to), and you also can always run the tests yourself the normal way.  If you add a new test source file, you will want to add it to the TEST_SOURCES line in the Makefile.

I'll also provide a brief description of what's going on in this particular Makefile, for reference in the future, in case you need to edit this Makefile.  You are welcome to ignore everything past this point, but it may be handy in the future (if you remember it's here).

From the top to the bottom:

The COMMON_SOURCES and TEST_SOURCES are just setting some variables.  In this case, it's a list of files needed to build something.  The COMMON_SOURCES are used to build any version of a _taliforth-*.bin_ file, and the TEST_SOURCES are a list of the files needed to generate _results.txt_ in the tests folder.  Lists of files are very common here, and they are just space separated.  All file names here should be given as accessed from the main folder (relative paths.)

When make finds a line with a name followed by a colon, the name is called a "target".  Think of these kind of like assembly labels.  The first target listed is the one that gets made when you just run `make` with no arguments, so the order is a little important.  In this case, the first target is _all_.  Just running `make` is the same as running `make all` for this Makefile.  After the first target, the order of the remaining targets does not matter at all.  Targets can just be made-up names, or they can be the names of files.  _all_, _tests_, and _sim_ are the made up names in this Makefile, and all the others are the names of files (some with wildcards in them).

After each target (after the colon and at least one space) is a "prerequisite list".  This is just a list of other targets that this target needs in order to be "made".  All of the items listed in the prerequisite list need to be either file names (which may or may not be targets in the Makefile) or made-up names (which MUST be targets somewhere in the Makefile).  The two prerequisites for _all_ are _taliforth-py65mon.bin_ and _WORDLIST.md_.  The pipe symbol has special meaning to control the order some things are done in, and I believe it's here to make sure the bin file is made before the wordlist is generated.  I don't normally use it, so I don't understand it fully.  On the lines with $(variables) in them, we are just using the list of files we stored in variables up at the top.

On the next line after each target is a list of commands (called a _recipe_) to run to "make" that target.  It's important that all of these command lines _**MUST START WITH ONE TAB**_.  This is very important.  It cannot be spaces.  You can run as many commands as you need, in the order they are listed, but each line needs to have a TAB in front.  It's also worth knowing that a separate shell is spawned for each line, so if you need to do something like cd first, it needs to be done on the same line (use `;` to separate commands).  You can see an example of this in the recipe for the tests/results.txt target.

Each combination of a target/prerequisite line followed by zero or more recipe lines is called a _rule_.  Make reads in all of the rules and sees how they connect.  If you know any graph theory, I should be able to just say that make creates a dependency graph in memory.  When you ask make to make a target, it will check the prerequisites.  If a given prerequisite is a target in a different rule (either as a made-up name or as a file name), make will check that rule FIRST.

If a rule has a file as the target and files as the prerequisites, it will run the recipe only if the timestamp on any of the prerequisite files is newer than the timestamp on the target.  This saves you from rebuilding a files whose sources have not changed, but it does depend on you accurately telling make about all of the sources required for that target file.

Lets see what happens if I change the native_words.asm file.  We start at _all_, which needs taliforth-py65mon.bin, so we call that rule.  This rule uses a wildcard (the % character), and whatever it matches in the target can be matched in the prerequisites by using % again (and this Makefile does that).  This shows that taliforth-py65mon.bin depends on platform/platform-py65mon.asm as well as all of the files listed in COMMON_SOURCES_, which includes the native-words.asm file.  Because we have just modified the native-words.asm file, it's timestamp is NEWER than the taliforth-py65mon.bin file, so the recipe is run to "make" taliforth-py65mon.bin.  The \ (followed immediately by a newline) allows you to continue a line on the next line, but that next line still needs the tab at the beginning.  The $@ is the name of the target and the $< is the first prerequisite listed.

It's also worth noting that if the target is missing, the recipe will also be run in an attempt to make the file exist in the first place.

If any of the listed prerequisistes had a target in the makefile, those rules would be checked FIRST, before running the recipe, to make sure all the prerequisites are as new as they can be before comparing against the timestamp of the current target.  In this case, the user-words.asc and forth-words.asc rules would be checked (using the %.asc target), but the recipes would not be run because the .asc files are newer than the .fs files they have as prerequisites.

_taliforth-py65mon.bin_ is now complete, so we return to the _all_ target and process WORDLIST.md.  I just noticed that this actually falls into the "made-up" names category as we never make a WORDLIST.md file in the current directory - the file we make is docs/WORDLIST.md.  I suppose that explains why this rule always runs its recipe every time I make.  I'm not sure if that was intentional or not, but that's the way it's currently written.  This rule will always run because the file is missing (and never created) in the main directory.  Also, make doesn't check to see if the file actually was made.  It just checks that all of the commands ran with no error codes returned.

In this case, the prerequisites for _all_ have been completed, so make goes to run the recipe for _all_, but it's blank, so make is now done.  If you run make again, it will only make the wordlist (because it will try every time, in this case), but it will not run the ophis assembler again.  It will only do that if any of the sources for Tali change.

Note that the _all_ target does not have the tests in it, and none of the prerequisites have the tests in them, so when you just run `make` it will not run the the tests.  If you run `make tests`, on the other hand, it see it needs tests/results.txt and will run the commands to make it, but only if the taliforth-py65mon.bin file (or any of it prerequisites) has changed or if the tests have changed.

As one final example, so show the power of make, if you change something in forth-code/user-words.asc, and then run `make tests`, make will run the recipes (in this order):
user-words.asc (using the wildcard)
taliforth-py65mon.bin (using the wildcard)
tests/results.txt
and finally tests, which is a made-up name that is provided because it's easier to type than tests/results.txt

