### PR TITLE
Added ed tests to Makefile for tests target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # expected to have the asciidoc toolchain installed
 
 COMMON_SOURCES=taliforth.asm definitions.asm native_words.asm headers.asm strings.asm forth_words.asc user_words.asc disassembler.asm ed.asm
-TEST_SOURCES=tests/core.fs tests/string.fs tests/double.fs tests/facility.fs tests/stringlong.fs tests/tali.fs tests/tools.fs tests/block.fs tests/user.fs tests/cycles.fs tests/talitest.py
+TEST_SOURCES=tests/core.fs tests/string.fs tests/double.fs tests/facility.fs tests/stringlong.fs tests/tali.fs tests/tools.fs tests/block.fs tests/user.fs tests/cycles.fs tests/talitest.py tests/ed.fs
 
 all: taliforth-py65mon.bin docs/WORDLIST.md
 


### PR DESCRIPTION
This goes along with #159 
It adds ed.fs to the list of test sources so that the tests will be re-run for a `make tests` (or `make gitready`) if the ed.fs file is modified.