### PR TITLE
Porting suggestions from Programmiernutte (interrupts/addressing)

### DIFF
--- a/native_words.asm
+++ b/native_words.asm
@@ -26,11 +26,6 @@
 ;       use the 65c02 reset for that. Flows into ABORT.
 ;       """
 xt_cold:        
-                ; Since the default case for Tali is the py65mon emulator, we
-                ; have no use for interrupts. If you are going to include
-                ; them in your system in any way, you're going to have to
-                ; do it from scratch. Sorry.
-                sei
                 cld
  
                 ; Set the OUTPUT vector to the default kernel_putc

--- a/platform/platform-py65mon.asm
+++ b/platform/platform-py65mon.asm
@@ -132,6 +132,12 @@ kernel_init:
         ; back to the label forth to start the Forth system.
         ; """
 .scope
+                ; Since the default case for Tali is the py65mon emulator, we
+                ; have no use for interrupts. If you are going to include
+                ; them in your system in any way, you're going to have to
+                ; do it from scratch. Sorry.
+                sei             ; Disable interrupts
+                
                 ; We've successfully set everything up, so print the kernel
                 ; string
                 ldx #0

--- a/taliforth.asm
+++ b/taliforth.asm
@@ -5,9 +5,6 @@
 
 ; This is the main file for Tali Forth 2
 
-; By default, we have 32 KiB of RAM and 32 KiB of ROM. See docs/memorymap.txt
-; for details
-.advance $8000
 
 ; Label used to calculate UNUSED. Silly for Tali Forth, where we assume
 ; 32 KiB RAM and 32 KiB ROM, but kept here to make the code more useful


### PR DESCRIPTION
Fix for #148.  

Moved SEI instruction out of **COLD** and into into **kernel_init:** in platform-py65mon.asm, as whether or not to use interrupts will be a platform-specific decision.

Removed .advance $8000 in taliforth.asm as the address specified in the platform file should be used.

NOTE: I didn't add the generated files to help reduce the conflicts when merging, so you will need to reassemble taliforth-py65mon.bin after merging (just running `make tests` should rebuild Tali and then run all of the tests too).
