### PR TITLE
Update makefile so WORDLIST.md will be regenerated for target gitready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,4 @@ docsmd: docs/manual.html
 	cd docs; ./asciidoc_to_markdown.sh 
 
 # A convenience target for preparing for a git commit.
-gitready: docs taliforth-py65mon.bin tests
+gitready: docs all tests


### PR DESCRIPTION
Have WORDLIST.md be regenerated when making the "gitready" target.  The idea is that you can just run `make gitready` from the main Tali folder before committing changes with git.  If everything is already done, it will say `make: Nothing to be done for 'gitready'.`, but if any steps need to done, it will do them for you.

Let me know if you want your asciidoc_to_markdown.sh script run every time for commits as well.