### PR TITLE
Final fix to Makefile for docs/WORDLIST.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 COMMON_SOURCES=taliforth.asm definitions.asm native_words.asm headers.asm strings.asm forth_words.asc user_words.asc
 TEST_SOURCES=tests/core.fs tests/string.fs tests/double.fs tests/facility.fs tests/stringlong.fs tests/tali.fs tests/tools.fs tests/block.fs tests/user.fs tests/cycles.fs tests/talitest.py
 
-all: taliforth-py65mon.bin | WORDLIST.md
+all: taliforth-py65mon.bin docs/WORDLIST.md
 
 taliforth-%.bin: platform/platform-%.asm $(COMMON_SOURCES)
 	ophis -l docs/$*-listing.txt \
@@ -22,7 +22,7 @@ taliforth-%.bin: platform/platform-%.asm $(COMMON_SOURCES)
 # Automatically update the wordlist which also gives us the status of the words
 # We need for the binary to be generated first or else we won't be able to find
 # new words in the label listing
-WORDLIST.md: docs/WORDLIST.md
+docs/WORDLIST.md: taliforth-py65mon.bin
 	python3 tools/generate_wordlist.py > docs/WORDLIST.md
 
 


### PR DESCRIPTION
This makes it so the docs/WORDLIST.md is only updated if taliforth-py65mon.bin has changed.  Previously it was regenerated every time make was run, whether it needed it or not.