### PR TITLE
  Feature/glossary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ sim:	taliforth-py65mon.bin
 docs/manual.html: docs/*.adoc 
 	cd docs; asciidoctor -a toc=left manual.adoc
 
+docs/ch_glossary.adoc:	native_words.asm
+	tools/generate_glossary.py > docs/ch_glossary.adoc
+
 # The diagrams use ditaa to generate pretty diagrams from text files.
 # They have their own makefile in the docs/pics directory.
 docs-diagrams: docs/pics/*.txt

--- a/docs/ch_glossary.adoc
+++ b/docs/ch_glossary.adoc
@@ -1,0 +1,1485 @@
+[horizontal]
+`!`:: _ANS core_ ( n addr -- ) "Store TOS in memory"
+https://forth-standard.org/standard/core/Store
+
+`#`:: _ANS core_ ( ud -- ud ) "Add character to pictured output string"
+https://forth-standard.org/standard/core/num
+Add one char to the beginning of the pictured output string. Based
+on https://github.com/philburk/pforth/blob/master/fth/numberio.fth
+Forth code  BASE @ UD/MOD ROT 9 OVER < IF 7 + THEN [CHAR] 0 + HOLD
+
+
+`#>`:: _ANS core_ ( d -- addr u ) "Finish pictured number conversion"
+https://forth-standard.org/standard/core/num-end
+Finish conversion of pictured number string, putting address and
+length on the Data Stack. Original Fort is  2DROP HLD @ PAD OVER -
+Based on
+https://github.com/philburk/pforth/blob/master/fth/numberio.fth
+
+
+`#s`:: _ANS core_ ( d -- addr u ) "Completely convert pictured output"
+https://forth-standard.org/standard/core/numS
+Completely convert number for pictured numerical output. Based on
+https://github.com/philburk/pforth/blob/master/fth/system.fth
+Original Forth code  BEGIN # 2DUP OR 0= UNTIL
+
+
+`'`:: _ANS core_ ( "name" -- xt ) "Return a word's execution token (xt)"
+https://forth-standard.org/standard/core/Tick
+
+`(`:: _ANS core_ ( -- ) "Discard input up to close paren ( comment )"
+http://forth-standard.org/standard/core/p
+
+`*`:: _ANS core_ ( n n -- n ) "16*16 --> 16 "
+https://forth-standard.org/standard/core/Times
+Multiply two signed 16 bit numbers, returning a 16 bit result.
+This is nothing  more than UM* DROP
+
+
+`*/`:: _ANS core_ ( n1 n2 n3 -- n4 ) "n1 * n2 / n3 -->  n"
+https://forth-standard.org/standard/core/TimesDiv
+Multiply n1 by n2 and divide by n3, returning the result
+without a remainder. This is */MOD without the mod, and
+can be defined in Fort as : */  */MOD SWAP DROP ; which is
+pretty much what we do here
+
+
+`*/mod`:: _ANS core_ ( n1 n2 n3 -- n4 n5 ) "n1 * n2 / n3 --> n-mod n"
+https://forth-standard.org/standard/core/TimesDivMOD
+Multiply n1 by n2 producing the intermediate double-cell result
+d. Divide d by n3 producing the single-cell remainder n4 and the
+single-cell quotient n5. In Forth, this is
+: */MOD  >R M* >R SM/REM ;  Note that */ accesses this routine.
+
+
+`+`:: _ANS core_ ( n n -- n ) "Add TOS and NOS"
+https://forth-standard.org/standard/core/Plus
+
+`+!`:: _ANS core_ ( n addr -- ) "Add number to value at given address"
+https://forth-standard.org/standard/core/PlusStore
+
+`+loop`:: _ANS core_ ( -- ) "Finish loop construct"
+https://forth-standard.org/standard/core/PlusLOOP
+Compile-time part of +LOOP, also used for LOOP. Is usually
+: +LOOP POSTPONE (+LOOP) , POSTPONE UNLOOP ; IMMEDIATE
+COMPILE-ONLY
+in Forth. LOOP uses this routine as well. We jump here with the
+address for looping as TOS and the address for aborting the loop
+(LEAVE) as the second double-byte entry on the Return Stack (see
+DO and docs/loops.txt for details).
+
+
+`,`:: _ANS core_ ( n -- ) "Allot and store one cell in memory"
+https://forth-standard.org/standard/core/Comma
+Store TOS at current place in memory. Since this an eight-bit
+machine, we can ignore all alignment issures.
+
+
+`-`:: _ANS core_ ( n n -- n ) "Subtract TOS from NOS"
+https://forth-standard.org/standard/core/Minus
+
+`-leading`:: _Tali String_ ( addr1 u1 -- addr2 u2 ) "Remove leading spaces"
+Remove leading whitespace. This is the reverse of -TRAILING
+
+
+`-rot`:: _Gforth_ ( a b c -- c a b ) "Rotate upwards"
+http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Data-stack.html
+
+`-trailing`:: _ANS string_ ( addr u1 -- addr u2 ) "Remove trailing spaces"
+https://forth-standard.org/standard/string/MinusTRAILING
+Remove trailing spaces
+
+
+`.`:: _ANS core_ ( u -- ) "Print TOS"
+https://forth-standard.org/standard/core/d
+
+`."`:: _ANS core ext_ ( "string" -- ) "Print string from compiled word"
+https://forth-standard.org/standard/core/Dotq
+Compile string that is printed during run time. ANS Forth wants
+this to be compile-only, even though everybody and their friend
+uses it for everything. We follow the book here, and recommend
+.( for general printing
+
+
+`.(`:: _ANS core_ ( -- ) "Print input up to close paren .( comment )"
+http://forth-standard.org/standard/core/Dotp
+
+`.r`:: _ANS core ext_ ( n u -- ) "Print NOS as unsigned number with TOS with"
+https://forth-standard.org/standard/core/DotR
+Based on the Forth code
+: .R  >R DUP ABS 0 <# #S ROT SIGN #> R> OVER - SPACES TYPE
+
+
+`.s`:: _ANS tools _ ( -- ) "Print content of Data Stack"
+https://forth-standard.org/standard/tools/DotS
+Print content of Data Stack non-distructively. Since this is for
+humans, we don't have to worry about speed. We follow the format
+of Gforth and print the number of elements first in brackets,
+followed by the Data Stack content (if any).
+
+
+`/`:: _ANS core_ ( n1 n2 -- n ) "Divide NOS by TOS"
+https://forth-standard.org/standard/core/Div
+Forth code is either  >R S>D R> FM/MOD SWAP DROP
+or >R S>D R> SM/REM SWAP DROP -- we use SM/REM in Tali Forth.
+This code is currently unoptimized. This code without the SLASH
+DROP at the end is /MOD, so we share the code as far as possible.
+
+
+`/mod`:: _ANS core_ ( n1 n2 -- n3 n4 ) "Divide NOS by TOS with a remainder"
+https://forth-standard.org/standard/core/DivMOD
+This is a dummy entry, the actual code is shared with SLASH
+
+
+`/string`:: _ANS string_ ( addr u n -- addr u ) "Shorten string by n"
+https://forth-standard.org/standard/string/DivSTRING
+Forth code is
+: /STRING ( ADDR U N -- ADDR U ) ROT OVER + ROT ROT -
+Put differently, we need to add TOS and 3OS, and subtract
+TOS from NOS, and then drop TOS
+
+
+`0`:: _Tali Forth_ ( -- 0 ) "Push 0 to Data Stack"
+; """The disassembler assumes that this routine does not use Y. Note
+that CASE and FORTH-WORDLIST use the same routine, as the WD for Forth
+is 0.
+
+`0<`:: _ANS core_ ( n -- f ) "Return a TRUE flag if TOS negative"
+https://forth-standard.org/standard/core/Zeroless
+
+`0<>`:: _ANS core ext_ ( m -- f ) "Return TRUE flag if not zero"
+https://forth-standard.org/standard/core/Zerone
+
+`0=`:: _ANS core_ ( n -- f ) "Check if TOS is zero"
+https://forth-standard.org/standard/core/ZeroEqual
+
+`0>`:: _ANS core ext_ ( n -- f ) "Return a TRUE flag if TOS is positive"
+https://forth-standard.org/standard/core/Zeromore
+
+`1`:: _Tali Forth_ ( -- n ) "Push the number 1 to the Data Stack"
+This is also the code for EDITOR-WORDLIST
+
+`1+`:: _ANS core_ ( u -- u+1 ) "Increase TOS by one"
+https://forth-standard.org/standard/core/OnePlus
+Code is shared with CHAR-PLUS
+
+
+`1-`:: _ANS core_ ( u -- u-1 ) "Decrease TOS by one"
+https://forth-standard.org/standard/core/OneMinus
+
+`2`:: _Tali Forth_ ( -- u ) "Push the number 2 to stack"
+This code is shared with ASSEMBLER-WORDLIST
+
+`2!`:: _ANS core_ ( n1 n2 addr -- ) "Store two numbers at given address"
+https://forth-standard.org/standard/core/TwoStore
+Stores so n2 goes to addr and n1 to the next consecutive cell.
+Is equivalent to  SWAP OVER ! CELL+ !
+
+
+`2*`:: _ANS core_ ( n -- n ) "Multiply TOS by two"
+https://forth-standard.org/standard/core/TwoTimes
+Also used for CELLS
+
+
+`2/`:: _ANS core_ ( n -- n ) "Divide TOS by two"
+https://forth-standard.org/standard/core/TwoDiv
+
+`2>r`:: _ANS core ext_ ( n1 n2 -- )(R: -- n1 n2 "Push top two entries to Return Stack"
+https://forth-standard.org/standard/core/TwotoR
+Push top two entries to Return Stack. The same as SWAP >R >R
+except that if we jumped here, the return address will be in the
+way. May not be natively compiled unless we're clever and use
+special routines.
+
+
+`2@`:: _ANS core_ ( addr -- n1 n2 ) "Fetch the cell pair n1 n2 stored at addr"
+https://forth-standard.org/standard/core/TwoFetch
+Note n2 stored at addr and n1 in the next cell -- in our case,
+the next byte. This is equvalent to  DUP CELL+ @ SWAP @
+
+
+`2constant`:: _ANS double_ (C: d "name" -- ) ( -- d) "Create a constant for a double word"
+https://forth-standard.org/standard/double/TwoCONSTANT
+Based on the Forth code
+: 2CONSTANT ( D -- )  CREATE SWAP , , DOES> DUP @ SWAP CELL+ @
+
+
+`2drop`:: _ANS core_ ( n n -- ) "Drop TOS and NOS"
+https://forth-standard.org/standard/core/TwoDROP
+
+`2dup`:: _ANS core_ ( a b -- a b a b ) "Duplicate first two stack elements"
+https://forth-standard.org/standard/core/TwoDUP
+
+`2literal`:: _ANS double_ (C: d -- ) ( -- d) "Compile a literal double word"
+https://forth-standard.org/standard/double/TwoLITERAL
+Based on the Forth code
+: 2LITERAL ( D -- ) SWAP POSTPONE LITERAL POSTPONE LITERAL ; IMMEDIATE
+
+
+`2over`:: _ANS core_ ( d1 d2 -- d1 d2 d1 ) "Copy double word NOS to TOS"
+https://forth-standard.org/standard/core/TwoOVER
+
+`2r>`:: _ANS core ext_ ( -- n1 n2 ) (R: n1 n2 -- ) "Pull two cells from Return Stack"
+https://forth-standard.org/standard/core/TwoRfrom
+Pull top two entries from Return Stack. Is the same as
+R> R> SWAP. As with R>, the problem with the is word is that
+the top value on the ReturnStack for a STC Forth is the
+return address, which we need to get out of the way first.
+Native compile needs to be handled as a special case.
+
+
+`2r@`:: _ANS core ext_ ( -- n n ) "Copy top two entries from Return Stack"
+https://forth-standard.org/standard/core/TwoRFetch
+This is R> R> 2DUP >R >R SWAP but we can do it a lot faster in
+assembler. We use trickery to access the elements on the Return
+Stack instead of pulling the return address first and storing
+it somewhere else like for 2R> and 2>R. In this version, we leave
+it as Never Native; at some point, we should compare versions to
+see if an Always Native version would be better
+
+
+`2swap`:: _ANS core_ ( n1 n2 n3 n4 -- n3 n4 n1 n1 ) "Exchange two double words"
+https://forth-standard.org/standard/core/TwoSWAP
+
+`2variable`:: _ANS double_ ( "name" -- ) "Create a variable for a double word"
+https://forth-standard.org/standard/double/TwoVARIABLE
+This can be realized in Forth as either
+CREATE 2 CELLS ALLOT  or just  CREATE 0 , 0 ,
+Note that in this case, the variable is not initialized to
+zero
+
+`:`:: _ANS core_ ( "name" -- ) "Start compilation of a new word"
+https://forth-standard.org/standard/core/Colon
+Use the CREATE routine and fill in the rest by hand.
+
+
+`:NONAME`:: _ANS core_ ( -- ) "Start compilation of a new word""
+https://forth-standard.org/standard/core/ColonNONAME
+Compile a word with no nt.  ";" will put its xt on the stack.
+
+
+`;`:: _ANS core_ ( -- ) "End compilation of new word"
+https://forth-standard.org/standard/core/Semi
+End the compilation of a new word into the Dictionary. When we
+enter this, WORKWORD is pointing to the nt_ of this word in the
+Dictionary, DP to the previous word, and CP to the next free byte.
+A Forth definition would be (see "Starting Forth"):
+: POSTPONE EXIT  REVEAL POSTPONE ; [ ; IMMEDIATE  Following the
+practice of Gforth, we warn here if a word has been redefined.
+
+
+`<`:: _ANS core_ ( n m -- f ) "Return true if NOS < TOS"
+https://forth-standard.org/standard/core/less
+
+`<#`:: _ANS core_ ( -- ) "Start number conversion"
+https://forth-standard.org/standard/core/num-start
+Start the process to create pictured numeric output. The new
+string is constructed from back to front, saving the new character
+at the beginning of the output string. Since we use PAD as a
+starting address and work backward (!), the string is constructed
+in the space between the end of the Dictionary (as defined by CP)
+and the PAD. This allows us to satisfy the ANS Forth condition that
+programs don't fool around with the PAD but still use its address.
+Based on pForth
+http://pforth.googlecode.com/svn/trunk/fth/numberio.fth
+pForth is in the pubic domain. Forth is : <# PAD HLD ! ; we use the
+internal variable tohold instead of HLD.
+
+
+`<>`:: _ANS core ext_ ( n m -- f ) "Return a true flag if TOS != NOS"
+https://forth-standard.org/standard/core/ne
+This is just a variant of EQUAL, we code it separately
+for speed.
+
+
+`=`:: _ANS core_ ( n n -- f ) "See if TOS and NOS are equal"
+https://forth-standard.org/standard/core/Equal
+
+`>`:: _ANS core_ ( n n -- f ) "See if NOS is greater than TOS"
+https://forth-standard.org/standard/core/more
+
+`>body`:: _ANS core_ ( xt -- addr ) "Return a word's Code Field Area (CFA)"
+https://forth-standard.org/standard/core/toBODY
+Given a word's execution token (xt), return the address of the
+start of that word's parameter field (PFA). This is defined as the
+address that HERE would return right after CREATE. This is a
+difficult word for STC Forths, because most words don't actually
+have a Code Field Area (CFA) to skip. We solve this by having CREATE
+add a flag, "has CFA" (HC), in the header so >BODY know to skip
+the subroutine jumps to DOVAR, DOCONST, or DODOES
+
+
+`>in`:: _ANS core_ ( -- addr ) "Return address of the input pointer"
+`>number`:: _ANS core_ ( ud addr u -- ud addr u ) "Convert a number"
+https://forth-standard.org/standard/core/toNUMBER
+Convert a string to a double number. Logic here is based on the
+routine by Phil Burk of the same name in pForth, see
+https://github.com/philburk/pforth/blob/master/fth/numberio.fth
+for the original Forth code. We arrive here from NUMBER which has
+made sure that we don't have to deal with a sign and we don't have
+to deal with a dot as a last character that signalizes double -
+this should be a pure number string. This routine calles UM*, which
+uses tmp1, tmp2 and tmp3, so we cannot access any of those.
+
+`>order`:: _Gforth search_ ( wid -- ) "Add wordlist at beginning of search order"
+https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Word-Lists.html
+
+`>r`:: _ANS core_ ( n -- )(R: -- n) "Push TOS to the Return Stack"
+https://forth-standard.org/standard/core/toR
+This word is handled differently for native and for
+subroutine coding, see COMPILE, . This is a complile-only
+word.
+
+
+`?`:: _ANS tools_ ( addr -- ) "Print content of a variable"
+https://forth-standard.org/standard/tools/q
+Only used interactively. Since humans are so slow, we
+save size and just go for the subroutine jumps
+
+
+`?do`:: _ANS core ext_ ( limit start -- )(R: -- limit start) "Conditional loop start"
+https://forth-standard.org/standard/core/qDO
+
+`?dup`:: _ANS core_ ( n -- 0 | n n ) "Duplicate TOS non-zero"
+https://forth-standard.org/standard/core/qDUP
+
+`@`:: _ANS core_ ( addr -- n ) "Push cell content from memory to stack"
+https://forth-standard.org/standard/core/Fetch
+
+`[`:: _ANS core_ ( -- ) "Enter interpretation state"
+https://forth-standard.org/standard/core/Bracket
+This is an immediate and compile-only word
+
+
+`[']`:: _ANS core_ ( -- ) "Store xt of following word during compilation"
+https://forth-standard.org/standard/core/BracketTick
+
+`[char]`:: _ANS core_ ( "c" -- ) "Compile character"
+https://forth-standard.org/standard/core/BracketCHAR
+Compile the ASCII value of a character as a literal. This is an
+immediate, compile-only word. A definition given in
+http://forth-standard.org/standard/implement is
+: [CHAR]  CHAR POSTPONE LITERAL ; IMMEDIATE
+
+
+`\`:: _ANS core ext_ ( -- ) "Ignore rest of line"
+https://forth-standard.org/standard/core/bs
+
+`]`:: _ANS core_ ( -- ) "Enter the compile state"
+https://forth-standard.org/standard/right-bracket
+This is an immediate word.
+
+
+`abort`:: _ANS core_ ( -- ) "Reset the Data Stack and restart the CLI"
+https://forth-standard.org/standard/core/ABORT
+Clear Data Stack and continue into QUIT. We can jump here via
+subroutine if we want to because we are going to reset the 65c02's
+stack pointer (the Return Stack) anyway during QUIT. Note we don't
+actually delete the stuff on the Data Stack
+
+
+`abort"`:: _ANS core_ ( "string" -- ) "If flag TOS is true, MESSAGE with message"
+https://forth-standard.org/standard/core/ABORTq
+Abort with a message
+
+
+`abs`:: _ANS core_ ( n -- u ) "Return absolute value of a number"
+https://forth-standard.org/standard/core/ABS
+Return the absolute value of a number.
+
+
+`accept`:: _ANS core _ ( addr n -- n ) "Receive a string of characters from the keyboard"
+https://forth-standard.org/standard/core/ACCEPT
+Receive a string of at most n1 characters, placing them at
+addr. Return the actual number of characters as n2. Characters
+are echoed as they are received. ACCEPT is called by REFILL in
+modern Forths.
+
+
+`action-of`:: _ANS core ext_ ( "name" -- xt ) "Get named deferred word's xt"
+http://forth-standard.org/standard/core/ACTION-OF
+
+`again`:: _ANS core ext_ ( addr -- ) "Code backwards branch to address left by BEGIN"
+https://forth-standard.org/standard/core/AGAIN
+
+`align`:: _ANS core_ ( -- ) "Make sure CP is aligned on word size"
+https://forth-standard.org/standard/core/ALIGN
+On a 8-bit machine, this does nothing. ALIGNED uses
+this routine as well, and also does nothing
+## ALIGNED ( addr -- addr ) "Return the first aligned address
+## "aligned"  auto  ANS core
+
+`allot`:: _ANS core_ ( n -- ) "Reserve or release memory"
+https://forth-standard.org/standard/core/ALLOT
+Reserve a certain number of bytes (not cells) or release them.
+If n = 0, do nothing. If n is negative, release n bytes, but only
+to the beginning of the Dictionary. If n is positive (the most
+common case), reserve n bytes, but not past the end of the
+Dictionary. See http://forth-standard.org/standard/core/ALLOT
+
+
+`allow-native`:: _Tali Forth_ ( -- ) "Flag last word to allow native compiling"
+`also`:: _ANS search ext_ ( -- ) "Make room in the search order for another wordlist"
+http://forth-standard.org/standard/search/ALSO
+
+`always-native`:: _Tali Forth_ ( -- ) "Flag last word as always natively compiled"
+`and`:: _ANS core_ ( n n -- n ) "Logically AND TOS and NOS"
+https://forth-standard.org/standard/core/AND
+
+`assembler-wordlist`:: _Tali Assembler_ ( -- u ) "WID for the Assembler wordlist"
+This is a dummy entry, the code is shared with TWO
+
+`at-xy`:: _ANS facility_ ( n m -- ) "Move cursor to position given"
+https://forth-standard.org/standard/facility/AT-XY
+On an ANS compatible terminal, place cursor at row n colum m.
+Code is ESC[<n>;<m>H Do not use U. to print the numbers because the
+trailing space will not work with xterm
+
+
+`base`:: _ANS core_ ( -- addr ) "Push address of radix base to stack"
+https://forth-standard.org/standard/core/BASE
+
+`begin`:: _ANS core_ ( -- addr ) "Mark entry point for loop"
+https://forth-standard.org/standard/core/BEGIN
+This is just an immediate version of here which could just
+as well be coded in Forth as
+: BEGIN HERE ; IMMEDIATE COMPILE-ONLY
+Since this is a compiling word, we don't care that much about
+about speed
+
+
+`bell`:: _Tali Forth_ ( -- ) "Emit ASCII BELL"
+`bl`:: _ANS core_ ( -- c ) "Push ASCII value of SPACE to stack"
+https://forth-standard.org/standard/core/BL
+
+`blank`:: _ANS string_ ( addr u -- ) "Fill memory region with spaces"
+https://forth-standard.org/standard/string/BLANK
+
+`blkbuffer`:: _Tali block_ ( -- addr ) "Push address of block buffer"
+`block`:: _ANS block_ ( u -- a-addr ) "Fetch a block into a buffer"
+https://forth-standard.org/standard/block/BLK
+https://forth-standard.org/standard/block/BLOCK
+
+`block-ramdrive-init`:: _Tali block_ ( u -- ) "Create a ramdrive for blocks"
+Create a RAM drive, with the given number of
+blocks, in the dictionary along with setting up the block words to
+use it.  The read/write routines do not provide bounds checking.
+Expected use: 4 block-ramdrive-init ( to create blocks 0-3 )
+
+
+`block-read`:: _Tali block_ ( addr u -- ) "Read a block from storage (deferred word)"
+BLOCK-READ is a vectored word that the user needs to override
+with their own version to read a block from storage.
+The stack parameters are ( buffer_address block# -- ).
+
+
+`block-read-vector`:: _Tali block_ ( -- addr ) "Address of the block-read vector"
+BLOCK-READ is a vectored word that the user needs to override
+with their own version to read a block from storage.
+This word gives the address of the vector so it can be replaced.
+
+
+`block-write`:: _Tali block_ ( addr u -- ) "Write a block to storage (deferred word)"
+BLOCK-WRITE is a vectored word that the user needs to override
+with their own version to write a block to storage.
+The stack parameters are ( buffer_address block# -- ).
+
+
+`block-write-vector`:: _Tali block_ ( -- addr ) "Address of the block-write vector"
+BLOCK-WRITE is a vectored word that the user needs to override
+with their own version to write a block to storage.
+This word gives the address of the vector so it can be replaced.
+
+
+`bounds`:: _Gforth_ ( addr u -- addr+u addr ) "Prepare address for looping"
+http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Memory-Blocks.html
+Given a string, return the correct Data Stack parameters for
+a DO/LOOP loop; over its characters. This is realized as
+OVER + SWAP in Forth, but we do it a lot faster in assembler
+
+
+`buffblocknum`:: _Tali block_ ( -- addr ) "Push address of variable holding block in buffer"
+`buffer`:: _ANS block_ ( u -- a-addr ) "Get a buffer for a block"
+https://forth-standard.org/standard/block/BUFFER
+
+`buffer:`:: _ANS core ext_ ( u "<name>" -- ; -- addr ) "Create an uninitialized buffer"
+https://forth-standard.org/standard/core/BUFFERColon
+Create a buffer of size u that puts its address on the stack
+when its name is used.
+
+
+`buffstatus`:: _Tali block_ ( -- addr ) "Push address of variable holding buffer status"
+`bye`:: _ANS tools ext_ ( -- ) "Break"
+https://forth-standard.org/standard/tools/BYE
+
+`c!`:: _ANS core_ ( c addr -- ) "Store character at address given"
+https://forth-standard.org/standard/core/CStore
+
+
+`c,`:: _ANS core_ ( c -- ) "Store one byte/char in the Dictionary"
+https://forth-standard.org/standard/core/CComma
+
+`c@`:: _ANS core_ ( addr -- c ) "Get a character/byte from given address"
+https://forth-standard.org/standard/core/CFetch
+
+`case`:: _ANS core ext_ (C: -- 0) ( -- ) "Conditional flow control"
+http://forth-standard.org/standard/core/CASE
+This is a dummy header, CASE shares the actual code with ZERO.
+
+
+`cell+`:: _ANS core_ ( u -- u ) "Add cell size in bytes"
+https://forth-standard.org/standard/core/CELLPlus
+Add the number of bytes ("address units") that one cell needs.
+Since this is an 8 bit machine with 16 bit cells, we add two bytes.
+
+
+`cells`:: _ANS core_ ( u -- u ) "Convert cells to size in bytes"
+https://forth-standard.org/standard/core/CELLS
+Dummy entry for the CELLS word, the code is the same as for
+2*, which is where the header directs us to
+
+
+`char`:: _ANS core_ ( "c" -- u ) "Convert character to ASCII value"
+https://forth-standard.org/standard/core/CHAR
+
+`char+`:: _ANS core_ ( addr -- addr+1 ) "Add the size of a character unit to address"
+https://forth-standard.org/standard/core/CHARPlus
+This is a dummy entry, the code is shared with ONE_PLUS
+
+
+`chars`:: _ANS core_ ( n -- n ) "Number of bytes that n chars need"
+https://forth-standard.org/standard/core/CHARS
+Return how many address units n chars are. Since this is an 8 bit
+machine, this does absolutely nothing and is included for
+compatibility with other Forth versions
+
+
+`cleave`:: _Tali Forth_ ( addr u -- addr2 u2 addr1 u1 ) "Split off word from string"
+`cmove`:: _ANS string_ ( addr1 addr2 u -- ) "Copy bytes going from low to high"
+https://forth-standard.org/standard/string/CMOVE
+Copy u bytes from addr1 to addr2, going low to high (addr2 is
+larger than addr1). Based on code in Leventhal, Lance A.
+6502 Assembly Language Routines", p. 201, where it is called
+move left". There are no official tests for this word.
+
+
+`cmove>`:: _ANS string_ ( add1 add2 u -- ) "Copy bytes from high to low"
+https://forth-standard.org/standard/string/CMOVEtop
+Based on code in Leventhal, Lance A. "6502 Assembly Language
+Routines", p. 201, where it is called "move right". There are
+no official tests for this word.
+
+
+`cold`:: _Tali Forth_ ( -- ) "Reset the Forth system"
+Reset the Forth system. Does not restart the kernel,
+use the 65c02 reset for that. Flows into ABORT.
+
+
+`compare`:: _ANS string_ ( addr1 u1 addr2 u2 -- -1 | 0 | 1) "Compare two strings"
+https://forth-standard.org/standard/string/COMPARE
+Compare string1 (denoted by addr1 u1) to string2 (denoted by
+addr2 u2).  Return -1 if string1 < string2, 0 if string1 = string2
+and 1 if string1 > string2 (ASCIIbetical comparison).  A string
+that entirely matches the beginning of the other string, but is
+shorter, is considered less than the longer string.
+
+
+`compile,`:: _ANS core ext_ ( xt -- ) "Compile xt"
+https://forth-standard.org/standard/core/COMPILEComma
+Compile the given xt in the current word definition. It is an
+error if we are not in the compile state. Because we are using
+subroutine threading, we can't use , (COMMA) to compile new words
+the traditional way. By default, native compiled is allowed, unless
+there is a NN (Never Native) flag associated. If not, we use the
+value NC_LIMIT (from definitions.tasm) to decide if the code
+is too large to be natively coded: If the size is larger than
+NC_LIMIT, we silently use subroutine coding. If the AN (Always
+Native) flag is set, the word is always natively compiled
+
+
+`compile-only`:: _Tali Forth_ ( -- ) "Mark most recent word as COMPILE-ONLY"
+Set the Compile Only flag (CO) of the most recently defined
+word. The alternative way to do this is to define a word
+?COMPILE that makes sure  we're in compile mode
+
+
+`constant`:: _ANS core_ ( n "name" -- ) "Define a constant"
+https://forth-standard.org/standard/core/CONSTANT
+Forth equivalent is  CREATE , DOES> @  but we do
+more in assembler and let CREATE do the heavy lifting.
+See http://www.bradrodriguez.com/papers/moving3.htm for
+a primer on how this works in various Forths. This is the
+same code as VALUE in our case.
+
+
+`count`:: _ANS core_ ( c-addr -- addr u ) "Convert character string to normal format"
+https://forth-standard.org/standard/core/COUNT
+Convert old-style character string to address-length pair. Note
+that the length of the string c-addr ist stored in character length
+(8 bit), not cell length (16 bit). This is rarely used these days,
+though COUNT can also be used to step through a string character by
+character.
+
+
+`cr`:: _ANS core_ ( -- ) "Print a line feed"
+https://forth-standard.org/standard/core/CR
+
+`create`:: _ANS core_ ( "name" -- ) "Create Dictionary entry for 'name'"
+https://forth-standard.org/standard/core/CREATE
+See the drawing in headers.asm for details on the header
+
+
+`d+`:: _ANS double_ ( d d -- d ) "Add two double-celled numbers"
+https://forth-standard.org/standard/double/DPlus
+
+`d-`:: _ANS double_ ( d d -- d ) "Subtract two double-celled numbers"
+https://forth-standard.org/standard/double/DMinus
+
+`d.`:: _ANS double_ ( d -- ) "Print double"
+http://forth-standard.org/standard/double/Dd
+From the Forth code:
+: D. TUCK DABS <# #S ROT SIGN #> TYPE SPACE
+
+
+`d.r`:: _ANS double_ ( d u -- ) "Print double right-justified u wide"
+http://forth-standard.org/standard/double/DDotR
+
+`d>s`:: _ANS double_ ( d -- n ) "Convert a double number to single"
+https://forth-standard.org/standard/double/DtoS
+Though this is basically just DROP, we keep it
+separate so we can test for underflow
+
+
+`dabs`:: _ANS double_ ( d -- d ) "Return the absolute value of a double"
+https://forth-standard.org/standard/double/DABS
+
+`decimal`:: _ANS core_ ( -- ) "Change radix base to decimal"
+https://forth-standard.org/standard/core/DECIMAL
+
+`defer`:: _ANS core ext_ ( "name" -- ) "Create a placeholder for words by name"
+https://forth-standard.org/standard/core/DEFER
+Reserve an name that can be linked to various xt by IS. The
+ANS reference implementation is
+CREATE ['] ABORT , DOES> @ EXECUTE
+But we use this routine as a low-level word so things go faster
+
+`defer!`:: _ANS core ext_ ( xt2 x1 -- ) "Set xt1 to execute xt2"
+http://forth-standard.org/standard/core/DEFERStore
+
+`defer@`:: _ANS core ext_ ( xt1 -- xt2 ) "Get the current XT for a deferred word"
+http://forth-standard.org/standard/core/DEFERFetch
+
+`definitions`:: _ANS search_ ( -- ) "Make first wordlist in search order the current wordlist"
+`depth`:: _ANS core_ ( -- u ) "Get number of cells (not bytes) used by stack"
+https://forth-standard.org/standard/core/DEPTH
+
+`digit?`:: _Tali Forth_ ( char -- u f | char f ) "Convert ASCII char to number"
+Inspired by the pForth instruction DIGIT, see
+https://github.com/philburk/pforth/blob/master/fth/numberio.fth
+Rewritten from DIGIT>NUMBER in Tali Forth. Note in contrast to
+pForth, we get the base (radix) ourselves instead of having the
+user provide it. There is no standard name for this routine, which
+itself is not ANS; we use DIGIT? following pForth and Gforth.
+
+
+`disasm`:: _Tali Forth_ ( addr u -- ) "Disassemble a block of memory"
+Convert a segment of memory to assembler output. This
+word is vectored so people can add their own disassembler.
+Natively, this produces Simpler Assembly Notation (SAN)
+code, see the file disassembler.asm
+
+
+`dnegate`:: _ANS double_ ( d -- d ) "Negate double cell number"
+https://forth-standard.org/standard/double/DNEGATE
+
+`do`:: _ANS core_ ( limit start -- )(R: -- limit start)  "Start a loop"
+https://forth-standard.org/standard/core/DO
+Compile-time part of DO. Could be realized in Forth as
+: DO POSTPONE (DO) HERE ; IMMEDIATE COMPILE-ONLY
+but we do it in assembler for speed. To work with LEAVE, we compile
+a routine that pushes the end address to the Return Stack at run
+time. This is based on a suggestion by Garth Wilson, see
+docs/loops.txt for details. This may not be native compile. Don't
+check for a stack underflow
+
+
+`does>`:: _ANS core_ ( -- ) "Add payload when defining new words"
+https://forth-standard.org/standard/core/DOES
+Create the payload for defining new defining words. See
+http://www.bradrodriguez.com/papers/moving3.htm and
+docs/create-does.txt for a discussion of
+DOES>'s internal workings. This uses tmp1 and tmp2
+
+
+`drop`:: _ANS core_ ( u -- ) "Pop top entry on Data Stack"
+https://forth-standard.org/standard/core/DROP
+
+`dump`:: _ANS tools_ ( addr u -- ) "Display a memory region"
+https://forth-standard.org/standard/tools/DUMP
+DUMP's exact output is defined as "implementation dependent".
+This is in assembler because it is
+useful for testing and development, so we want to have it work
+as soon as possible. Uses TMP2
+
+
+`dup`:: _ANS core_ ( u -- u u ) "Duplicate TOS"
+https://forth-standard.org/standard/core/DUP
+
+`ed`:: _Tali Forth_ ( -- u ) "Line-based editor"
+Start the line-based editor ed6502. See separate file
+for details.
+
+
+`editor-wordlist`:: _Tali Editor_ ( -- u ) "WID for the Editor wordlist"
+This is a dummy entry, the code is shared with ONE
+
+`el`:: _Tali Editor_ ( line# -- ) "Erase the given line number"
+`else`:: _ANS core_ (C: orig -- orig) ( -- ) "Conditional flow control"
+http://forth-standard.org/standard/core/ELSE
+The code is shared with ENDOF
+
+
+`emit`:: _ANS core_ ( char -- ) "Print character to current output"
+https://forth-standard.org/standard/core/EMIT
+Run-time default for EMIT. The user can revector this by changing
+the value of the OUTPUT variable. We ignore the MSB completely, and
+do not check to see if we have been given a valid ASCII character.
+Don't make this native compile
+
+
+`empty-buffers`:: _ANS block ext_ ( -- ) "Empty all buffers without saving"
+https://forth-standard.org/standard/block/EMPTY-BUFFERS
+
+`endcase`:: _ANS core ext_ (C: case-sys -- ) ( x -- ) "Conditional flow control" 
+http://forth-standard.org/standard/core/ENDCASE
+
+`endof`:: _ANS core ext_ (C: case-sys1 of-sys1-- case-sys2) ( -- ) "Conditional flow control" 
+http://forth-standard.org/standard/core/ENDOF
+This is a dummy entry, the code is shared with ELSE
+
+
+`enter-screen`:: _Tali Editor_ ( scr# -- ) "Enter all lines for given screen"
+`environment?`:: _ANS core_ ( addr u -- 0 | i*x true )  "Return system information"
+https://forth-standard.org/standard/core/ENVIRONMENTq
+
+`erase`:: _ANS core ext_ ( addr u -- ) "Fill memory region with zeros"
+https://forth-standard.org/standard/core/ERASE
+Note that ERASE works with "address" units
+(bytes), not cells.
+
+
+`erase-screen`:: _Tali Editor_ ( scr# -- ) "Erase all lines for given screen"
+`evaluate`:: _ANS core_ ( addr u -- ) "Execute a string"
+https://forth-standard.org/standard/core/EVALUATE
+Set SOURCE-ID to -1, make addr u the input source, set >IN to zero.
+After processing the line, revert to old input source. We use this
+to compile high-level Forth words and user-defined words during
+start up and cold boot. In contrast to ACCEPT, we need to, uh,
+accept more than 255 characters here, even though it's a pain in
+8-bit.
+
+
+`execute`:: _ANS core_ ( xt -- ) "Jump to word based on execution token"
+https://forth-standard.org/standard/core/EXECUTE
+
+`execute-parsing`:: _Gforth_ ( addr u xt -- ) "Pass a string to a parsing word"
+https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/The-Input-Stream.html
+Execute the parsing word defined by the execution token (xt) on the
+string as if it were passed on the command line. See the file
+tests/tali.fs for examples. Note that this word is coded completely
+different in its Gforth version, see the file execute-parsing.fs
+(in /usr/share/gforth/0.7.3/compat/ on Ubuntu 18.04 LTS) for details.
+
+
+`exit`:: _ANS core_ ( -- ) "Return control to the calling word immediately"
+https://forth-standard.org/standard/core/EXIT
+If we're in a loop, we need to UNLOOP first and get everything
+we we might have put on the Return Stack off as well. This should
+be natively compiled
+
+
+`false`:: _ANS core ext_ ( -- f ) "Push flag FALSE to Data Stack"
+https://forth-standard.org/standard/core/FALSE
+
+`fill`:: _ANS core_ ( addr u char -- ) "Fill a memory region with a character"
+https://forth-standard.org/standard/core/FILL
+Fill u bytes of memory with char starting at addr. Note that
+this works on bytes, not on cells. On an 8-bit machine such as the
+65c02, this is a serious pain in the rear. It is not defined what
+happens when we reach the end of the address space
+
+
+`find`:: _ANS core_ ( caddr -- addr 0 | xt 1 | xt -1 ) "Find word in Dictionary"
+https://forth-standard.org/standard/core/FIND
+Included for backwards compatibility only, because it still
+can be found in so may examples. It should, however, be replaced
+by FIND-NAME. Counted string either returns address with a FALSE
+flag if not found in the Dictionary, or the xt with a flag to
+indicate if this is immediate or not. FIND is a wrapper around
+FIND-NAME, we get this all over with as quickly as possible. See
+https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Word-Lists.html
+https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html
+
+
+`find-name`:: _Gforth_ ( addr u -- nt|0 ) "Get the name token of input word"
+`flush`:: _ANS block_ ( -- ) "Save dirty buffers and empty buffers"
+https://forth-standard.org/standard/block/FLUSH
+
+`fm/mod`:: _ANS core_ ( d n1  -- rem n2 ) "Floored signed division"
+https://forth-standard.org/standard/core/FMDivMOD
+There are various ways to realize this. We follow EForth with
+DUP 0< DUP >R  IF NEGATE >R DNEGATE R> THEN >R DUP
+0<  IF R@ + THEN  R> UM/MOD R> IF SWAP NEGATE SWAP THEN
+See (http://www.forth.org/eforth.html). However you can also
+go FM/MOD via SM/REM (http://www.figuk.plus.com/build/arith.htm):
+DUP >R  SM/REM DUP 0< IF SWAP R> + SWAP 1+ ELSE  R> DROP THEN
+Note that by default, Tali Forth uses SM/REM for most things.
+
+
+`forth`:: _ANS search ext_ ( -- ) "Replace first WID in search order with Forth-Wordlist"
+https://forth-standard.org/standard/search/FORTH
+
+`forth-wordlist`:: _ANS search_ ( -- u ) "WID for the Forth Wordlist"
+https://forth-standard.org/standard/search/FORTH-WORDLIST
+This is a dummy entry, the actual code is shared with ZERO.
+
+`get-current`:: _ANS search_ ( -- wid ) "Get the id of the compilation wordlist"
+https://forth-standard.org/standard/search/GET-CURRENT
+
+`get-order`:: _ANS search_ ( -- wid_n .. wid_1 n) "Get the current search order"
+https://forth-standard.org/standard/search/GET-ORDER
+
+`here`:: _ANS core_ ( -- addr ) "Put Compiler Pointer on Data Stack"
+https://forth-standard.org/standard/core/HERE
+This code is also used by the assembler directive ARROW
+("->") though as immediate
+
+`hex`:: _ANS core ext_ ( -- ) "Change base radix to hexadecimal"
+https://forth-standard.org/standard/core/HEX
+
+`hexstore`:: _Tali _ ( addr1 u1 addr2 -- u2 ) "Change base radix to hexadecimal"
+Given a string addr1 u1 with numbers in the current base seperated
+by spaces, store the numbers at the address addr2, returning the
+number of elements. Non-number elements are skipped, an zero-length
+string produces a zero output.
+
+
+`hold`:: _ANS core_ ( char -- ) "Insert character at current output"
+https://forth-standard.org/standard/core/HOLD
+Insert a character at the current position of a pictured numeric
+output string on
+https://github.com/philburk/pforth/blob/master/fth/numberio.fth
+Forth code is : HOLD  -1 HLD +!  HLD @ C! ;  We use the the internal
+variable tohold instead of HLD.
+
+
+`i`:: _ANS core_ ( -- n )(R: n -- n)  "Copy loop counter to stack"
+https://forth-standard.org/standard/core/I
+Note that this is not the same as R@ because we use a fudge
+factor for loop control; see docs/loop.txt for details. We
+should make this native compile for speed.
+
+
+`if`:: _ANS core_ (C: -- orig) (flag -- ) "Conditional flow control"
+http://forth-standard.org/standard/core/IF
+
+`immediate`:: _ANS core_ ( -- ) "Mark most recent word as IMMEDIATE"
+https://forth-standard.org/standard/core/IMMEDIATE
+Make sure the most recently defined word is immediate. Will only
+affect the last word in the dictionary. Note that if the word is
+defined in ROM, this will have no affect, but will not produce an
+error message.
+
+
+`input`:: _Tali Forth_ ( -- addr ) "Return address of input vector"
+`input>r`:: _Tali Forth_ ( -- ) ( R: -- n n n n ) "Save input state to the Return Stack"
+Save the current input state as defined by insrc, cib, ciblen, and
+toin to the Return Stack. Used by EVALUTE. The naive way of doing
+this is to push each two-byte variable to the stack in the form of
+
+`int>name`:: _Tali Forth_ ( xt -- nt ) "Get name token from execution token"
+www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html
+This is called >NAME in Gforth, but we change it to
+INT>NAME to match NAME>INT
+
+
+`invert`:: _ANS core_ ( n -- n ) "Complement of TOS"
+https://forth-standard.org/standard/core/INVERT
+
+`is`:: _ANS core ext_ ( xt "name" -- ) "Set named word to execute xt"
+http://forth-standard.org/standard/core/IS
+
+`j`:: _ANS core_ ( -- n ) (R: n -- n ) "Copy second loop counter to stack"
+https://forth-standard.org/standard/core/J
+Copy second loop counter from Return Stack to stack. Note we use
+a fudge factor for loop control; see docs/loop.txt for more details.
+At this point, we have the "I" counter/limit and the LEAVE address
+on the stack above this (three entries), whereas the ideal Forth
+implementation would just have two. Make this native compiled for
+speed
+
+
+`key`:: _ANS core_ ( -- char ) "Get one character from the input"
+`l`:: _Tali Editor_ ( -- ) "List the current screen"
+`latestnt`:: _Tali Forth_ ( -- nt ) "Push most recent nt to the stack"
+www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html
+The Gforth version of this word is called LATEST
+
+
+`latestxt`:: _Gforth_ ( -- xt ) "Push most recent xt to the stack"
+http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Anonymous-Definitions.html
+
+`leave`:: _ANS core_ ( -- ) "Leave DO/LOOP construct"
+https://forth-standard.org/standard/core/LEAVE
+Note that this does not work with  anything but a DO/LOOP in
+contrast to other versions such as discussed at
+http://blogs.msdn.com/b/ashleyf/archive/2011/02/06/loopty-do-i-loop.aspx
+: LEAVE POSTPONE BRANCH HERE SWAP 0 , ; IMMEDIATE COMPILE-ONLY
+See docs/loops.txt on details of how this works. This must be native
+compile and not IMMEDIATE
+
+
+`line`:: _Tali Editor_ ( line# -- c-addr ) "Turn a line number into address in current screen"
+`list`:: _ANS block ext_ ( scr# scr# -- ) "Load screens in the given range"
+https://forth-standard.org/standard/block/LIST
+https://forth-standard.org/standard/block/THRU
+
+`literal`:: _ANS core_ ( n -- ) "Store TOS to be push on stack during runtime"
+https://forth-standard.org/standard/core/LITERAL
+Compile-only word to store TOS so that it is pushed on stack
+during runtime. This is a immediate, compile-only word. At runtime,
+it works by calling literal_runtime by compling JSR LITERAL_RT.
+Note the cmpl_ routines use TMPTOS
+
+
+`load`:: _ANS block_ ( scr# -- ) "Load the Forth code in a screen/block"
+https://forth-standard.org/standard/block/LOAD
+Note: LOAD current works because there is only one buffer.
+if/when multiple buffers are supported, we'll have to deal
+with the fact that it might re-load the old block into a
+different buffer.
+
+
+`loop`:: _ANS core_ ( -- ) "Finish loop construct"
+https://forth-standard.org/standard/core/LOOP
+Compile-time part of LOOP. This does nothing more but push 1 on
+the stack and then call +LOOP. In Forth, this is
+: LOOP  POSTPONE 1 POSTPONE (+LOOP) , POSTPONE UNLOOP
+IMMEDIATE ; COMPILE-ONLY
+This drops through to +LOOP
+
+
+`lshift`:: _ANS core_ ( x u -- u ) "Shift TOS left"
+https://forth-standard.org/standard/core/LSHIFT
+
+`m*`:: _ANS core_ ( n n -- d ) "16 * 16 --> 32"
+https://forth-standard.org/standard/core/MTimes
+Multiply two 16 bit numbers, producing a 32 bit result. All
+values are signed. Adapted from FIG Forth for Tali Forth. The
+original Forth is : M* OVER OVER XOR >R ABS SWAP ABS UM* R> D+-
+with  : D+- O< IF DNEGATE THEN
+
+
+`marker`:: _ANS core ext_ ( "name" -- ) "Create a deletion boundry"
+https://forth-standard.org/standard/core/MARKER
+This word replaces FORGET in earlier Forths. Old entries are not
+actually deleted, but merely overwritten by restoring CP and DP. To
+do this, we want to end up with something that jumps to a run-time
+component with a link to the original CP and DP values:
+
+jsr marker_runtime
+<Original CP MSB>
+<Original CP LSB>
+<Original DP MSB> ( for CURRENT wordlist )
+<Original DP LSB>
+< USER variables from offset 4 to 39 >
+
+The user variables include:
+CURRENT (byte variable)
+<All wordlists> (currently 12) (cell array)
+<#ORDER> (byte variable)
+<All search order> (currently 9) (byte array)
+
+This code uses tmp1 and tmp2
+
+
+`max`:: _ANS core_ ( n n -- n ) "Keep larger of two numbers"
+https://forth-standard.org/standard/core/MAX
+Compare TOS and NOS and keep which one is larger. Adapted from
+Lance A. Leventhal "6502 Assembly Language Subroutines". Negative
+Flag indicates which number is larger. See also
+http://6502.org/tutorials/compare_instructions.html and
+http://www.righto.com/2012/12/the-6502-overflow-flag-explained.html
+
+
+`min`:: _ANS core_ ( n n -- n ) "Keep smaller of two numbers"
+https://forth-standard.org/standard/core/MIN
+Adapted from Lance A. Leventhal "6502 Assembly Language
+Subroutines." Negative Flag indicateds which number is larger. See
+http://www.righto.com/2012/12/the-6502-overflow-flag-explained.html
+
+
+`mod`:: _ANS core_ ( n1 n2 -- n ) "Divide NOS by TOS and return the remainder"
+https://forth-standard.org/standard/core/MOD
+The Forth definition of this word is  : MOD /MOD DROP
+so we just jump to xt_slash_mod and dump the actual result.
+
+
+`move`:: _ANS core_ ( addr1 addr2 u -- ) "Copy bytes"
+https://forth-standard.org/standard/core/MOVE
+Copy u "address units" from addr1 to addr2. Since our address
+units are bytes, this is just a front-end for CMOVE and CMOVE>. This
+is actually the only one of these three words that is in the CORE
+set. This word must not be natively compiled
+
+
+`name>int`:: _Gforth_ ( nt -- xt ) "Convert Name Token to Execute Token"
+See
+https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html
+
+
+`name>string`:: _Gforth_ ( nt -- addr u ) "Given a name token, return string of word"
+http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html
+
+`nc-limit`:: _Tali Forth_ ( -- addr ) "Return address where NC-LIMIT value is kept"
+`negate`:: _ANS core_ ( n -- n ) "Two's complement"
+https://forth-standard.org/standard/core/NEGATE
+
+`never-native`:: _Tali Forth_ ( -- ) "Flag last word as never natively compiled"
+`nip`:: _ANS core ext_ ( b a -- a ) "Delete NOS"
+https://forth-standard.org/standard/core/NIP
+
+`number`:: _Tali Forth_ ( addr u -- u | d ) "Convert a number string"
+Convert a number string to a double or single cell number. This
+is a wrapper for >NUMBER and follows the convention set out in the
+Forth Programmer's Handbook" (Conklin & Rather) 3rd edition p. 87.
+Based in part on the "Starting Forth" code
+https://www.forth.com/starting-forth/10-input-output-operators/
+Gforth uses S>NUMBER? and S>UNUMBER? which return numbers and a flag
+https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Number-Conversion.html
+Another difference to Gforth is that we follow ANS Forth that the
+dot to signal a double cell number is required to be the last
+character of the string. Number calls >NUMBER which in turn calls UM*,
+which uses tmp1, tmp2, and tmp3, so we can't use them here, which is
+a pain.
+
+
+`o`:: _Tali Editor_ ( line# -- ) "Overwrite the given line"
+`of`:: _ANS core ext_ (C: -- of-sys) (x1 x2 -- |x1) "Conditional flow control" 
+http://forth-standard.org/standard/core/OF
+
+`only`:: _ANS search ext_ ( -- ) "Set earch order to minimum wordlist"
+https://forth-standard.org/standard/search/ONLY
+
+`or`:: _ANS core_ ( m n -- n ) "Logically OR TOS and NOS"
+https://forth-standard.org/standard/core/OR
+
+`order`:: _ANS core_ ( -- ) "Print current word order list and current WID"
+https://forth-standard.org/standard/search/ORDER
+A Forth implementation of this word is:
+
+`output`:: _Tali Forth_ ( -- addr ) "Return the address of the EMIT vector address"
+`over`:: _ANS core_ ( b a -- b a b ) "Copy NOS to TOS"
+https://forth-standard.org/standard/core/OVER
+
+`pad`:: _ANS core ext_ ( -- addr ) "Return address of user scratchpad"
+https://forth-standard.org/standard/core/PAD
+Return address to a temporary area in free memory for user. Must
+be at least 84 bytes in size (says ANS). It is located relative to
+the compile area pointer (CP) and therefore varies in position.
+This area is reserved for the user and not used by the system
+
+
+`page`:: _ANS facility_ ( -- ) "Clear the screen"
+https://forth-standard.org/standard/facility/PAGE
+Clears a page if supported by ANS terminal codes. This is
+Clear Screen ("ESC[2J") plus moving the cursor to the top
+left of the screen
+
+
+`parse`:: _ANS core ext_ ( "name" c -- addr u ) "Parse input with delimiter character"
+https://forth-standard.org/standard/core/PARSE
+Find word in input string delimited by character given. Do not
+skip leading delimiters -- this is the main difference to PARSE-NAME.
+PARSE and PARSE-NAME replace WORD in modern systems. ANS discussion
+http://www.forth200x.org/documents/html3/rationale.html#rat:core:PARSE
+
+cib  cib+toin   cib+ciblen
+v      v            v
+|###################|
+
+|------>|  toin (>IN)
+|------------------->|  ciblen
+
+The input string is stored starting at the address in the Current
+Input Buffer (CIB), the length of which is in CIBLEN. While searching
+for the delimiter, TOIN (>IN) points to the where we currently are.
+Since PARSE does not skip leading delimiters, we assume we are on a
+useful string if there are any characters at all. As with
+PARSE-NAME, we must be able to handle strings with a length of
+16-bit for EVALUTE, which is a pain on an 8-bit machine.
+
+
+`parse-name`:: _ANS core ext_ ( "name" -- addr u ) "Parse the input"
+https://forth-standard.org/standard/core/PARSE-NAME
+Find next word in input string, skipping leading whitespace. This is
+a special form of PARSE and drops through to that word. See PARSE
+for more detail. We use this word internally for the interpreter
+because it is a lot easier to use. Reference implementations at
+http://forth-standard.org/standard/core/PARSE-NAME and
+http://www.forth200x.org/reference-implementations/parse-name.fs
+Roughly, the word is comparable to BL WORD COUNT. -- Note that
+though the ANS standard talks about skipping "spaces", whitespace
+is actually perfectly legal (see for example
+http://forth-standard.org/standard/usage#subsubsection.3.4.1.1).
+Otherwise, PARSE-NAME chokes on tabs.
+
+
+`pick`:: _ANS core ext_ ( n n u -- n n n ) "Move element u of the stack to TOS"
+https://forth-standard.org/standard/core/PICK
+Take the u-th element out of the stack and put it on TOS,
+overwriting the original TOS. 0 PICK is equivalent to DUP, 1 PICK to
+OVER. Note that using PICK is considered poor coding form. Also note
+that FIG Forth has a different behavior for PICK than ANS Forth.
+
+
+`postpone`:: _ANS core_ ( -- ) "Change IMMEDIATE status (it's complicated)"
+https://forth-standard.org/standard/core/POSTPONE
+Add the compilation behavior of a word to a new word at
+compile time. If the word that follows it is immediate, include
+it so that it will be compiled when the word being defined is
+itself used for a new word. Tricky, but very useful. Because
+POSTPONE expects a word (not an xt) in the input stream (not
+on the Data Stack). This means we cannot build words with
+jsr xt_postpone, jsr <word>" directly.
+
+
+`previous`:: _ANS search ext_ ( -- ) "Remove the first wordlist in the search order"
+http://forth-standard.org/standard/search/PREVIOUS
+
+`quit`:: _ANS core_ ( -- ) "Reset the input and get new input"
+https://forth-standard.org/standard/core/QUIT
+Rest the input and start command loop
+
+
+`r>`:: _ANS core_ ( -- n )(R: n --) "Move top of Return Stack to TOS"
+https://forth-standard.org/standard/core/Rfrom
+Move Top of Return Stack to Top of Data Stack. We have to move
+the RTS address out of the way first. This word is handled
+differently for native and and subroutine compilation, see COMPILE,
+This is a compile-only word
+
+
+`r>input`:: _Tali Forth_ ( -- ) ( R: n n n n -- ) "Restore input state from Return Stack"
+Restore the current input state as defined by insrc, cib, ciblen,
+and toin from the Return Stack. See INPUT_TO_R for a discussion of
+this word. Uses tmp1
+
+
+`r@`:: _ANS core_ ( -- n ) "Get copy of top of Return Stack"
+https://forth-standard.org/standard/core/RFetch
+This word is Compile Only in Tali Forth, though Gforth has it
+work normally as well -- An alternative way to write this word
+would be to access the elements on the stack directly like 2R@
+does, these versions should be compared at some point.
+
+
+`recurse`:: _ANS core_ ( -- ) "Copy recursive call to word being defined"
+https://forth-standard.org/standard/core/RECURSE
+This word may not be natively compiled
+
+
+`refill`:: _ANS core ext_ ( -- f ) "Refill the input buffer"
+https://forth-standard.org/standard/core/REFILL
+Attempt to fill the input buffer from the input source, returning
+a true flag if successful. When the input source is the user input
+device, attempt to receive input into the terminal input buffer. If
+successful, make the result the input buffer, set >IN to zero, and
+return true. Receipt of a line containing no characters is considered
+successful. If there is no input available from the current input
+source, return false. When the input source is a string from EVALUATE,
+return false and perform no other action." See
+https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/The-Input-Stream.html
+and Conklin & Rather p. 156
+
+
+`repeat`:: _ANS core_ (C: orig dest -- ) ( -- ) "Loop flow control"
+http://forth-standard.org/standard/core/REPEAT
+
+`root-wordlist`:: _Tali Editor_ ( -- u ) "WID for the Root (minimal) wordlist"
+`rot`:: _ANS core_ ( a b c -- b c a ) "Rotate first three stack entries downwards"
+https://forth-standard.org/standard/core/ROT
+Remember "R for 'Revolution'" - the bottom entry comes out
+on top!
+
+
+`rshift`:: _ANS core_ ( x u -- x ) "Shift TOS to the right"
+https://forth-standard.org/standard/core/RSHIFT
+
+`s"`:: _ANS core_ ( "string" -- )( -- addr u ) "Store string in memory"
+https://forth-standard.org/standard/core/Sq
+Store address and length of string given, returning ( addr u ).
+ANS core claims this is compile-only, but the file set expands it
+to be interpreted, so it is a state-sensitive word, which in theory
+are evil. We follow general usage. Can also be realized as
+: S" [CHAR] " PARSE POSTPONE SLITERAL ; IMMEDIATE
+but it is used so much we want it in code.
+
+
+`s>d`:: _ANS core_ ( u -- d ) "Convert single cell number to double cell"
+https://forth-standard.org/standard/core/StoD
+
+`s\"`:: _ANS core_ ( "string" -- )( -- addr u ) "Store string in memory"
+https://forth-standard.org/standard/core/Seq
+Store address and length of string given, returning ( addr u ).
+ANS core claims this is compile-only, but the file set expands it
+to be interpreted, so it is a state-sensitive word, which in theory
+are evil. We follow general usage.  This is just like S" except
+that it allows for some special escaped characters.
+
+
+`save-buffers`:: _ANS block_ ( -- ) "Save all dirty buffers to storage"
+https://forth-standard.org/standard/block/SAVE-BUFFERS
+
+`scr`:: _ANS block ext_ ( -- addr ) "Push address of variable holding last screen listed"
+https://forth-standard.org/standard/block/SCR
+
+`search`:: _ANS string_ ( addr1 u1 addr2 u2 -- addr3 u3 flag) "Search for a substring"
+https://forth-standard.org/standard/string/SEARCH
+Search for string2 (denoted by addr2 u2) in string1 (denoted by
+addr1 u1).  If a match is found the flag will be true and
+addr3 will have the address of the start of the match and u3 will have
+the number of characters remaining from the match point to the end
+of the original string1.  If a match is not found, the flag will be
+false and addr3 and u3 will be the original string1's addr1 and u1.
+
+
+`search-wordlist`:: _ANS search_ ( caddr u wid -- 0 | xt 1 | xt -1) "Search for a word in a wordlist"
+https://forth-standard.org/standard/search/SEARCH_WORDLIST
+
+`see`:: _ANS tools_ ( "name" -- ) "Print information about a Forth word"
+https://forth-standard.org/standard/tools/SEE
+SEE takes the name of a word and prints its name token (nt),
+execution token (xt), size in bytes, flags used, and then dumps the
+code and disassembles it.
+
+
+`set-current`:: _ANS search_ ( wid -- ) "Set the compilation wordlist"
+https://forth-standard.org/standard/search/SET-CURRENT
+
+`set-order`:: _ANS search_ ( wid_n .. wid_1 n -- ) "Set the current search order"
+https://forth-standard.org/standard/search/SET-ORDER
+
+`sign`:: _ANS core_ ( n -- ) "Add minus to pictured output"
+https://forth-standard.org/standard/core/SIGN
+Code based on
+http://pforth.googlecode.com/svn/trunk/fth/numberio.fth
+Original Forth code is   0< IF ASCII - HOLD THEN
+
+
+`sliteral`:: _ANS string_ ( addr u -- )( -- addr u ) "Compile a string for runtime"
+https://forth-standard.org/standard/string/SLITERAL
+Add the runtime for an existing string.
+
+
+`sm/rem`:: _ANS core_ ( d n1 -- n2 n3 ) "Symmetic signed division"
+https://forth-standard.org/standard/core/SMDivREM
+Symmetic signed division. Compare FM/MOD. Based on F-PC 3.6
+by Ulrich Hoffmann. See http://www.xlerb.de/uho/ansi.seq Forth:
+OVER >R 2DUP XOR 0< >R ABS >R DABS R> UM/MOD R> ?NEGATE SWAP
+R> ?NEGATE SWAP
+
+
+`source`:: _ANS core_ ( -- addr u ) "Return location and size of input buffer""
+https://forth-standard.org/standard/core/SOURCE
+
+`source-id`:: _ANS core ext_ ( -- n ) "Return source identifier"
+https://forth-standard.org/standard/core/SOURCE-ID
+Identify the input source unless it is a block (s. Conklin &
+Rather p. 156). Since we don't have blocks (yet), this will give
+the input source: 0 is keyboard, -1 (0ffff) is character string,
+and a text file gives the fileid.
+
+
+`space`:: _ANS core_ ( -- ) "Print a single space"
+https://forth-standard.org/standard/core/SPACE
+
+`spaces`:: _ANS core_ ( u -- ) "Print a number of spaces"
+https://forth-standard.org/standard/core/SPACES
+
+`state`:: _ANS core_ ( -- addr ) "Return the address of compilation state flag"
+https://forth-standard.org/standard/core/STATE
+STATE is true when in compilation state, false otherwise. Note
+we do not return the state itself, but only the address where
+it lives. The state should not be changed directly by the user; see
+http://forth.sourceforge.net/standard/dpans/dpans6.htm#6.1.2250
+
+
+`strip-underflow`:: _Tali Forth_ ( -- addr ) "Return address where underflow status is kept"
+STRIP_UNDERFLOW contains a flag that determines if underflow
+checking should be removed during the compilation of new words.
+Default is false.
+
+
+`swap`:: _ANS core_ ( b a -- a b ) "Exchange TOS and NOS"
+https://forth-standard.org/standard/core/SWAP
+
+`then`:: _ANS core_ (C: orig -- ) ( -- ) "Conditional flow control"
+http://forth-standard.org/standard/core/THEN
+
+`to`:: _ANS core ext_ ( n "name" -- ) or ( "name") "Change a value"
+https://forth-standard.org/standard/core/TO
+Gives a new value to a, uh, VALUE. One possible Forth
+implementation is  ' >BODY !  but given the problems we have
+with >BODY on STC Forths, we do this the hard way. Since
+Tali Forth uses the same code for CONSTANTs and VALUEs, you
+could use this to redefine a CONSTANT, but that is a no-no.
+
+Note that the standard has different behaviors for TO depending
+on the state (https://forth-standard.org/standard/core/TO).
+This makes TO state-dependent (which is bad) and also rather
+complex (see the Gforth implementation for comparison). This
+word may not be natively compiled and must be immediate. Frankly,
+it would have made more sense to have two words for this.
+
+
+`true`:: _ANS core ext_ ( -- f ) "Push TRUE flag to Data Stack"
+https://forth-standard.org/standard/core/TRUE
+
+`tuck`:: _ANS core ext_ ( b a -- a b a ) "Copy TOS below NOS"
+https://forth-standard.org/standard/core/TUCK
+
+`type`:: _ANS core_ ( addr u -- ) "Print string"
+https://forth-standard.org/standard/core/TYPE
+Works through EMIT to allow OUTPUT revectoring. Currently, only
+strings of up to 255 characters are printed
+
+
+`u.`:: _ANS core_ ( u -- ) "Print TOS as unsigned number"
+https://forth-standard.org/standard/core/Ud
+This is : U. 0 <# #S #> TYPE SPACE ; in Forth
+We use the internal assembler function print_u followed
+by a single space
+
+
+`u.r`:: _ANS core ext_ ( u u -- ) "Print NOS as unsigned number with TOS with"
+https://forth-standard.org/standard/core/UDotR
+
+`u<`:: _ANS core_ ( n m -- f ) "Return true if NOS < TOS (unsigned)"
+https://forth-standard.org/standard/core/Uless
+
+`u>`:: _ANS core ext_ ( n m -- f ) "Return true if NOS > TOS (unsigned)"
+https://forth-standard.org/standard/core/Umore
+
+`ud.`:: _Tali double_ ( d -- ) "Print double as unsigned"
+Based on the Forth code  : UD. <# #S #> TYPE SPACE
+
+
+`ud.r`:: _Tali double_ ( d u -- ) "Print unsigned double right-justified u wide"
+Based on the Forth code : UD.R  >R <# #S #> R> OVER - SPACES TYPE
+
+
+`um*`:: _ANS core_ ( u u -- ud ) "Multiply 16 x 16 -> 32"
+https://forth-standard.org/standard/core/UMTimes
+Multiply two unsigned 16 bit numbers, producing a 32 bit result.
+This is based on modified FIG Forth code by Dr. Jefyll, see
+http://forum.6502.org/viewtopic.php?f=9&t=689 for a detailed
+discussion. We don't use the system scratch pad (SYSPAD) for temp
+storage because >NUMBER uses it as well, but instead tmp1 to
+tmp3 (tmp1 is N in the original code, tmp1+1 is N+1, etc).
+Old Forth versions such as FIG Forth call this U*
+
+Consider switching to a table-supported version based on
+http://codebase64.org/doku.php?id=base:seriously_fast_multiplication
+http://codebase64.org/doku.php?id=magazines:chacking16#d_graphics_for_the_masseslib3d>
+http://forum.6502.org/viewtopic.php?p=205#p205
+http://forum.6502.org/viewtopic.php?f=9&t=689
+
+
+`um/mod`:: _ANS core_ ( ud u -- ur u ) "32/16 -> 16 division"
+https://forth-standard.org/standard/core/UMDivMOD
+Divide double cell number by single cell number, returning the
+quotient as TOS and any remainder as NOS. All numbers are unsigned.
+This is the basic division operation all others use. Based on FIG
+Forth code, modified by Garth Wilson, see
+http://6502.org/source/integers/ummodfix/ummodfix.htm
+This uses tmp1, tmp1+1, and tmptos
+
+
+`unloop`:: _ANS core_ ( -- )(R: n1 n2 n3 ---) "Drop loop control from Return stack"
+https://forth-standard.org/standard/core/UNLOOP
+Note that 6xPLA uses just as many bytes as a loop would
+
+
+`until`:: _ANS core_ (C: dest -- ) ( -- ) "Loop flow control"
+http://forth-standard.org/standard/core/UNTIL
+
+`unused`:: _ANS core ext_ ( -- u ) "Return size of space available to Dictionary"
+https://forth-standard.org/standard/core/UNUSED
+UNUSED does not include the ACCEPT history buffers. Total RAM
+should be HERE + UNUSED + <history buffer size>, the last of which
+defaults to $400
+
+
+`update`:: _ANS block_ ( -- ) "Mark current block as dirty"
+https://forth-standard.org/standard/block/UPDATE
+
+`useraddr`:: _Tali Forth_ ( -- addr ) "Push address of base address of user variables"
+`value`:: _ANS core_ ( n "name" -- ) "Define a value"
+https://forth-standard.org/standard/core/VALUE
+This is a dummy header for the WORDLIST. The actual code is
+identical to that of CONSTANT
+
+
+`variable`:: _ANS core_ ( "name" -- ) "Define a variable"
+https://forth-standard.org/standard/core/VARIABLE
+There are various Forth definitions for this word, such as
+CREATE 1 CELLS ALLOT  or  CREATE 0 ,  We use a variant of the
+second one so the variable is initialized to zero
+
+
+`while`:: _ANS core_ ( C: dest -- orig dest ) ( x -- ) "Loop flow control"
+http://forth-standard.org/standard/core/WHILE
+
+`within`:: _ANS core ext_ ( n1 n2 n3 -- ) "See if within a range"
+https://forth-standard.org/standard/core/WITHIN
+This an assembler version of the ANS Forth implementation
+at https://forth-standard.org/standard/core/WITHIN which is
+OVER - >R - R> U<  note there is an alternative high-level version
+ROT TUCK > -ROT > INVERT AND
+
+
+`word`:: _ANS core_ ( char "name " -- caddr ) "Parse input stream"
+https://forth-standard.org/standard/core/WORD
+Obsolete parsing word included for backwards compatibility only.
+Do not use this, use PARSE or PARSE-NAME. Skips leading delimiters
+and copies word to storage area for a maximum size of 255 bytes.
+Returns the result as a counted string (requires COUNT to convert
+to modern format), and inserts a space after the string. See "Forth
+Programmer's Handbook" 3rd edition p. 159 and
+http://www.forth200x.org/documents/html/rationale.html#rat:core:PARSE
+for discussions of why you shouldn't be using WORD anymore. Forth
+would be   PARSE DUP BUFFER1 C! OUTPUT 1+ SWAP MOVE BUFFER1
+We only allow input of 255 chars. Seriously, use PARSE-NAME.
+
+
+`wordlist`:: _ANS search_ ( -- wid ) "Create new wordlist (from pool of 8)"
+https://forth-standard.org/standard/search/WORDLIST
+
+`words`:: _ANS tools_ ( -- ) "Print known words from Dictionary"
+https://forth-standard.org/standard/tools/WORDS
+This is pretty much only used at the command line so we can
+be slow and try to save space. DROP must always be the first word in a
+clean system (without Forth words), BYE the last. There is no reason
+why we couldn't define this as a high level word except that it is
+really useful for testing
+
+
+`wordsize`:: _Tali Forth_ ( nt -- u ) "Get size of word in bytes"
+Given an word's name token (nt), return the size of the
+word's payload size in bytes (CFA plus PFA) in bytes. Does not
+count the final RTS.  
+
+`xor`:: _ANS core_ ( n n -- n ) "Logically XOR TOS and NOS"
+https://forth-standard.org/standard/core/XOR
+

--- a/docs/ch_glossary.adoc
+++ b/docs/ch_glossary.adoc
@@ -4,25 +4,16 @@ https://forth-standard.org/standard/core/Store
 
 `#`:: _ANS core_ ( ud -- ud ) "Add character to pictured output string"
 https://forth-standard.org/standard/core/num
-Add one char to the beginning of the pictured output string. Based
-on https://github.com/philburk/pforth/blob/master/fth/numberio.fth
-Forth code  BASE @ UD/MOD ROT 9 OVER < IF 7 + THEN [CHAR] 0 + HOLD
-
+Add one char to the beginning of the pictured output string.
 
 `#>`:: _ANS core_ ( d -- addr u ) "Finish pictured number conversion"
 https://forth-standard.org/standard/core/num-end
 Finish conversion of pictured number string, putting address and
-length on the Data Stack. Original Fort is  2DROP HLD @ PAD OVER -
-Based on
-https://github.com/philburk/pforth/blob/master/fth/numberio.fth
-
+length on the Data Stack.
 
 `#s`:: _ANS core_ ( d -- addr u ) "Completely convert pictured output"
 https://forth-standard.org/standard/core/numS
-Completely convert number for pictured numerical output. Based on
-https://github.com/philburk/pforth/blob/master/fth/system.fth
-Original Forth code  BEGIN # 2DUP OR 0= UNTIL
-
+Completely convert number for pictured numerical output.
 
 `'`:: _ANS core_ ( "name" -- xt ) "Return a word's execution token (xt)"
 https://forth-standard.org/standard/core/Tick
@@ -33,24 +24,17 @@ http://forth-standard.org/standard/core/p
 `*`:: _ANS core_ ( n n -- n ) "16*16 --> 16 "
 https://forth-standard.org/standard/core/Times
 Multiply two signed 16 bit numbers, returning a 16 bit result.
-This is nothing  more than UM* DROP
-
 
 `*/`:: _ANS core_ ( n1 n2 n3 -- n4 ) "n1 * n2 / n3 -->  n"
 https://forth-standard.org/standard/core/TimesDiv
 Multiply n1 by n2 and divide by n3, returning the result
-without a remainder. This is */MOD without the mod, and
-can be defined in Fort as : */  */MOD SWAP DROP ; which is
-pretty much what we do here
-
+without a remainder. This is */MOD without the mod.
 
 `*/mod`:: _ANS core_ ( n1 n2 n3 -- n4 n5 ) "n1 * n2 / n3 --> n-mod n"
 https://forth-standard.org/standard/core/TimesDivMOD
 Multiply n1 by n2 producing the intermediate double-cell result
 d. Divide d by n3 producing the single-cell remainder n4 and the
-single-cell quotient n5. In Forth, this is
-: */MOD  >R M* >R SM/REM ;  Note that */ accesses this routine.
-
+single-cell quotient n5.
 
 `+`:: _ANS core_ ( n n -- n ) "Add TOS and NOS"
 https://forth-standard.org/standard/core/Plus
@@ -60,20 +44,10 @@ https://forth-standard.org/standard/core/PlusStore
 
 `+loop`:: _ANS core_ ( -- ) "Finish loop construct"
 https://forth-standard.org/standard/core/PlusLOOP
-Compile-time part of +LOOP, also used for LOOP. Is usually
-: +LOOP POSTPONE (+LOOP) , POSTPONE UNLOOP ; IMMEDIATE
-COMPILE-ONLY
-in Forth. LOOP uses this routine as well. We jump here with the
-address for looping as TOS and the address for aborting the loop
-(LEAVE) as the second double-byte entry on the Return Stack (see
-DO and docs/loops.txt for details).
-
 
 `,`:: _ANS core_ ( n -- ) "Allot and store one cell in memory"
 https://forth-standard.org/standard/core/Comma
-Store TOS at current place in memory. Since this an eight-bit
-machine, we can ignore all alignment issures.
-
+Store TOS at current place in memory.
 
 `-`:: _ANS core_ ( n n -- n ) "Subtract TOS from NOS"
 https://forth-standard.org/standard/core/Minus
@@ -81,14 +55,12 @@ https://forth-standard.org/standard/core/Minus
 `-leading`:: _Tali String_ ( addr1 u1 -- addr2 u2 ) "Remove leading spaces"
 Remove leading whitespace. This is the reverse of -TRAILING
 
-
 `-rot`:: _Gforth_ ( a b c -- c a b ) "Rotate upwards"
 http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Data-stack.html
 
 `-trailing`:: _ANS string_ ( addr u1 -- addr u2 ) "Remove trailing spaces"
 https://forth-standard.org/standard/string/MinusTRAILING
 Remove trailing spaces
-
 
 `.`:: _ANS core_ ( u -- ) "Print TOS"
 https://forth-standard.org/standard/core/d
@@ -100,50 +72,28 @@ this to be compile-only, even though everybody and their friend
 uses it for everything. We follow the book here, and recommend
 .( for general printing
 
-
 `.(`:: _ANS core_ ( -- ) "Print input up to close paren .( comment )"
 http://forth-standard.org/standard/core/Dotp
 
 `.r`:: _ANS core ext_ ( n u -- ) "Print NOS as unsigned number with TOS with"
 https://forth-standard.org/standard/core/DotR
-Based on the Forth code
-: .R  >R DUP ABS 0 <# #S ROT SIGN #> R> OVER - SPACES TYPE
-
 
 `.s`:: _ANS tools _ ( -- ) "Print content of Data Stack"
 https://forth-standard.org/standard/tools/DotS
-Print content of Data Stack non-distructively. Since this is for
-humans, we don't have to worry about speed. We follow the format
+Print content of Data Stack non-distructively. We follow the format
 of Gforth and print the number of elements first in brackets,
 followed by the Data Stack content (if any).
 
-
 `/`:: _ANS core_ ( n1 n2 -- n ) "Divide NOS by TOS"
 https://forth-standard.org/standard/core/Div
-Forth code is either  >R S>D R> FM/MOD SWAP DROP
-or >R S>D R> SM/REM SWAP DROP -- we use SM/REM in Tali Forth.
-This code is currently unoptimized. This code without the SLASH
-DROP at the end is /MOD, so we share the code as far as possible.
-
 
 `/mod`:: _ANS core_ ( n1 n2 -- n3 n4 ) "Divide NOS by TOS with a remainder"
 https://forth-standard.org/standard/core/DivMOD
-This is a dummy entry, the actual code is shared with SLASH
-
 
 `/string`:: _ANS string_ ( addr u n -- addr u ) "Shorten string by n"
 https://forth-standard.org/standard/string/DivSTRING
-Forth code is
-: /STRING ( ADDR U N -- ADDR U ) ROT OVER + ROT ROT -
-Put differently, we need to add TOS and 3OS, and subtract
-TOS from NOS, and then drop TOS
-
 
 `0`:: _Tali Forth_ ( -- 0 ) "Push 0 to Data Stack"
-; """The disassembler assumes that this routine does not use Y. Note
-that CASE and FORTH-WORDLIST use the same routine, as the WD for Forth
-is 0.
-
 `0<`:: _ANS core_ ( n -- f ) "Return a TRUE flag if TOS negative"
 https://forth-standard.org/standard/core/Zeroless
 
@@ -161,8 +111,6 @@ This is also the code for EDITOR-WORDLIST
 
 `1+`:: _ANS core_ ( u -- u+1 ) "Increase TOS by one"
 https://forth-standard.org/standard/core/OnePlus
-Code is shared with CHAR-PLUS
-
 
 `1-`:: _ANS core_ ( u -- u-1 ) "Decrease TOS by one"
 https://forth-standard.org/standard/core/OneMinus
@@ -175,34 +123,24 @@ https://forth-standard.org/standard/core/TwoStore
 Stores so n2 goes to addr and n1 to the next consecutive cell.
 Is equivalent to  SWAP OVER ! CELL+ !
 
-
 `2*`:: _ANS core_ ( n -- n ) "Multiply TOS by two"
 https://forth-standard.org/standard/core/TwoTimes
 Also used for CELLS
-
 
 `2/`:: _ANS core_ ( n -- n ) "Divide TOS by two"
 https://forth-standard.org/standard/core/TwoDiv
 
 `2>r`:: _ANS core ext_ ( n1 n2 -- )(R: -- n1 n2 "Push top two entries to Return Stack"
 https://forth-standard.org/standard/core/TwotoR
-Push top two entries to Return Stack. The same as SWAP >R >R
-except that if we jumped here, the return address will be in the
-way. May not be natively compiled unless we're clever and use
-special routines.
-
+Push top two entries to Return Stack.
 
 `2@`:: _ANS core_ ( addr -- n1 n2 ) "Fetch the cell pair n1 n2 stored at addr"
 https://forth-standard.org/standard/core/TwoFetch
 Note n2 stored at addr and n1 in the next cell -- in our case,
 the next byte. This is equvalent to  DUP CELL+ @ SWAP @
 
-
 `2constant`:: _ANS double_ (C: d "name" -- ) ( -- d) "Create a constant for a double word"
 https://forth-standard.org/standard/double/TwoCONSTANT
-Based on the Forth code
-: 2CONSTANT ( D -- )  CREATE SWAP , , DOES> DUP @ SWAP CELL+ @
-
 
 `2drop`:: _ANS core_ ( n n -- ) "Drop TOS and NOS"
 https://forth-standard.org/standard/core/TwoDROP
@@ -215,82 +153,43 @@ https://forth-standard.org/standard/double/TwoLITERAL
 Based on the Forth code
 : 2LITERAL ( D -- ) SWAP POSTPONE LITERAL POSTPONE LITERAL ; IMMEDIATE
 
-
 `2over`:: _ANS core_ ( d1 d2 -- d1 d2 d1 ) "Copy double word NOS to TOS"
 https://forth-standard.org/standard/core/TwoOVER
 
 `2r>`:: _ANS core ext_ ( -- n1 n2 ) (R: n1 n2 -- ) "Pull two cells from Return Stack"
 https://forth-standard.org/standard/core/TwoRfrom
-Pull top two entries from Return Stack. Is the same as
-R> R> SWAP. As with R>, the problem with the is word is that
-the top value on the ReturnStack for a STC Forth is the
-return address, which we need to get out of the way first.
-Native compile needs to be handled as a special case.
-
+Pull top two entries from Return Stack.
 
 `2r@`:: _ANS core ext_ ( -- n n ) "Copy top two entries from Return Stack"
 https://forth-standard.org/standard/core/TwoRFetch
-This is R> R> 2DUP >R >R SWAP but we can do it a lot faster in
-assembler. We use trickery to access the elements on the Return
-Stack instead of pulling the return address first and storing
-it somewhere else like for 2R> and 2>R. In this version, we leave
-it as Never Native; at some point, we should compare versions to
-see if an Always Native version would be better
-
 
 `2swap`:: _ANS core_ ( n1 n2 n3 n4 -- n3 n4 n1 n1 ) "Exchange two double words"
 https://forth-standard.org/standard/core/TwoSWAP
 
 `2variable`:: _ANS double_ ( "name" -- ) "Create a variable for a double word"
 https://forth-standard.org/standard/double/TwoVARIABLE
-This can be realized in Forth as either
-CREATE 2 CELLS ALLOT  or just  CREATE 0 , 0 ,
-Note that in this case, the variable is not initialized to
-zero
+The variable is not initialized to zero.
 
 `:`:: _ANS core_ ( "name" -- ) "Start compilation of a new word"
 https://forth-standard.org/standard/core/Colon
-Use the CREATE routine and fill in the rest by hand.
-
 
 `:NONAME`:: _ANS core_ ( -- ) "Start compilation of a new word""
 https://forth-standard.org/standard/core/ColonNONAME
 Compile a word with no nt.  ";" will put its xt on the stack.
 
-
 `;`:: _ANS core_ ( -- ) "End compilation of new word"
 https://forth-standard.org/standard/core/Semi
-End the compilation of a new word into the Dictionary. When we
-enter this, WORKWORD is pointing to the nt_ of this word in the
-Dictionary, DP to the previous word, and CP to the next free byte.
-A Forth definition would be (see "Starting Forth"):
-: POSTPONE EXIT  REVEAL POSTPONE ; [ ; IMMEDIATE  Following the
-practice of Gforth, we warn here if a word has been redefined.
-
+End the compilation of a new word into the Dictionary.
 
 `<`:: _ANS core_ ( n m -- f ) "Return true if NOS < TOS"
 https://forth-standard.org/standard/core/less
 
 `<#`:: _ANS core_ ( -- ) "Start number conversion"
 https://forth-standard.org/standard/core/num-start
-Start the process to create pictured numeric output. The new
-string is constructed from back to front, saving the new character
-at the beginning of the output string. Since we use PAD as a
-starting address and work backward (!), the string is constructed
-in the space between the end of the Dictionary (as defined by CP)
-and the PAD. This allows us to satisfy the ANS Forth condition that
-programs don't fool around with the PAD but still use its address.
-Based on pForth
-http://pforth.googlecode.com/svn/trunk/fth/numberio.fth
-pForth is in the pubic domain. Forth is : <# PAD HLD ! ; we use the
-internal variable tohold instead of HLD.
-
+Start the process to create pictured numeric output.
 
 `<>`:: _ANS core ext_ ( n m -- f ) "Return a true flag if TOS != NOS"
 https://forth-standard.org/standard/core/ne
-This is just a variant of EQUAL, we code it separately
-for speed.
-
 
 `=`:: _ANS core_ ( n n -- f ) "See if TOS and NOS are equal"
 https://forth-standard.org/standard/core/Equal
@@ -302,12 +201,7 @@ https://forth-standard.org/standard/core/more
 https://forth-standard.org/standard/core/toBODY
 Given a word's execution token (xt), return the address of the
 start of that word's parameter field (PFA). This is defined as the
-address that HERE would return right after CREATE. This is a
-difficult word for STC Forths, because most words don't actually
-have a Code Field Area (CFA) to skip. We solve this by having CREATE
-add a flag, "has CFA" (HC), in the header so >BODY know to skip
-the subroutine jumps to DOVAR, DOCONST, or DODOES
-
+address that HERE would return right after CREATE.
 
 `>in`:: _ANS core_ ( -- addr ) "Return address of the input pointer"
 `>number`:: _ANS core_ ( ud addr u -- ud addr u ) "Convert a number"
@@ -330,12 +224,8 @@ This word is handled differently for native and for
 subroutine coding, see COMPILE, . This is a complile-only
 word.
 
-
 `?`:: _ANS tools_ ( addr -- ) "Print content of a variable"
 https://forth-standard.org/standard/tools/q
-Only used interactively. Since humans are so slow, we
-save size and just go for the subroutine jumps
-
 
 `?do`:: _ANS core ext_ ( limit start -- )(R: -- limit start) "Conditional loop start"
 https://forth-standard.org/standard/core/qDO
@@ -350,17 +240,13 @@ https://forth-standard.org/standard/core/Fetch
 https://forth-standard.org/standard/core/Bracket
 This is an immediate and compile-only word
 
-
 `[']`:: _ANS core_ ( -- ) "Store xt of following word during compilation"
 https://forth-standard.org/standard/core/BracketTick
 
 `[char]`:: _ANS core_ ( "c" -- ) "Compile character"
 https://forth-standard.org/standard/core/BracketCHAR
 Compile the ASCII value of a character as a literal. This is an
-immediate, compile-only word. A definition given in
-http://forth-standard.org/standard/implement is
-: [CHAR]  CHAR POSTPONE LITERAL ; IMMEDIATE
-
+immediate, compile-only word.
 
 `\`:: _ANS core ext_ ( -- ) "Ignore rest of line"
 https://forth-standard.org/standard/core/bs
@@ -369,7 +255,6 @@ https://forth-standard.org/standard/core/bs
 https://forth-standard.org/standard/right-bracket
 This is an immediate word.
 
-
 `abort`:: _ANS core_ ( -- ) "Reset the Data Stack and restart the CLI"
 https://forth-standard.org/standard/core/ABORT
 Clear Data Stack and continue into QUIT. We can jump here via
@@ -377,16 +262,13 @@ subroutine if we want to because we are going to reset the 65c02's
 stack pointer (the Return Stack) anyway during QUIT. Note we don't
 actually delete the stuff on the Data Stack
 
-
 `abort"`:: _ANS core_ ( "string" -- ) "If flag TOS is true, MESSAGE with message"
 https://forth-standard.org/standard/core/ABORTq
 Abort with a message
 
-
 `abs`:: _ANS core_ ( n -- u ) "Return absolute value of a number"
 https://forth-standard.org/standard/core/ABS
 Return the absolute value of a number.
-
 
 `accept`:: _ANS core _ ( addr n -- n ) "Receive a string of characters from the keyboard"
 https://forth-standard.org/standard/core/ACCEPT
@@ -394,7 +276,6 @@ Receive a string of at most n1 characters, placing them at
 addr. Return the actual number of characters as n2. Characters
 are echoed as they are received. ACCEPT is called by REFILL in
 modern Forths.
-
 
 `action-of`:: _ANS core ext_ ( "name" -- xt ) "Get named deferred word's xt"
 http://forth-standard.org/standard/core/ACTION-OF
@@ -404,10 +285,10 @@ https://forth-standard.org/standard/core/AGAIN
 
 `align`:: _ANS core_ ( -- ) "Make sure CP is aligned on word size"
 https://forth-standard.org/standard/core/ALIGN
-On a 8-bit machine, this does nothing. ALIGNED uses
-this routine as well, and also does nothing
-## ALIGNED ( addr -- addr ) "Return the first aligned address
-## "aligned"  auto  ANS core
+On a 8-bit machine, this does nothing.
+
+`aligned`:: _ANS core_ ( addr -- addr ) "Return the first aligned address"
+https://forth-standard.org/standard/core/ALIGNED
 
 `allot`:: _ANS core_ ( n -- ) "Reserve or release memory"
 https://forth-standard.org/standard/core/ALLOT
@@ -416,7 +297,6 @@ If n = 0, do nothing. If n is negative, release n bytes, but only
 to the beginning of the Dictionary. If n is positive (the most
 common case), reserve n bytes, but not past the end of the
 Dictionary. See http://forth-standard.org/standard/core/ALLOT
-
 
 `allow-native`:: _Tali Forth_ ( -- ) "Flag last word to allow native compiling"
 `also`:: _ANS search ext_ ( -- ) "Make room in the search order for another wordlist"
@@ -432,21 +312,13 @@ This is a dummy entry, the code is shared with TWO
 `at-xy`:: _ANS facility_ ( n m -- ) "Move cursor to position given"
 https://forth-standard.org/standard/facility/AT-XY
 On an ANS compatible terminal, place cursor at row n colum m.
-Code is ESC[<n>;<m>H Do not use U. to print the numbers because the
-trailing space will not work with xterm
-
+Code is ESC[<n>;<m>H
 
 `base`:: _ANS core_ ( -- addr ) "Push address of radix base to stack"
 https://forth-standard.org/standard/core/BASE
 
 `begin`:: _ANS core_ ( -- addr ) "Mark entry point for loop"
 https://forth-standard.org/standard/core/BEGIN
-This is just an immediate version of here which could just
-as well be coded in Forth as
-: BEGIN HERE ; IMMEDIATE COMPILE-ONLY
-Since this is a compiling word, we don't care that much about
-about speed
-
 
 `bell`:: _Tali Forth_ ( -- ) "Emit ASCII BELL"
 `bl`:: _ANS core_ ( -- c ) "Push ASCII value of SPACE to stack"
@@ -464,39 +336,33 @@ https://forth-standard.org/standard/block/BLOCK
 Create a RAM drive, with the given number of
 blocks, in the dictionary along with setting up the block words to
 use it.  The read/write routines do not provide bounds checking.
-Expected use: 4 block-ramdrive-init ( to create blocks 0-3 )
-
+Expected use: `4 block-ramdrive-init` ( to create blocks 0-3 )
 
 `block-read`:: _Tali block_ ( addr u -- ) "Read a block from storage (deferred word)"
 BLOCK-READ is a vectored word that the user needs to override
 with their own version to read a block from storage.
 The stack parameters are ( buffer_address block# -- ).
 
-
 `block-read-vector`:: _Tali block_ ( -- addr ) "Address of the block-read vector"
 BLOCK-READ is a vectored word that the user needs to override
 with their own version to read a block from storage.
 This word gives the address of the vector so it can be replaced.
-
 
 `block-write`:: _Tali block_ ( addr u -- ) "Write a block to storage (deferred word)"
 BLOCK-WRITE is a vectored word that the user needs to override
 with their own version to write a block to storage.
 The stack parameters are ( buffer_address block# -- ).
 
-
 `block-write-vector`:: _Tali block_ ( -- addr ) "Address of the block-write vector"
 BLOCK-WRITE is a vectored word that the user needs to override
 with their own version to write a block to storage.
 This word gives the address of the vector so it can be replaced.
 
-
 `bounds`:: _Gforth_ ( addr u -- addr+u addr ) "Prepare address for looping"
 http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Memory-Blocks.html
 Given a string, return the correct Data Stack parameters for
-a DO/LOOP loop; over its characters. This is realized as
+a DO/LOOP loop over its characters. This is realized as
 OVER + SWAP in Forth, but we do it a lot faster in assembler
-
 
 `buffblocknum`:: _Tali block_ ( -- addr ) "Push address of variable holding block in buffer"
 `buffer`:: _ANS block_ ( u -- a-addr ) "Get a buffer for a block"
@@ -507,14 +373,12 @@ https://forth-standard.org/standard/core/BUFFERColon
 Create a buffer of size u that puts its address on the stack
 when its name is used.
 
-
 `buffstatus`:: _Tali block_ ( -- addr ) "Push address of variable holding buffer status"
 `bye`:: _ANS tools ext_ ( -- ) "Break"
 https://forth-standard.org/standard/tools/BYE
 
 `c!`:: _ANS core_ ( c addr -- ) "Store character at address given"
 https://forth-standard.org/standard/core/CStore
-
 
 `c,`:: _ANS core_ ( c -- ) "Store one byte/char in the Dictionary"
 https://forth-standard.org/standard/core/CComma
@@ -524,28 +388,20 @@ https://forth-standard.org/standard/core/CFetch
 
 `case`:: _ANS core ext_ (C: -- 0) ( -- ) "Conditional flow control"
 http://forth-standard.org/standard/core/CASE
-This is a dummy header, CASE shares the actual code with ZERO.
-
 
 `cell+`:: _ANS core_ ( u -- u ) "Add cell size in bytes"
 https://forth-standard.org/standard/core/CELLPlus
 Add the number of bytes ("address units") that one cell needs.
 Since this is an 8 bit machine with 16 bit cells, we add two bytes.
 
-
 `cells`:: _ANS core_ ( u -- u ) "Convert cells to size in bytes"
 https://forth-standard.org/standard/core/CELLS
-Dummy entry for the CELLS word, the code is the same as for
-2*, which is where the header directs us to
-
 
 `char`:: _ANS core_ ( "c" -- u ) "Convert character to ASCII value"
 https://forth-standard.org/standard/core/CHAR
 
 `char+`:: _ANS core_ ( addr -- addr+1 ) "Add the size of a character unit to address"
 https://forth-standard.org/standard/core/CHARPlus
-This is a dummy entry, the code is shared with ONE_PLUS
-
 
 `chars`:: _ANS core_ ( n -- n ) "Number of bytes that n chars need"
 https://forth-standard.org/standard/core/CHARS
@@ -553,27 +409,22 @@ Return how many address units n chars are. Since this is an 8 bit
 machine, this does absolutely nothing and is included for
 compatibility with other Forth versions
 
-
 `cleave`:: _Tali Forth_ ( addr u -- addr2 u2 addr1 u1 ) "Split off word from string"
 `cmove`:: _ANS string_ ( addr1 addr2 u -- ) "Copy bytes going from low to high"
 https://forth-standard.org/standard/string/CMOVE
 Copy u bytes from addr1 to addr2, going low to high (addr2 is
 larger than addr1). Based on code in Leventhal, Lance A.
 6502 Assembly Language Routines", p. 201, where it is called
-move left". There are no official tests for this word.
-
+move left".
 
 `cmove>`:: _ANS string_ ( add1 add2 u -- ) "Copy bytes from high to low"
 https://forth-standard.org/standard/string/CMOVEtop
 Based on code in Leventhal, Lance A. "6502 Assembly Language
-Routines", p. 201, where it is called "move right". There are
-no official tests for this word.
-
+Routines", p. 201, where it is called "move right".
 
 `cold`:: _Tali Forth_ ( -- ) "Reset the Forth system"
 Reset the Forth system. Does not restart the kernel,
 use the 65c02 reset for that. Flows into ABORT.
-
 
 `compare`:: _ANS string_ ( addr1 u1 addr2 u2 -- -1 | 0 | 1) "Compare two strings"
 https://forth-standard.org/standard/string/COMPARE
@@ -582,7 +433,6 @@ addr2 u2).  Return -1 if string1 < string2, 0 if string1 = string2
 and 1 if string1 > string2 (ASCIIbetical comparison).  A string
 that entirely matches the beginning of the other string, but is
 shorter, is considered less than the longer string.
-
 
 `compile,`:: _ANS core ext_ ( xt -- ) "Compile xt"
 https://forth-standard.org/standard/core/COMPILEComma
@@ -596,38 +446,26 @@ is too large to be natively coded: If the size is larger than
 NC_LIMIT, we silently use subroutine coding. If the AN (Always
 Native) flag is set, the word is always natively compiled
 
-
 `compile-only`:: _Tali Forth_ ( -- ) "Mark most recent word as COMPILE-ONLY"
 Set the Compile Only flag (CO) of the most recently defined
-word. The alternative way to do this is to define a word
-?COMPILE that makes sure  we're in compile mode
-
+word.
 
 `constant`:: _ANS core_ ( n "name" -- ) "Define a constant"
 https://forth-standard.org/standard/core/CONSTANT
-Forth equivalent is  CREATE , DOES> @  but we do
-more in assembler and let CREATE do the heavy lifting.
-See http://www.bradrodriguez.com/papers/moving3.htm for
-a primer on how this works in various Forths. This is the
-same code as VALUE in our case.
-
 
 `count`:: _ANS core_ ( c-addr -- addr u ) "Convert character string to normal format"
 https://forth-standard.org/standard/core/COUNT
 Convert old-style character string to address-length pair. Note
-that the length of the string c-addr ist stored in character length
+that the length of the string c-addr is stored in character length
 (8 bit), not cell length (16 bit). This is rarely used these days,
 though COUNT can also be used to step through a string character by
 character.
-
 
 `cr`:: _ANS core_ ( -- ) "Print a line feed"
 https://forth-standard.org/standard/core/CR
 
 `create`:: _ANS core_ ( "name" -- ) "Create Dictionary entry for 'name'"
 https://forth-standard.org/standard/core/CREATE
-See the drawing in headers.asm for details on the header
-
 
 `d+`:: _ANS double_ ( d d -- d ) "Add two double-celled numbers"
 https://forth-standard.org/standard/double/DPlus
@@ -637,9 +475,6 @@ https://forth-standard.org/standard/double/DMinus
 
 `d.`:: _ANS double_ ( d -- ) "Print double"
 http://forth-standard.org/standard/double/Dd
-From the Forth code:
-: D. TUCK DABS <# #S ROT SIGN #> TYPE SPACE
-
 
 `d.r`:: _ANS double_ ( d u -- ) "Print double right-justified u wide"
 http://forth-standard.org/standard/double/DDotR
@@ -649,7 +484,6 @@ https://forth-standard.org/standard/double/DtoS
 Though this is basically just DROP, we keep it
 separate so we can test for underflow
 
-
 `dabs`:: _ANS double_ ( d -- d ) "Return the absolute value of a double"
 https://forth-standard.org/standard/double/DABS
 
@@ -658,10 +492,7 @@ https://forth-standard.org/standard/core/DECIMAL
 
 `defer`:: _ANS core ext_ ( "name" -- ) "Create a placeholder for words by name"
 https://forth-standard.org/standard/core/DEFER
-Reserve an name that can be linked to various xt by IS. The
-ANS reference implementation is
-CREATE ['] ABORT , DOES> @ EXECUTE
-But we use this routine as a low-level word so things go faster
+Reserve an name that can be linked to various xt by IS.
 
 `defer!`:: _ANS core ext_ ( xt2 x1 -- ) "Set xt1 to execute xt2"
 http://forth-standard.org/standard/core/DEFERStore
@@ -681,71 +512,49 @@ pForth, we get the base (radix) ourselves instead of having the
 user provide it. There is no standard name for this routine, which
 itself is not ANS; we use DIGIT? following pForth and Gforth.
 
-
 `disasm`:: _Tali Forth_ ( addr u -- ) "Disassemble a block of memory"
 Convert a segment of memory to assembler output. This
 word is vectored so people can add their own disassembler.
 Natively, this produces Simpler Assembly Notation (SAN)
 code, see the file disassembler.asm
 
-
 `dnegate`:: _ANS double_ ( d -- d ) "Negate double cell number"
 https://forth-standard.org/standard/double/DNEGATE
 
 `do`:: _ANS core_ ( limit start -- )(R: -- limit start)  "Start a loop"
 https://forth-standard.org/standard/core/DO
-Compile-time part of DO. Could be realized in Forth as
-: DO POSTPONE (DO) HERE ; IMMEDIATE COMPILE-ONLY
-but we do it in assembler for speed. To work with LEAVE, we compile
-a routine that pushes the end address to the Return Stack at run
-time. This is based on a suggestion by Garth Wilson, see
-docs/loops.txt for details. This may not be native compile. Don't
-check for a stack underflow
-
 
 `does>`:: _ANS core_ ( -- ) "Add payload when defining new words"
 https://forth-standard.org/standard/core/DOES
 Create the payload for defining new defining words. See
 http://www.bradrodriguez.com/papers/moving3.htm and
 docs/create-does.txt for a discussion of
-DOES>'s internal workings. This uses tmp1 and tmp2
-
+DOES>'s internal workings.
 
 `drop`:: _ANS core_ ( u -- ) "Pop top entry on Data Stack"
 https://forth-standard.org/standard/core/DROP
 
 `dump`:: _ANS tools_ ( addr u -- ) "Display a memory region"
 https://forth-standard.org/standard/tools/DUMP
-DUMP's exact output is defined as "implementation dependent".
-This is in assembler because it is
-useful for testing and development, so we want to have it work
-as soon as possible. Uses TMP2
-
 
 `dup`:: _ANS core_ ( u -- u u ) "Duplicate TOS"
 https://forth-standard.org/standard/core/DUP
 
 `ed`:: _Tali Forth_ ( -- u ) "Line-based editor"
 Start the line-based editor ed6502. See separate file
-for details.
-
+ed.asm or the manual for details.
 
 `editor-wordlist`:: _Tali Editor_ ( -- u ) "WID for the Editor wordlist"
-This is a dummy entry, the code is shared with ONE
-
 `el`:: _Tali Editor_ ( line# -- ) "Erase the given line number"
 `else`:: _ANS core_ (C: orig -- orig) ( -- ) "Conditional flow control"
 http://forth-standard.org/standard/core/ELSE
-The code is shared with ENDOF
-
 
 `emit`:: _ANS core_ ( char -- ) "Print character to current output"
 https://forth-standard.org/standard/core/EMIT
 Run-time default for EMIT. The user can revector this by changing
 the value of the OUTPUT variable. We ignore the MSB completely, and
 do not check to see if we have been given a valid ASCII character.
-Don't make this native compile
-
+Don't make this native compile.
 
 `empty-buffers`:: _ANS block ext_ ( -- ) "Empty all buffers without saving"
 https://forth-standard.org/standard/block/EMPTY-BUFFERS
@@ -757,7 +566,6 @@ http://forth-standard.org/standard/core/ENDCASE
 http://forth-standard.org/standard/core/ENDOF
 This is a dummy entry, the code is shared with ELSE
 
-
 `enter-screen`:: _Tali Editor_ ( scr# -- ) "Enter all lines for given screen"
 `environment?`:: _ANS core_ ( addr u -- 0 | i*x true )  "Return system information"
 https://forth-standard.org/standard/core/ENVIRONMENTq
@@ -766,7 +574,6 @@ https://forth-standard.org/standard/core/ENVIRONMENTq
 https://forth-standard.org/standard/core/ERASE
 Note that ERASE works with "address" units
 (bytes), not cells.
-
 
 `erase-screen`:: _Tali Editor_ ( scr# -- ) "Erase all lines for given screen"
 `evaluate`:: _ANS core_ ( addr u -- ) "Execute a string"
@@ -778,7 +585,6 @@ start up and cold boot. In contrast to ACCEPT, we need to, uh,
 accept more than 255 characters here, even though it's a pain in
 8-bit.
 
-
 `execute`:: _ANS core_ ( xt -- ) "Jump to word based on execution token"
 https://forth-standard.org/standard/core/EXECUTE
 
@@ -786,17 +592,13 @@ https://forth-standard.org/standard/core/EXECUTE
 https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/The-Input-Stream.html
 Execute the parsing word defined by the execution token (xt) on the
 string as if it were passed on the command line. See the file
-tests/tali.fs for examples. Note that this word is coded completely
-different in its Gforth version, see the file execute-parsing.fs
-(in /usr/share/gforth/0.7.3/compat/ on Ubuntu 18.04 LTS) for details.
-
+tests/tali.fs for examples.
 
 `exit`:: _ANS core_ ( -- ) "Return control to the calling word immediately"
 https://forth-standard.org/standard/core/EXIT
 If we're in a loop, we need to UNLOOP first and get everything
 we we might have put on the Return Stack off as well. This should
-be natively compiled
-
+be natively compiled.
 
 `false`:: _ANS core ext_ ( -- f ) "Push flag FALSE to Data Stack"
 https://forth-standard.org/standard/core/FALSE
@@ -807,7 +609,6 @@ Fill u bytes of memory with char starting at addr. Note that
 this works on bytes, not on cells. On an 8-bit machine such as the
 65c02, this is a serious pain in the rear. It is not defined what
 happens when we reach the end of the address space
-
 
 `find`:: _ANS core_ ( caddr -- addr 0 | xt 1 | xt -1 ) "Find word in Dictionary"
 https://forth-standard.org/standard/core/FIND
@@ -820,21 +621,13 @@ FIND-NAME, we get this all over with as quickly as possible. See
 https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Word-Lists.html
 https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html
 
-
 `find-name`:: _Gforth_ ( addr u -- nt|0 ) "Get the name token of input word"
 `flush`:: _ANS block_ ( -- ) "Save dirty buffers and empty buffers"
 https://forth-standard.org/standard/block/FLUSH
 
 `fm/mod`:: _ANS core_ ( d n1  -- rem n2 ) "Floored signed division"
 https://forth-standard.org/standard/core/FMDivMOD
-There are various ways to realize this. We follow EForth with
-DUP 0< DUP >R  IF NEGATE >R DNEGATE R> THEN >R DUP
-0<  IF R@ + THEN  R> UM/MOD R> IF SWAP NEGATE SWAP THEN
-See (http://www.forth.org/eforth.html). However you can also
-go FM/MOD via SM/REM (http://www.figuk.plus.com/build/arith.htm):
-DUP >R  SM/REM DUP 0< IF SWAP R> + SWAP 1+ ELSE  R> DROP THEN
 Note that by default, Tali Forth uses SM/REM for most things.
-
 
 `forth`:: _ANS search ext_ ( -- ) "Replace first WID in search order with Forth-Wordlist"
 https://forth-standard.org/standard/search/FORTH
@@ -863,22 +656,16 @@ by spaces, store the numbers at the address addr2, returning the
 number of elements. Non-number elements are skipped, an zero-length
 string produces a zero output.
 
-
 `hold`:: _ANS core_ ( char -- ) "Insert character at current output"
 https://forth-standard.org/standard/core/HOLD
 Insert a character at the current position of a pictured numeric
 output string on
 https://github.com/philburk/pforth/blob/master/fth/numberio.fth
-Forth code is : HOLD  -1 HLD +!  HLD @ C! ;  We use the the internal
-variable tohold instead of HLD.
-
 
 `i`:: _ANS core_ ( -- n )(R: n -- n)  "Copy loop counter to stack"
 https://forth-standard.org/standard/core/I
 Note that this is not the same as R@ because we use a fudge
-factor for loop control; see docs/loop.txt for details. We
-should make this native compile for speed.
-
+factor for loop control; see docs/loop.txt for details.
 
 `if`:: _ANS core_ (C: -- orig) (flag -- ) "Conditional flow control"
 http://forth-standard.org/standard/core/IF
@@ -890,18 +677,15 @@ affect the last word in the dictionary. Note that if the word is
 defined in ROM, this will have no affect, but will not produce an
 error message.
 
-
 `input`:: _Tali Forth_ ( -- addr ) "Return address of input vector"
 `input>r`:: _Tali Forth_ ( -- ) ( R: -- n n n n ) "Save input state to the Return Stack"
 Save the current input state as defined by insrc, cib, ciblen, and
-toin to the Return Stack. Used by EVALUTE. The naive way of doing
-this is to push each two-byte variable to the stack in the form of
+toin to the Return Stack. Used by EVALUTE.
 
 `int>name`:: _Tali Forth_ ( xt -- nt ) "Get name token from execution token"
 www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html
 This is called >NAME in Gforth, but we change it to
 INT>NAME to match NAME>INT
-
 
 `invert`:: _ANS core_ ( n -- n ) "Complement of TOS"
 https://forth-standard.org/standard/core/INVERT
@@ -918,13 +702,11 @@ on the stack above this (three entries), whereas the ideal Forth
 implementation would just have two. Make this native compiled for
 speed
 
-
 `key`:: _ANS core_ ( -- char ) "Get one character from the input"
 `l`:: _Tali Editor_ ( -- ) "List the current screen"
 `latestnt`:: _Tali Forth_ ( -- nt ) "Push most recent nt to the stack"
 www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html
 The Gforth version of this word is called LATEST
-
 
 `latestxt`:: _Gforth_ ( -- xt ) "Push most recent xt to the stack"
 http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Anonymous-Definitions.html
@@ -934,10 +716,6 @@ https://forth-standard.org/standard/core/LEAVE
 Note that this does not work with  anything but a DO/LOOP in
 contrast to other versions such as discussed at
 http://blogs.msdn.com/b/ashleyf/archive/2011/02/06/loopty-do-i-loop.aspx
-: LEAVE POSTPONE BRANCH HERE SWAP 0 , ; IMMEDIATE COMPILE-ONLY
-See docs/loops.txt on details of how this works. This must be native
-compile and not IMMEDIATE
-
 
 `line`:: _Tali Editor_ ( line# -- c-addr ) "Turn a line number into address in current screen"
 `list`:: _ANS block ext_ ( scr# scr# -- ) "Load screens in the given range"
@@ -949,25 +727,14 @@ https://forth-standard.org/standard/core/LITERAL
 Compile-only word to store TOS so that it is pushed on stack
 during runtime. This is a immediate, compile-only word. At runtime,
 it works by calling literal_runtime by compling JSR LITERAL_RT.
-Note the cmpl_ routines use TMPTOS
-
 
 `load`:: _ANS block_ ( scr# -- ) "Load the Forth code in a screen/block"
 https://forth-standard.org/standard/block/LOAD
-Note: LOAD current works because there is only one buffer.
-if/when multiple buffers are supported, we'll have to deal
-with the fact that it might re-load the old block into a
-different buffer.
-
 
 `loop`:: _ANS core_ ( -- ) "Finish loop construct"
 https://forth-standard.org/standard/core/LOOP
 Compile-time part of LOOP. This does nothing more but push 1 on
-the stack and then call +LOOP. In Forth, this is
-: LOOP  POSTPONE 1 POSTPONE (+LOOP) , POSTPONE UNLOOP
-IMMEDIATE ; COMPILE-ONLY
-This drops through to +LOOP
-
+the stack and then call +LOOP.
 
 `lshift`:: _ANS core_ ( x u -- u ) "Shift TOS left"
 https://forth-standard.org/standard/core/LSHIFT
@@ -975,10 +742,7 @@ https://forth-standard.org/standard/core/LSHIFT
 `m*`:: _ANS core_ ( n n -- d ) "16 * 16 --> 32"
 https://forth-standard.org/standard/core/MTimes
 Multiply two 16 bit numbers, producing a 32 bit result. All
-values are signed. Adapted from FIG Forth for Tali Forth. The
-original Forth is : M* OVER OVER XOR >R ABS SWAP ABS UM* R> D+-
-with  : D+- O< IF DNEGATE THEN
-
+values are signed. Adapted from FIG Forth for Tali Forth.
 
 `marker`:: _ANS core ext_ ( "name" -- ) "Create a deletion boundry"
 https://forth-standard.org/standard/core/MARKER
@@ -996,32 +760,25 @@ Flag indicates which number is larger. See also
 http://6502.org/tutorials/compare_instructions.html and
 http://www.righto.com/2012/12/the-6502-overflow-flag-explained.html
 
-
 `min`:: _ANS core_ ( n n -- n ) "Keep smaller of two numbers"
 https://forth-standard.org/standard/core/MIN
 Adapted from Lance A. Leventhal "6502 Assembly Language
 Subroutines." Negative Flag indicateds which number is larger. See
 http://www.righto.com/2012/12/the-6502-overflow-flag-explained.html
 
-
 `mod`:: _ANS core_ ( n1 n2 -- n ) "Divide NOS by TOS and return the remainder"
 https://forth-standard.org/standard/core/MOD
-The Forth definition of this word is  : MOD /MOD DROP
-so we just jump to xt_slash_mod and dump the actual result.
-
 
 `move`:: _ANS core_ ( addr1 addr2 u -- ) "Copy bytes"
 https://forth-standard.org/standard/core/MOVE
 Copy u "address units" from addr1 to addr2. Since our address
 units are bytes, this is just a front-end for CMOVE and CMOVE>. This
 is actually the only one of these three words that is in the CORE
-set. This word must not be natively compiled
-
+set.
 
 `name>int`:: _Gforth_ ( nt -- xt ) "Convert Name Token to Execute Token"
 See
 https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html
-
 
 `name>string`:: _Gforth_ ( nt -- addr u ) "Given a name token, return string of word"
 http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html
@@ -1044,10 +801,7 @@ Gforth uses S>NUMBER? and S>UNUMBER? which return numbers and a flag
 https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Number-Conversion.html
 Another difference to Gforth is that we follow ANS Forth that the
 dot to signal a double cell number is required to be the last
-character of the string. Number calls >NUMBER which in turn calls UM*,
-which uses tmp1, tmp2, and tmp3, so we can't use them here, which is
-a pain.
-
+character of the string.
 
 `o`:: _Tali Editor_ ( line# -- ) "Overwrite the given line"
 `of`:: _ANS core ext_ (C: -- of-sys) (x1 x2 -- |x1) "Conditional flow control" 
@@ -1061,7 +815,9 @@ https://forth-standard.org/standard/core/OR
 
 `order`:: _ANS core_ ( -- ) "Print current word order list and current WID"
 https://forth-standard.org/standard/search/ORDER
-A Forth implementation of this word is:
+Note the search order is displayed from first search to last
+searched and is therefore exactly the reverse of the order in which
+Forth stacks are displayed.
 
 `output`:: _Tali Forth_ ( -- addr ) "Return the address of the EMIT vector address"
 `over`:: _ANS core_ ( b a -- b a b ) "Copy NOS to TOS"
@@ -1074,13 +830,11 @@ be at least 84 bytes in size (says ANS). It is located relative to
 the compile area pointer (CP) and therefore varies in position.
 This area is reserved for the user and not used by the system
 
-
 `page`:: _ANS facility_ ( -- ) "Clear the screen"
 https://forth-standard.org/standard/facility/PAGE
 Clears a page if supported by ANS terminal codes. This is
 Clear Screen ("ESC[2J") plus moving the cursor to the top
 left of the screen
-
 
 `parse`:: _ANS core ext_ ( "name" c -- addr u ) "Parse input with delimiter character"
 https://forth-standard.org/standard/core/PARSE
@@ -1103,7 +857,6 @@ is actually perfectly legal (see for example
 http://forth-standard.org/standard/usage#subsubsection.3.4.1.1).
 Otherwise, PARSE-NAME chokes on tabs.
 
-
 `pick`:: _ANS core ext_ ( n n u -- n n n ) "Move element u of the stack to TOS"
 https://forth-standard.org/standard/core/PICK
 Take the u-th element out of the stack and put it on TOS,
@@ -1111,17 +864,12 @@ overwriting the original TOS. 0 PICK is equivalent to DUP, 1 PICK to
 OVER. Note that using PICK is considered poor coding form. Also note
 that FIG Forth has a different behavior for PICK than ANS Forth.
 
-
 `postpone`:: _ANS core_ ( -- ) "Change IMMEDIATE status (it's complicated)"
 https://forth-standard.org/standard/core/POSTPONE
 Add the compilation behavior of a word to a new word at
 compile time. If the word that follows it is immediate, include
 it so that it will be compiled when the word being defined is
-itself used for a new word. Tricky, but very useful. Because
-POSTPONE expects a word (not an xt) in the input stream (not
-on the Data Stack). This means we cannot build words with
-jsr xt_postpone, jsr <word>" directly.
-
+itself used for a new word. Tricky, but very useful.
 
 `previous`:: _ANS search ext_ ( -- ) "Remove the first wordlist in the search order"
 http://forth-standard.org/standard/search/PREVIOUS
@@ -1130,33 +878,21 @@ http://forth-standard.org/standard/search/PREVIOUS
 https://forth-standard.org/standard/core/QUIT
 Rest the input and start command loop
 
-
 `r>`:: _ANS core_ ( -- n )(R: n --) "Move top of Return Stack to TOS"
 https://forth-standard.org/standard/core/Rfrom
-Move Top of Return Stack to Top of Data Stack. We have to move
-the RTS address out of the way first. This word is handled
-differently for native and and subroutine compilation, see COMPILE,
-This is a compile-only word
-
+Move Top of Return Stack to Top of Data Stack.
 
 `r>input`:: _Tali Forth_ ( -- ) ( R: n n n n -- ) "Restore input state from Return Stack"
 Restore the current input state as defined by insrc, cib, ciblen,
-and toin from the Return Stack. See INPUT_TO_R for a discussion of
-this word. Uses tmp1
-
+and toin from the Return Stack.
 
 `r@`:: _ANS core_ ( -- n ) "Get copy of top of Return Stack"
 https://forth-standard.org/standard/core/RFetch
 This word is Compile Only in Tali Forth, though Gforth has it
-work normally as well -- An alternative way to write this word
-would be to access the elements on the stack directly like 2R@
-does, these versions should be compared at some point.
-
+work normally as well
 
 `recurse`:: _ANS core_ ( -- ) "Copy recursive call to word being defined"
 https://forth-standard.org/standard/core/RECURSE
-This word may not be natively compiled
-
 
 `refill`:: _ANS core ext_ ( -- f ) "Refill the input buffer"
 https://forth-standard.org/standard/core/REFILL
@@ -1171,7 +907,6 @@ return false and perform no other action." See
 https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/The-Input-Stream.html
 and Conklin & Rather p. 156
 
-
 `repeat`:: _ANS core_ (C: orig dest -- ) ( -- ) "Loop flow control"
 http://forth-standard.org/standard/core/REPEAT
 
@@ -1181,7 +916,6 @@ https://forth-standard.org/standard/core/ROT
 Remember "R for 'Revolution'" - the bottom entry comes out
 on top!
 
-
 `rshift`:: _ANS core_ ( x u -- x ) "Shift TOS to the right"
 https://forth-standard.org/standard/core/RSHIFT
 
@@ -1190,10 +924,7 @@ https://forth-standard.org/standard/core/Sq
 Store address and length of string given, returning ( addr u ).
 ANS core claims this is compile-only, but the file set expands it
 to be interpreted, so it is a state-sensitive word, which in theory
-are evil. We follow general usage. Can also be realized as
-: S" [CHAR] " PARSE POSTPONE SLITERAL ; IMMEDIATE
-but it is used so much we want it in code.
-
+are evil. We follow general usage.
 
 `s>d`:: _ANS core_ ( u -- d ) "Convert single cell number to double cell"
 https://forth-standard.org/standard/core/StoD
@@ -1205,7 +936,6 @@ ANS core claims this is compile-only, but the file set expands it
 to be interpreted, so it is a state-sensitive word, which in theory
 are evil. We follow general usage.  This is just like S" except
 that it allows for some special escaped characters.
-
 
 `save-buffers`:: _ANS block_ ( -- ) "Save all dirty buffers to storage"
 https://forth-standard.org/standard/block/SAVE-BUFFERS
@@ -1222,7 +952,6 @@ the number of characters remaining from the match point to the end
 of the original string1.  If a match is not found, the flag will be
 false and addr3 and u3 will be the original string1's addr1 and u1.
 
-
 `search-wordlist`:: _ANS search_ ( caddr u wid -- 0 | xt 1 | xt -1) "Search for a word in a wordlist"
 https://forth-standard.org/standard/search/SEARCH_WORDLIST
 
@@ -1232,7 +961,6 @@ SEE takes the name of a word and prints its name token (nt),
 execution token (xt), size in bytes, flags used, and then dumps the
 code and disassembles it.
 
-
 `set-current`:: _ANS search_ ( wid -- ) "Set the compilation wordlist"
 https://forth-standard.org/standard/search/SET-CURRENT
 
@@ -1241,23 +969,15 @@ https://forth-standard.org/standard/search/SET-ORDER
 
 `sign`:: _ANS core_ ( n -- ) "Add minus to pictured output"
 https://forth-standard.org/standard/core/SIGN
-Code based on
-http://pforth.googlecode.com/svn/trunk/fth/numberio.fth
-Original Forth code is   0< IF ASCII - HOLD THEN
-
 
 `sliteral`:: _ANS string_ ( addr u -- )( -- addr u ) "Compile a string for runtime"
 https://forth-standard.org/standard/string/SLITERAL
 Add the runtime for an existing string.
 
-
 `sm/rem`:: _ANS core_ ( d n1 -- n2 n3 ) "Symmetic signed division"
 https://forth-standard.org/standard/core/SMDivREM
 Symmetic signed division. Compare FM/MOD. Based on F-PC 3.6
-by Ulrich Hoffmann. See http://www.xlerb.de/uho/ansi.seq Forth:
-OVER >R 2DUP XOR 0< >R ABS >R DABS R> UM/MOD R> ?NEGATE SWAP
-R> ?NEGATE SWAP
-
+by Ulrich Hoffmann. See http://www.xlerb.de/uho/ansi.seq
 
 `source`:: _ANS core_ ( -- addr u ) "Return location and size of input buffer""
 https://forth-standard.org/standard/core/SOURCE
@@ -1268,7 +988,6 @@ Identify the input source unless it is a block (s. Conklin &
 Rather p. 156). Since we don't have blocks (yet), this will give
 the input source: 0 is keyboard, -1 (0ffff) is character string,
 and a text file gives the fileid.
-
 
 `space`:: _ANS core_ ( -- ) "Print a single space"
 https://forth-standard.org/standard/core/SPACE
@@ -1283,12 +1002,10 @@ we do not return the state itself, but only the address where
 it lives. The state should not be changed directly by the user; see
 http://forth.sourceforge.net/standard/dpans/dpans6.htm#6.1.2250
 
-
 `strip-underflow`:: _Tali Forth_ ( -- addr ) "Return address where underflow status is kept"
 STRIP_UNDERFLOW contains a flag that determines if underflow
 checking should be removed during the compilation of new words.
 Default is false.
-
 
 `swap`:: _ANS core_ ( b a -- a b ) "Exchange TOS and NOS"
 https://forth-standard.org/standard/core/SWAP
@@ -1308,16 +1025,10 @@ https://forth-standard.org/standard/core/TUCK
 
 `type`:: _ANS core_ ( addr u -- ) "Print string"
 https://forth-standard.org/standard/core/TYPE
-Works through EMIT to allow OUTPUT revectoring. Currently, only
-strings of up to 255 characters are printed
-
+Works through EMIT to allow OUTPUT revectoring.
 
 `u.`:: _ANS core_ ( u -- ) "Print TOS as unsigned number"
 https://forth-standard.org/standard/core/Ud
-This is : U. 0 <# #S #> TYPE SPACE ; in Forth
-We use the internal assembler function print_u followed
-by a single space
-
 
 `u.r`:: _ANS core ext_ ( u u -- ) "Print NOS as unsigned number with TOS with"
 https://forth-standard.org/standard/core/UDotR
@@ -1331,10 +1042,8 @@ https://forth-standard.org/standard/core/Umore
 `ud.`:: _Tali double_ ( d -- ) "Print double as unsigned"
 Based on the Forth code  : UD. <# #S #> TYPE SPACE
 
-
 `ud.r`:: _Tali double_ ( d u -- ) "Print unsigned double right-justified u wide"
 Based on the Forth code : UD.R  >R <# #S #> R> OVER - SPACES TYPE
-
 
 `um*`:: _ANS core_ ( u u -- ud ) "Multiply 16 x 16 -> 32"
 https://forth-standard.org/standard/core/UMTimes
@@ -1348,13 +1057,9 @@ quotient as TOS and any remainder as NOS. All numbers are unsigned.
 This is the basic division operation all others use. Based on FIG
 Forth code, modified by Garth Wilson, see
 http://6502.org/source/integers/ummodfix/ummodfix.htm
-This uses tmp1, tmp1+1, and tmptos
-
 
 `unloop`:: _ANS core_ ( -- )(R: n1 n2 n3 ---) "Drop loop control from Return stack"
 https://forth-standard.org/standard/core/UNLOOP
-Note that 6xPLA uses just as many bytes as a loop would
-
 
 `until`:: _ANS core_ (C: dest -- ) ( -- ) "Loop flow control"
 http://forth-standard.org/standard/core/UNTIL
@@ -1365,34 +1070,24 @@ UNUSED does not include the ACCEPT history buffers. Total RAM
 should be HERE + UNUSED + <history buffer size>, the last of which
 defaults to $400
 
-
 `update`:: _ANS block_ ( -- ) "Mark current block as dirty"
 https://forth-standard.org/standard/block/UPDATE
 
 `useraddr`:: _Tali Forth_ ( -- addr ) "Push address of base address of user variables"
 `value`:: _ANS core_ ( n "name" -- ) "Define a value"
 https://forth-standard.org/standard/core/VALUE
-This is a dummy header for the WORDLIST. The actual code is
-identical to that of CONSTANT
-
 
 `variable`:: _ANS core_ ( "name" -- ) "Define a variable"
 https://forth-standard.org/standard/core/VARIABLE
 There are various Forth definitions for this word, such as
-CREATE 1 CELLS ALLOT  or  CREATE 0 ,  We use a variant of the
+`CREATE 1 CELLS ALLOT`  or  `CREATE 0 ,`  We use a variant of the
 second one so the variable is initialized to zero
-
 
 `while`:: _ANS core_ ( C: dest -- orig dest ) ( x -- ) "Loop flow control"
 http://forth-standard.org/standard/core/WHILE
 
 `within`:: _ANS core ext_ ( n1 n2 n3 -- ) "See if within a range"
 https://forth-standard.org/standard/core/WITHIN
-This an assembler version of the ANS Forth implementation
-at https://forth-standard.org/standard/core/WITHIN which is
-OVER - >R - R> U<  note there is an alternative high-level version
-ROT TUCK > -ROT > INVERT AND
-
 
 `word`:: _ANS core_ ( char "name " -- caddr ) "Parse input stream"
 https://forth-standard.org/standard/core/WORD
@@ -1403,23 +1098,12 @@ Returns the result as a counted string (requires COUNT to convert
 to modern format), and inserts a space after the string. See "Forth
 Programmer's Handbook" 3rd edition p. 159 and
 http://www.forth200x.org/documents/html/rationale.html#rat:core:PARSE
-for discussions of why you shouldn't be using WORD anymore. Forth
-would be   PARSE DUP BUFFER1 C! OUTPUT 1+ SWAP MOVE BUFFER1
-We only allow input of 255 chars. Seriously, use PARSE-NAME.
-
+for discussions of why you shouldn't be using WORD anymore.
 
 `wordlist`:: _ANS search_ ( -- wid ) "Create new wordlist (from pool of 8)"
 https://forth-standard.org/standard/search/WORDLIST
 
 `words`:: _ANS tools_ ( -- ) "Print known words from Dictionary"
-https://forth-standard.org/standard/tools/WORDS
-This is pretty much only used at the command line so we can
-be slow and try to save space. DROP must always be the first word in a
-clean system (without Forth words), BYE the last. There is no reason
-why we couldn't define this as a high level word except that it is
-really useful for testing
-
-
 `wordsize`:: _Tali Forth_ ( nt -- u ) "Get size of word in bytes"
 Given an word's name token (nt), return the size of the
 word's payload size in bytes (CFA plus PFA) in bytes. Does not

--- a/docs/ch_glossary.adoc
+++ b/docs/ch_glossary.adoc
@@ -983,25 +983,10 @@ with  : D+- O< IF DNEGATE THEN
 `marker`:: _ANS core ext_ ( "name" -- ) "Create a deletion boundry"
 https://forth-standard.org/standard/core/MARKER
 This word replaces FORGET in earlier Forths. Old entries are not
-actually deleted, but merely overwritten by restoring CP and DP. To
-do this, we want to end up with something that jumps to a run-time
-component with a link to the original CP and DP values:
-
-jsr marker_runtime
-<Original CP MSB>
-<Original CP LSB>
-<Original DP MSB> ( for CURRENT wordlist )
-<Original DP LSB>
-< USER variables from offset 4 to 39 >
-
-The user variables include:
-CURRENT (byte variable)
-<All wordlists> (currently 12) (cell array)
-<#ORDER> (byte variable)
-<All search order> (currently 9) (byte array)
-
-This code uses tmp1 and tmp2
-
+actually deleted, but merely overwritten by restoring CP and DP.
+Run the named word at a later time to restore all of the wordlists
+to their state when the word was created with marker.  Any words
+created after the marker (including the marker) will be forgotten.
 
 `max`:: _ANS core_ ( n n -- n ) "Keep larger of two numbers"
 https://forth-standard.org/standard/core/MAX
@@ -1103,22 +1088,6 @@ Find word in input string delimited by character given. Do not
 skip leading delimiters -- this is the main difference to PARSE-NAME.
 PARSE and PARSE-NAME replace WORD in modern systems. ANS discussion
 http://www.forth200x.org/documents/html3/rationale.html#rat:core:PARSE
-
-cib  cib+toin   cib+ciblen
-v      v            v
-|###################|
-
-|------>|  toin (>IN)
-|------------------->|  ciblen
-
-The input string is stored starting at the address in the Current
-Input Buffer (CIB), the length of which is in CIBLEN. While searching
-for the delimiter, TOIN (>IN) points to the where we currently are.
-Since PARSE does not skip leading delimiters, we assume we are on a
-useful string if there are any characters at all. As with
-PARSE-NAME, we must be able to handle strings with a length of
-16-bit for EVALUTE, which is a pain on an 8-bit machine.
-
 
 `parse-name`:: _ANS core ext_ ( "name" -- addr u ) "Parse the input"
 https://forth-standard.org/standard/core/PARSE-NAME
@@ -1329,19 +1298,7 @@ http://forth-standard.org/standard/core/THEN
 
 `to`:: _ANS core ext_ ( n "name" -- ) or ( "name") "Change a value"
 https://forth-standard.org/standard/core/TO
-Gives a new value to a, uh, VALUE. One possible Forth
-implementation is  ' >BODY !  but given the problems we have
-with >BODY on STC Forths, we do this the hard way. Since
-Tali Forth uses the same code for CONSTANTs and VALUEs, you
-could use this to redefine a CONSTANT, but that is a no-no.
-
-Note that the standard has different behaviors for TO depending
-on the state (https://forth-standard.org/standard/core/TO).
-This makes TO state-dependent (which is bad) and also rather
-complex (see the Gforth implementation for comparison). This
-word may not be natively compiled and must be immediate. Frankly,
-it would have made more sense to have two words for this.
-
+Gives a new value to a, uh, VALUE.
 
 `true`:: _ANS core ext_ ( -- f ) "Push TRUE flag to Data Stack"
 https://forth-standard.org/standard/core/TRUE
@@ -1382,19 +1339,7 @@ Based on the Forth code : UD.R  >R <# #S #> R> OVER - SPACES TYPE
 `um*`:: _ANS core_ ( u u -- ud ) "Multiply 16 x 16 -> 32"
 https://forth-standard.org/standard/core/UMTimes
 Multiply two unsigned 16 bit numbers, producing a 32 bit result.
-This is based on modified FIG Forth code by Dr. Jefyll, see
-http://forum.6502.org/viewtopic.php?f=9&t=689 for a detailed
-discussion. We don't use the system scratch pad (SYSPAD) for temp
-storage because >NUMBER uses it as well, but instead tmp1 to
-tmp3 (tmp1 is N in the original code, tmp1+1 is N+1, etc).
 Old Forth versions such as FIG Forth call this U*
-
-Consider switching to a table-supported version based on
-http://codebase64.org/doku.php?id=base:seriously_fast_multiplication
-http://codebase64.org/doku.php?id=magazines:chacking16#d_graphics_for_the_masseslib3d>
-http://forum.6502.org/viewtopic.php?p=205#p205
-http://forum.6502.org/viewtopic.php?f=9&t=689
-
 
 `um/mod`:: _ANS core_ ( ud u -- ur u ) "32/16 -> 16 division"
 https://forth-standard.org/standard/core/UMDivMOD

--- a/docs/manual.adoc
+++ b/docs/manual.adoc
@@ -86,6 +86,9 @@ include::ch_tutorial_wordlists.adoc[]
 // --------------------------------------------------------
 = Appendix
 
+== Glossary
+include::ch_glossary.adoc[]
+
 == Reporting Problems
 
 The best way to point out a bug or make any other form of a comment is on Tali

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.5">
+<meta name="generator" content="Asciidoctor 1.5.6.1">
 <meta name="keywords" content="forth, 6502, assembler, programming, 8-bit, vintage, retro">
 <meta name="author" content="Sam Colwell, Scot W. Stevenson">
 <title>Manual for Tali Forth 2 for the 65c02</title>
@@ -91,13 +91,12 @@ strong,b{font-weight:bold;line-height:inherit}
 small{font-size:60%;line-height:inherit}
 code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
 ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol,ul.no-bullet,ol.no-bullet{margin-left:1.5em}
+ul,ol{margin-left:1.5em}
 ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
 ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
 ul.square{list-style-type:square}
 ul.circle{list-style-type:circle}
 ul.disc{list-style-type:disc}
-ul.no-bullet{list-style:none}
 ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
 dl dt{margin-bottom:.3125em;font-weight:bold}
 dl dd{margin-bottom:1.25em}
@@ -133,7 +132,11 @@ strong strong{font-weight:400}
 kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
 .keyseq kbd:first-child{margin-left:0}
 .keyseq kbd:last-child{margin-right:0}
-.menuseq,.menu{color:rgba(0,0,0,.8)}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
 b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
 b.button:before{content:"[";padding:0 3px 0 2px}
 b.button:after{content:"]";padding:0 2px 0 3px}
@@ -200,7 +203,7 @@ table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
 table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
 .admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
 .admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon img{max-width:initial}
 .admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
 .admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
 .admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
@@ -256,13 +259,13 @@ table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
 table.tableblock{max-width:100%;border-collapse:separate}
 table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
 table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all th.tableblock,table.grid-all td.tableblock{border-width:0 1px 1px 0}
-table.grid-all tfoot>tr>th.tableblock,table.grid-all tfoot>tr>td.tableblock{border-width:1px 1px 0 0}
-table.grid-cols th.tableblock,table.grid-cols td.tableblock{border-width:0 1px 0 0}
-table.grid-all *>tr>.tableblock:last-child,table.grid-cols *>tr>.tableblock:last-child{border-right-width:0}
-table.grid-rows th.tableblock,table.grid-rows td.tableblock{border-width:0 0 1px 0}
-table.grid-all tbody>tr:last-child>th.tableblock,table.grid-all tbody>tr:last-child>td.tableblock,table.grid-all thead:last-child>tr>th.tableblock,table.grid-rows tbody>tr:last-child>th.tableblock,table.grid-rows tbody>tr:last-child>td.tableblock,table.grid-rows thead:last-child>tr>th.tableblock{border-bottom-width:0}
-table.grid-rows tfoot>tr>th.tableblock,table.grid-rows tfoot>tr>td.tableblock{border-width:1px 0 0 0}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px 0}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
 table.frame-all{border-width:1px}
 table.frame-sides{border-width:0 1px}
 table.frame-topbot{border-width:1px 0}
@@ -283,10 +286,12 @@ ul li ol{margin-left:1.5em}
 dl dd{margin-left:1.125em}
 dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
 ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.unstyled,ol.unnumbered,ul.checklist,ul.none{list-style-type:none}
-ul.unstyled,ol.unnumbered,ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1em;font-size:.85em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{width:1em;position:relative;top:1px}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
 ul.inline{margin:0 auto .625em auto;margin-left:-1.375em;margin-right:0;padding:0;list-style:none;overflow:hidden}
 ul.inline>li{list-style:none;float:left;margin-left:1.375em;display:block}
 ul.inline>li>*{display:block}
@@ -303,7 +308,8 @@ ol.lowergreek{list-style-type:lower-greek}
 td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
 td.hdlist1{font-weight:bold;padding-bottom:1.25em}
 .literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist>table tr>td:first-of-type{padding:0 .75em;line-height:1}
+.colist>table tr>td:first-of-type{padding:.4em .75em 0 .75em;line-height:1;vertical-align:top}
+.colist>table tr>td:first-of-type img{max-width:initial}
 .colist>table tr>td:last-of-type{padding:.25em 0}
 .thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
 .imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
@@ -366,6 +372,7 @@ div.unbreakable{page-break-inside:avoid}
 .yellow{color:#bfbf00}
 .yellow-background{background-color:#fafa00}
 span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
 .admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
 .admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
 .admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
@@ -495,7 +502,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_the_words_code_create_code_and_code_does_code">The Words <code>create</code> and <code>does&gt;</code></a></li>
 <li><a href="#_control_flow">Control Flow</a></li>
 <li><a href="#_native_compiling_2">Native Compiling</a></li>
-<li><a href="#__code_cmove_code_code_cmove_code_and_code_move_code"><code>cmove</code>, <code>cmove&gt;</code> and <code>move</code></a></li>
+<li><a href="#_code_cmove_code_code_cmove_code_and_code_move_code"><code>cmove</code>, <code>cmove&gt;</code> and <code>move</code></a></li>
 </ul>
 </li>
 <li><a href="#_developing">Developing</a>
@@ -539,6 +546,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </li>
 <li><a href="#_appendix">Appendix</a>
 <ul class="sectlevel1">
+<li><a href="#_glossary">Glossary</a></li>
 <li><a href="#_reporting_problems">Reporting Problems</a></li>
 <li><a href="#_faq">FAQ</a></li>
 <li><a href="#_testing_tali_forth_2">Testing Tali Forth 2</a>
@@ -3666,7 +3674,7 @@ a list of what we want to happen at compile time and what at run time. Let&#8217
 start with a simple <code>do</code>-<code>loop</code>.</p>
 </div>
 <div class="sect4">
-<h5 id="__code_do_code_at_compile_time"><code>do</code> at compile-time:</h5>
+<h5 id="_code_do_code_at_compile_time"><code>do</code> at compile-time:</h5>
 <div class="ulist">
 <ul>
 <li>
@@ -3687,7 +3695,7 @@ where the loop contents begin</p>
 </div>
 </div>
 <div class="sect4">
-<h5 id="__code_do_code_at_run_time"><code>do</code> at run-time:</h5>
+<h5 id="_code_do_code_at_run_time"><code>do</code> at run-time:</h5>
 <div class="ulist">
 <ul>
 <li>
@@ -3701,7 +3709,7 @@ away with considering them at the same time.</p>
 </div>
 </div>
 <div class="sect4">
-<h5 id="__code_loop_code_at_compile_time"><code>loop</code> at compile time:</h5>
+<h5 id="_code_loop_code_at_compile_time"><code>loop</code> at compile time:</h5>
 <div class="ulist">
 <ul>
 <li>
@@ -3727,7 +3735,7 @@ construct to the Return Stack at run-time</p>
 </div>
 </div>
 <div class="sect4">
-<h5 id="__code_loop_code_at_run_time_which_is_code_loop_code"><code>loop</code> at run-time (which is <code>(+loop)</code>)</h5>
+<h5 id="_code_loop_code_at_run_time_which_is_code_loop_code"><code>loop</code> at run-time (which is <code>(+loop)</code>)</h5>
 <div class="ulist">
 <ul>
 <li>
@@ -4059,7 +4067,7 @@ headers.asm file and should never have the AN (Always Native) flag set.
 </div>
 </div>
 <div class="sect2">
-<h3 id="__code_cmove_code_code_cmove_code_and_code_move_code"><code>cmove</code>, <code>cmove&gt;</code> and <code>move</code></h3>
+<h3 id="_code_cmove_code_code_cmove_code_and_code_move_code"><code>cmove</code>, <code>cmove&gt;</code> and <code>move</code></h3>
 <div class="paragraph">
 <p>The three moving words <code>cmove</code>, <code>cmove&gt;</code> and <code>move</code> show subtle differences
 that can trip up new users and are reflected by different code under the hood.
@@ -6551,6 +6559,2741 @@ order if you run it too many times.</p>
 </div>
 <h1 id="_appendix" class="sect0">Appendix</h1>
 <div class="sect1">
+<h2 id="_glossary">Glossary</h2>
+<div class="sectionbody">
+<div class="hdlist">
+<table>
+<tr>
+<td class="hdlist1">
+<code>!</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n addr&#8201;&#8212;&#8201;) "Store TOS in memory"
+<a href="https://forth-standard.org/standard/core/Store" class="bare">https://forth-standard.org/standard/core/Store</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>#</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( ud&#8201;&#8212;&#8201;ud ) "Add character to pictured output string"
+<a href="https://forth-standard.org/standard/core/num" class="bare">https://forth-standard.org/standard/core/num</a>
+Add one char to the beginning of the pictured output string. Based
+on <a href="https://github.com/philburk/pforth/blob/master/fth/numberio.fth" class="bare">https://github.com/philburk/pforth/blob/master/fth/numberio.fth</a>
+Forth code  BASE @ UD/MOD ROT 9 OVER &lt; IF 7 + THEN [CHAR] 0 + HOLD</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>#&gt;</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( d&#8201;&#8212;&#8201;addr u ) "Finish pictured number conversion"
+<a href="https://forth-standard.org/standard/core/num-end" class="bare">https://forth-standard.org/standard/core/num-end</a>
+Finish conversion of pictured number string, putting address and
+length on the Data Stack. Original Fort is  2DROP HLD @ PAD OVER -
+Based on
+<a href="https://github.com/philburk/pforth/blob/master/fth/numberio.fth" class="bare">https://github.com/philburk/pforth/blob/master/fth/numberio.fth</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>#s</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( d&#8201;&#8212;&#8201;addr u ) "Completely convert pictured output"
+<a href="https://forth-standard.org/standard/core/numS" class="bare">https://forth-standard.org/standard/core/numS</a>
+Completely convert number for pictured numerical output. Based on
+<a href="https://github.com/philburk/pforth/blob/master/fth/system.fth" class="bare">https://github.com/philburk/pforth/blob/master/fth/system.fth</a>
+Original Forth code  BEGIN # 2DUP OR 0= UNTIL</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>'</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( "name"&#8201;&#8212;&#8201;xt ) "Return a word&#8217;s execution token (xt)"
+<a href="https://forth-standard.org/standard/core/Tick" class="bare">https://forth-standard.org/standard/core/Tick</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>(</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Discard input up to close paren ( comment )"
+<a href="http://forth-standard.org/standard/core/p" class="bare">http://forth-standard.org/standard/core/p</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>*</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;n ) "16*16 -&#8594; 16 "
+<a href="https://forth-standard.org/standard/core/Times" class="bare">https://forth-standard.org/standard/core/Times</a>
+Multiply two signed 16 bit numbers, returning a 16 bit result.
+This is nothing  more than UM* DROP</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>*/</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n1 n2 n3&#8201;&#8212;&#8201;n4 ) "n1 * n2 / n3 -&#8594;  n"
+<a href="https://forth-standard.org/standard/core/TimesDiv" class="bare">https://forth-standard.org/standard/core/TimesDiv</a>
+Multiply n1 by n2 and divide by n3, returning the result
+without a remainder. This is */MOD without the mod, and
+can be defined in Fort as : */  */MOD SWAP DROP ; which is
+pretty much what we do here</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>*/mod</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n1 n2 n3&#8201;&#8212;&#8201;n4 n5 ) "n1 * n2 / n3 -&#8594; n-mod n"
+<a href="https://forth-standard.org/standard/core/TimesDivMOD" class="bare">https://forth-standard.org/standard/core/TimesDivMOD</a>
+Multiply n1 by n2 producing the intermediate double-cell result</p>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p>Divide d by n3 producing the single-cell remainder n4 and the
+single-cell quotient n5. In Forth, this is
+: <strong>/MOD  &gt;R M</strong> &gt;R SM/REM ;  Note that */ accesses this routine.</p>
+</li>
+</ol>
+</div>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>+</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;n ) "Add TOS and NOS"
+<a href="https://forth-standard.org/standard/core/Plus" class="bare">https://forth-standard.org/standard/core/Plus</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>+!</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n addr&#8201;&#8212;&#8201;) "Add number to value at given address"
+<a href="https://forth-standard.org/standard/core/PlusStore" class="bare">https://forth-standard.org/standard/core/PlusStore</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>+loop</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Finish loop construct"
+<a href="https://forth-standard.org/standard/core/PlusLOOP" class="bare">https://forth-standard.org/standard/core/PlusLOOP</a>
+Compile-time part of +LOOP, also used for LOOP. Is usually
+: +LOOP POSTPONE (+LOOP) , POSTPONE UNLOOP ; IMMEDIATE
+COMPILE-ONLY
+in Forth. LOOP uses this routine as well. We jump here with the
+address for looping as TOS and the address for aborting the loop
+(LEAVE) as the second double-byte entry on the Return Stack (see
+DO and docs/loops.txt for details).</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>,</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n&#8201;&#8212;&#8201;) "Allot and store one cell in memory"
+<a href="https://forth-standard.org/standard/core/Comma" class="bare">https://forth-standard.org/standard/core/Comma</a>
+Store TOS at current place in memory. Since this an eight-bit
+machine, we can ignore all alignment issures.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>-</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;n ) "Subtract TOS from NOS"
+<a href="https://forth-standard.org/standard/core/Minus" class="bare">https://forth-standard.org/standard/core/Minus</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>-leading</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali String</em> ( addr1 u1&#8201;&#8212;&#8201;addr2 u2 ) "Remove leading spaces"
+Remove leading whitespace. This is the reverse of -TRAILING</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>-rot</code>
+</td>
+<td class="hdlist2">
+<p><em>Gforth</em> ( a b c&#8201;&#8212;&#8201;c a b ) "Rotate upwards"
+<a href="http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Data-stack.html" class="bare">http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Data-stack.html</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>-trailing</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS string</em> ( addr u1&#8201;&#8212;&#8201;addr u2 ) "Remove trailing spaces"
+<a href="https://forth-standard.org/standard/string/MinusTRAILING" class="bare">https://forth-standard.org/standard/string/MinusTRAILING</a>
+Remove trailing spaces</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>.</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( u&#8201;&#8212;&#8201;) "Print TOS"
+<a href="https://forth-standard.org/standard/core/d" class="bare">https://forth-standard.org/standard/core/d</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>."</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( "string"&#8201;&#8212;&#8201;) "Print string from compiled word"
+<a href="https://forth-standard.org/standard/core/Dotq" class="bare">https://forth-standard.org/standard/core/Dotq</a>
+Compile string that is printed during run time. ANS Forth wants
+this to be compile-only, even though everybody and their friend
+uses it for everything. We follow the book here, and recommend
+.( for general printing</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>.(</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Print input up to close paren .( comment )"
+<a href="http://forth-standard.org/standard/core/Dotp" class="bare">http://forth-standard.org/standard/core/Dotp</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>.r</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( n u&#8201;&#8212;&#8201;) "Print NOS as unsigned number with TOS with"
+<a href="https://forth-standard.org/standard/core/DotR" class="bare">https://forth-standard.org/standard/core/DotR</a>
+Based on the Forth code
+: .R  &gt;R DUP ABS 0 &lt;# #S ROT SIGN #&gt; R&gt; OVER - SPACES TYPE</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>.s</code>
+</td>
+<td class="hdlist2">
+<p>_ANS tools _ (&#8201;&#8212;&#8201;) "Print content of Data Stack"
+<a href="https://forth-standard.org/standard/tools/DotS" class="bare">https://forth-standard.org/standard/tools/DotS</a>
+Print content of Data Stack non-distructively. Since this is for
+humans, we don&#8217;t have to worry about speed. We follow the format
+of Gforth and print the number of elements first in brackets,
+followed by the Data Stack content (if any).</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>/</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n1 n2&#8201;&#8212;&#8201;n ) "Divide NOS by TOS"
+<a href="https://forth-standard.org/standard/core/Div" class="bare">https://forth-standard.org/standard/core/Div</a>
+Forth code is either  &gt;R S&gt;D R&gt; FM/MOD SWAP DROP
+or &gt;R S&gt;D R&gt; SM/REM SWAP DROP&#8201;&#8212;&#8201;we use SM/REM in Tali Forth.
+This code is currently unoptimized. This code without the SLASH
+DROP at the end is /MOD, so we share the code as far as possible.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>/mod</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n1 n2&#8201;&#8212;&#8201;n3 n4 ) "Divide NOS by TOS with a remainder"
+<a href="https://forth-standard.org/standard/core/DivMOD" class="bare">https://forth-standard.org/standard/core/DivMOD</a>
+This is a dummy entry, the actual code is shared with SLASH</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>/string</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS string</em> ( addr u n&#8201;&#8212;&#8201;addr u ) "Shorten string by n"
+<a href="https://forth-standard.org/standard/string/DivSTRING" class="bare">https://forth-standard.org/standard/string/DivSTRING</a>
+Forth code is
+: /STRING ( ADDR U N&#8201;&#8212;&#8201;ADDR U ) ROT OVER + ROT ROT -
+Put differently, we need to add TOS and 3OS, and subtract
+TOS from NOS, and then drop TOS</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>0</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;0 ) "Push 0 to Data Stack"
+; """The disassembler assumes that this routine does not use Y. Note
+that CASE and FORTH-WORDLIST use the same routine, as the WD for Forth
+is 0.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>0&lt;</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n&#8201;&#8212;&#8201;f ) "Return a TRUE flag if TOS negative"
+<a href="https://forth-standard.org/standard/core/Zeroless" class="bare">https://forth-standard.org/standard/core/Zeroless</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>0&lt;&gt;</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( m&#8201;&#8212;&#8201;f ) "Return TRUE flag if not zero"
+<a href="https://forth-standard.org/standard/core/Zerone" class="bare">https://forth-standard.org/standard/core/Zerone</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>0=</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n&#8201;&#8212;&#8201;f ) "Check if TOS is zero"
+<a href="https://forth-standard.org/standard/core/ZeroEqual" class="bare">https://forth-standard.org/standard/core/ZeroEqual</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>0&gt;</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( n&#8201;&#8212;&#8201;f ) "Return a TRUE flag if TOS is positive"
+<a href="https://forth-standard.org/standard/core/Zeromore" class="bare">https://forth-standard.org/standard/core/Zeromore</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>1</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;n ) "Push the number 1 to the Data Stack"
+This is also the code for EDITOR-WORDLIST</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>1+</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( u&#8201;&#8212;&#8201;u+1 ) "Increase TOS by one"
+<a href="https://forth-standard.org/standard/core/OnePlus" class="bare">https://forth-standard.org/standard/core/OnePlus</a>
+Code is shared with CHAR-PLUS</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>1-</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( u&#8201;&#8212;&#8201;u-1 ) "Decrease TOS by one"
+<a href="https://forth-standard.org/standard/core/OneMinus" class="bare">https://forth-standard.org/standard/core/OneMinus</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>2</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;u ) "Push the number 2 to stack"
+This code is shared with ASSEMBLER-WORDLIST</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>2!</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n1 n2 addr&#8201;&#8212;&#8201;) "Store two numbers at given address"
+<a href="https://forth-standard.org/standard/core/TwoStore" class="bare">https://forth-standard.org/standard/core/TwoStore</a>
+Stores so n2 goes to addr and n1 to the next consecutive cell.
+Is equivalent to  SWAP OVER ! CELL+ !</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>2*</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n&#8201;&#8212;&#8201;n ) "Multiply TOS by two"
+<a href="https://forth-standard.org/standard/core/TwoTimes" class="bare">https://forth-standard.org/standard/core/TwoTimes</a>
+Also used for CELLS</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>2/</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n&#8201;&#8212;&#8201;n ) "Divide TOS by two"
+<a href="https://forth-standard.org/standard/core/TwoDiv" class="bare">https://forth-standard.org/standard/core/TwoDiv</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>2&gt;r</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( n1 n2&#8201;&#8212;&#8201;)(R:&#8201;&#8212;&#8201;n1 n2 "Push top two entries to Return Stack"
+<a href="https://forth-standard.org/standard/core/TwotoR" class="bare">https://forth-standard.org/standard/core/TwotoR</a>
+Push top two entries to Return Stack. The same as SWAP &gt;R &gt;R
+except that if we jumped here, the return address will be in the
+way. May not be natively compiled unless we&#8217;re clever and use
+special routines.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>2@</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( addr&#8201;&#8212;&#8201;n1 n2 ) "Fetch the cell pair n1 n2 stored at addr"
+<a href="https://forth-standard.org/standard/core/TwoFetch" class="bare">https://forth-standard.org/standard/core/TwoFetch</a>
+Note n2 stored at addr and n1 in the next cell&#8201;&#8212;&#8201;in our case,
+the next byte. This is equvalent to  DUP CELL+ @ SWAP @</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>2constant</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS double</em> (C: d "name"&#8201;&#8212;&#8201;) (&#8201;&#8212;&#8201;d) "Create a constant for a double word"
+<a href="https://forth-standard.org/standard/double/TwoCONSTANT" class="bare">https://forth-standard.org/standard/double/TwoCONSTANT</a>
+Based on the Forth code
+: 2CONSTANT ( D&#8201;&#8212;&#8201;)  CREATE SWAP , , DOES&gt; DUP @ SWAP CELL+ @</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>2drop</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;) "Drop TOS and NOS"
+<a href="https://forth-standard.org/standard/core/TwoDROP" class="bare">https://forth-standard.org/standard/core/TwoDROP</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>2dup</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( a b&#8201;&#8212;&#8201;a b a b ) "Duplicate first two stack elements"
+<a href="https://forth-standard.org/standard/core/TwoDUP" class="bare">https://forth-standard.org/standard/core/TwoDUP</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>2literal</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS double</em> (C: d&#8201;&#8212;&#8201;) (&#8201;&#8212;&#8201;d) "Compile a literal double word"
+<a href="https://forth-standard.org/standard/double/TwoLITERAL" class="bare">https://forth-standard.org/standard/double/TwoLITERAL</a>
+Based on the Forth code
+: 2LITERAL ( D&#8201;&#8212;&#8201;) SWAP POSTPONE LITERAL POSTPONE LITERAL ; IMMEDIATE</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>2over</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( d1 d2&#8201;&#8212;&#8201;d1 d2 d1 ) "Copy double word NOS to TOS"
+<a href="https://forth-standard.org/standard/core/TwoOVER" class="bare">https://forth-standard.org/standard/core/TwoOVER</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>2r&gt;</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> (&#8201;&#8212;&#8201;n1 n2 ) (R: n1 n2&#8201;&#8212;&#8201;) "Pull two cells from Return Stack"
+<a href="https://forth-standard.org/standard/core/TwoRfrom" class="bare">https://forth-standard.org/standard/core/TwoRfrom</a>
+Pull top two entries from Return Stack. Is the same as
+R&gt; R&gt; SWAP. As with R&gt;, the problem with the is word is that
+the top value on the ReturnStack for a STC Forth is the
+return address, which we need to get out of the way first.
+Native compile needs to be handled as a special case.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>2r@</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> (&#8201;&#8212;&#8201;n n ) "Copy top two entries from Return Stack"
+<a href="https://forth-standard.org/standard/core/TwoRFetch" class="bare">https://forth-standard.org/standard/core/TwoRFetch</a>
+This is R&gt; R&gt; 2DUP &gt;R &gt;R SWAP but we can do it a lot faster in
+assembler. We use trickery to access the elements on the Return
+Stack instead of pulling the return address first and storing
+it somewhere else like for 2R&gt; and 2&gt;R. In this version, we leave
+it as Never Native; at some point, we should compare versions to
+see if an Always Native version would be better</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>2swap</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n1 n2 n3 n4&#8201;&#8212;&#8201;n3 n4 n1 n1 ) "Exchange two double words"
+<a href="https://forth-standard.org/standard/core/TwoSWAP" class="bare">https://forth-standard.org/standard/core/TwoSWAP</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>2variable</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS double</em> ( "name"&#8201;&#8212;&#8201;) "Create a variable for a double word"
+<a href="https://forth-standard.org/standard/double/TwoVARIABLE" class="bare">https://forth-standard.org/standard/double/TwoVARIABLE</a>
+This can be realized in Forth as either
+CREATE 2 CELLS ALLOT  or just  CREATE 0 , 0 ,
+Note that in this case, the variable is not initialized to
+zero</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>:</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( "name"&#8201;&#8212;&#8201;) "Start compilation of a new word"
+<a href="https://forth-standard.org/standard/core/Colon" class="bare">https://forth-standard.org/standard/core/Colon</a>
+Use the CREATE routine and fill in the rest by hand.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>:NONAME</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Start compilation of a new word""
+<a href="https://forth-standard.org/standard/core/ColonNONAME" class="bare">https://forth-standard.org/standard/core/ColonNONAME</a>
+Compile a word with no nt.  ";" will put its xt on the stack.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>;</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "End compilation of new word"
+<a href="https://forth-standard.org/standard/core/Semi" class="bare">https://forth-standard.org/standard/core/Semi</a>
+End the compilation of a new word into the Dictionary. When we
+enter this, WORKWORD is pointing to the nt_ of this word in the
+Dictionary, DP to the previous word, and CP to the next free byte.
+A Forth definition would be (see "Starting Forth"):
+: POSTPONE EXIT  REVEAL POSTPONE ; [ ; IMMEDIATE  Following the
+practice of Gforth, we warn here if a word has been redefined.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>&lt;</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n m&#8201;&#8212;&#8201;f ) "Return true if NOS &lt; TOS"
+<a href="https://forth-standard.org/standard/core/less" class="bare">https://forth-standard.org/standard/core/less</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>&lt;#</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Start number conversion"
+<a href="https://forth-standard.org/standard/core/num-start" class="bare">https://forth-standard.org/standard/core/num-start</a>
+Start the process to create pictured numeric output. The new
+string is constructed from back to front, saving the new character
+at the beginning of the output string. Since we use PAD as a
+starting address and work backward (!), the string is constructed
+in the space between the end of the Dictionary (as defined by CP)
+and the PAD. This allows us to satisfy the ANS Forth condition that
+programs don&#8217;t fool around with the PAD but still use its address.
+Based on pForth
+<a href="http://pforth.googlecode.com/svn/trunk/fth/numberio.fth" class="bare">http://pforth.googlecode.com/svn/trunk/fth/numberio.fth</a>
+pForth is in the pubic domain. Forth is : &lt;# PAD HLD ! ; we use the
+internal variable tohold instead of HLD.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>&lt;&gt;</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( n m&#8201;&#8212;&#8201;f ) "Return a true flag if TOS != NOS"
+<a href="https://forth-standard.org/standard/core/ne" class="bare">https://forth-standard.org/standard/core/ne</a>
+This is just a variant of EQUAL, we code it separately
+for speed.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>=</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;f ) "See if TOS and NOS are equal"
+<a href="https://forth-standard.org/standard/core/Equal" class="bare">https://forth-standard.org/standard/core/Equal</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>&gt;</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;f ) "See if NOS is greater than TOS"
+<a href="https://forth-standard.org/standard/core/more" class="bare">https://forth-standard.org/standard/core/more</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>&gt;body</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( xt&#8201;&#8212;&#8201;addr ) "Return a word&#8217;s Code Field Area (CFA)"
+<a href="https://forth-standard.org/standard/core/toBODY" class="bare">https://forth-standard.org/standard/core/toBODY</a>
+Given a word&#8217;s execution token (xt), return the address of the
+start of that word&#8217;s parameter field (PFA). This is defined as the
+address that HERE would return right after CREATE. This is a
+difficult word for STC Forths, because most words don&#8217;t actually
+have a Code Field Area (CFA) to skip. We solve this by having CREATE
+add a flag, "has CFA" (HC), in the header so &gt;BODY know to skip
+the subroutine jumps to DOVAR, DOCONST, or DODOES</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>&gt;in</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;addr ) "Return address of the input pointer"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>&gt;number</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( ud addr u&#8201;&#8212;&#8201;ud addr u ) "Convert a number"
+<a href="https://forth-standard.org/standard/core/toNUMBER" class="bare">https://forth-standard.org/standard/core/toNUMBER</a>
+Convert a string to a double number. Logic here is based on the
+routine by Phil Burk of the same name in pForth, see
+<a href="https://github.com/philburk/pforth/blob/master/fth/numberio.fth" class="bare">https://github.com/philburk/pforth/blob/master/fth/numberio.fth</a>
+for the original Forth code. We arrive here from NUMBER which has
+made sure that we don&#8217;t have to deal with a sign and we don&#8217;t have
+to deal with a dot as a last character that signalizes double -
+this should be a pure number string. This routine calles UM*, which
+uses tmp1, tmp2 and tmp3, so we cannot access any of those.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>&gt;order</code>
+</td>
+<td class="hdlist2">
+<p><em>Gforth search</em> ( wid&#8201;&#8212;&#8201;) "Add wordlist at beginning of search order"
+<a href="https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Word-Lists.html" class="bare">https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Word-Lists.html</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>&gt;r</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n&#8201;&#8212;&#8201;)(R:&#8201;&#8212;&#8201;n) "Push TOS to the Return Stack"
+<a href="https://forth-standard.org/standard/core/toR" class="bare">https://forth-standard.org/standard/core/toR</a>
+This word is handled differently for native and for
+subroutine coding, see COMPILE, . This is a complile-only
+word.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>?</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS tools</em> ( addr&#8201;&#8212;&#8201;) "Print content of a variable"
+<a href="https://forth-standard.org/standard/tools/q" class="bare">https://forth-standard.org/standard/tools/q</a>
+Only used interactively. Since humans are so slow, we
+save size and just go for the subroutine jumps</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>?do</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( limit start&#8201;&#8212;&#8201;)(R:&#8201;&#8212;&#8201;limit start) "Conditional loop start"
+<a href="https://forth-standard.org/standard/core/qDO" class="bare">https://forth-standard.org/standard/core/qDO</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>?dup</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n&#8201;&#8212;&#8201;0 | n n ) "Duplicate TOS non-zero"
+<a href="https://forth-standard.org/standard/core/qDUP" class="bare">https://forth-standard.org/standard/core/qDUP</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>@</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( addr&#8201;&#8212;&#8201;n ) "Push cell content from memory to stack"
+<a href="https://forth-standard.org/standard/core/Fetch" class="bare">https://forth-standard.org/standard/core/Fetch</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>[</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Enter interpretation state"
+<a href="https://forth-standard.org/standard/core/Bracket" class="bare">https://forth-standard.org/standard/core/Bracket</a>
+This is an immediate and compile-only word</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>[']</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Store xt of following word during compilation"
+<a href="https://forth-standard.org/standard/core/BracketTick" class="bare">https://forth-standard.org/standard/core/BracketTick</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>[char]</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( "c"&#8201;&#8212;&#8201;) "Compile character"
+<a href="https://forth-standard.org/standard/core/BracketCHAR" class="bare">https://forth-standard.org/standard/core/BracketCHAR</a>
+Compile the ASCII value of a character as a literal. This is an
+immediate, compile-only word. A definition given in
+<a href="http://forth-standard.org/standard/implement" class="bare">http://forth-standard.org/standard/implement</a> is
+: [CHAR]  CHAR POSTPONE LITERAL ; IMMEDIATE</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>\</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> (&#8201;&#8212;&#8201;) "Ignore rest of line"
+<a href="https://forth-standard.org/standard/core/bs" class="bare">https://forth-standard.org/standard/core/bs</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>]</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Enter the compile state"
+<a href="https://forth-standard.org/standard/right-bracket" class="bare">https://forth-standard.org/standard/right-bracket</a>
+This is an immediate word.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>abort</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Reset the Data Stack and restart the CLI"
+<a href="https://forth-standard.org/standard/core/ABORT" class="bare">https://forth-standard.org/standard/core/ABORT</a>
+Clear Data Stack and continue into QUIT. We can jump here via
+subroutine if we want to because we are going to reset the 65c02&#8217;s
+stack pointer (the Return Stack) anyway during QUIT. Note we don&#8217;t
+actually delete the stuff on the Data Stack</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>abort"</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( "string"&#8201;&#8212;&#8201;) "If flag TOS is true, MESSAGE with message"
+<a href="https://forth-standard.org/standard/core/ABORTq" class="bare">https://forth-standard.org/standard/core/ABORTq</a>
+Abort with a message</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>abs</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n&#8201;&#8212;&#8201;u ) "Return absolute value of a number"
+<a href="https://forth-standard.org/standard/core/ABS" class="bare">https://forth-standard.org/standard/core/ABS</a>
+Return the absolute value of a number.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>accept</code>
+</td>
+<td class="hdlist2">
+<p>_ANS core _ ( addr n&#8201;&#8212;&#8201;n ) "Receive a string of characters from the keyboard"
+<a href="https://forth-standard.org/standard/core/ACCEPT" class="bare">https://forth-standard.org/standard/core/ACCEPT</a>
+Receive a string of at most n1 characters, placing them at
+addr. Return the actual number of characters as n2. Characters
+are echoed as they are received. ACCEPT is called by REFILL in
+modern Forths.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>action-of</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( "name"&#8201;&#8212;&#8201;xt ) "Get named deferred word&#8217;s xt"
+<a href="http://forth-standard.org/standard/core/ACTION-OF" class="bare">http://forth-standard.org/standard/core/ACTION-OF</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>again</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( addr&#8201;&#8212;&#8201;) "Code backwards branch to address left by BEGIN"
+<a href="https://forth-standard.org/standard/core/AGAIN" class="bare">https://forth-standard.org/standard/core/AGAIN</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>align</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Make sure CP is aligned on word size"
+<a href="https://forth-standard.org/standard/core/ALIGN" class="bare">https://forth-standard.org/standard/core/ALIGN</a>
+On a 8-bit machine, this does nothing. ALIGNED uses
+this routine as well, and also does nothing
+<mark> ALIGNED ( addr&#8201;&#8212;&#8201;addr ) "Return the first aligned address
+</mark> "aligned"  auto  ANS core</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>allot</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n&#8201;&#8212;&#8201;) "Reserve or release memory"
+<a href="https://forth-standard.org/standard/core/ALLOT" class="bare">https://forth-standard.org/standard/core/ALLOT</a>
+Reserve a certain number of bytes (not cells) or release them.
+If n = 0, do nothing. If n is negative, release n bytes, but only
+to the beginning of the Dictionary. If n is positive (the most
+common case), reserve n bytes, but not past the end of the
+Dictionary. See <a href="http://forth-standard.org/standard/core/ALLOT" class="bare">http://forth-standard.org/standard/core/ALLOT</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>allow-native</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;) "Flag last word to allow native compiling"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>also</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS search ext</em> (&#8201;&#8212;&#8201;) "Make room in the search order for another wordlist"
+<a href="http://forth-standard.org/standard/search/ALSO" class="bare">http://forth-standard.org/standard/search/ALSO</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>always-native</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;) "Flag last word as always natively compiled"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>and</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;n ) "Logically AND TOS and NOS"
+<a href="https://forth-standard.org/standard/core/AND" class="bare">https://forth-standard.org/standard/core/AND</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>assembler-wordlist</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Assembler</em> (&#8201;&#8212;&#8201;u ) "WID for the Assembler wordlist"
+This is a dummy entry, the code is shared with TWO</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>at-xy</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS facility</em> ( n m&#8201;&#8212;&#8201;) "Move cursor to position given"
+<a href="https://forth-standard.org/standard/facility/AT-XY" class="bare">https://forth-standard.org/standard/facility/AT-XY</a>
+On an ANS compatible terminal, place cursor at row n colum m.
+Code is ESC[&lt;n&gt;;&lt;m&gt;H Do not use U. to print the numbers because the
+trailing space will not work with xterm</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>base</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;addr ) "Push address of radix base to stack"
+<a href="https://forth-standard.org/standard/core/BASE" class="bare">https://forth-standard.org/standard/core/BASE</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>begin</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;addr ) "Mark entry point for loop"
+<a href="https://forth-standard.org/standard/core/BEGIN" class="bare">https://forth-standard.org/standard/core/BEGIN</a>
+This is just an immediate version of here which could just
+as well be coded in Forth as
+: BEGIN HERE ; IMMEDIATE COMPILE-ONLY
+Since this is a compiling word, we don&#8217;t care that much about
+about speed</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>bell</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;) "Emit ASCII BELL"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>bl</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;c ) "Push ASCII value of SPACE to stack"
+<a href="https://forth-standard.org/standard/core/BL" class="bare">https://forth-standard.org/standard/core/BL</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>blank</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS string</em> ( addr u&#8201;&#8212;&#8201;) "Fill memory region with spaces"
+<a href="https://forth-standard.org/standard/string/BLANK" class="bare">https://forth-standard.org/standard/string/BLANK</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>blkbuffer</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali block</em> (&#8201;&#8212;&#8201;addr ) "Push address of block buffer"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>block</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS block</em> ( u&#8201;&#8212;&#8201;a-addr ) "Fetch a block into a buffer"
+<a href="https://forth-standard.org/standard/block/BLK" class="bare">https://forth-standard.org/standard/block/BLK</a>
+<a href="https://forth-standard.org/standard/block/BLOCK" class="bare">https://forth-standard.org/standard/block/BLOCK</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>block-ramdrive-init</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali block</em> ( u&#8201;&#8212;&#8201;) "Create a ramdrive for blocks"
+Create a RAM drive, with the given number of
+blocks, in the dictionary along with setting up the block words to
+use it.  The read/write routines do not provide bounds checking.
+Expected use: 4 block-ramdrive-init ( to create blocks 0-3 )</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>block-read</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali block</em> ( addr u&#8201;&#8212;&#8201;) "Read a block from storage (deferred word)"
+BLOCK-READ is a vectored word that the user needs to override
+with their own version to read a block from storage.
+The stack parameters are ( buffer_address block#&#8201;&#8212;&#8201;).</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>block-read-vector</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali block</em> (&#8201;&#8212;&#8201;addr ) "Address of the block-read vector"
+BLOCK-READ is a vectored word that the user needs to override
+with their own version to read a block from storage.
+This word gives the address of the vector so it can be replaced.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>block-write</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali block</em> ( addr u&#8201;&#8212;&#8201;) "Write a block to storage (deferred word)"
+BLOCK-WRITE is a vectored word that the user needs to override
+with their own version to write a block to storage.
+The stack parameters are ( buffer_address block#&#8201;&#8212;&#8201;).</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>block-write-vector</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali block</em> (&#8201;&#8212;&#8201;addr ) "Address of the block-write vector"
+BLOCK-WRITE is a vectored word that the user needs to override
+with their own version to write a block to storage.
+This word gives the address of the vector so it can be replaced.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>bounds</code>
+</td>
+<td class="hdlist2">
+<p><em>Gforth</em> ( addr u&#8201;&#8212;&#8201;addr+u addr ) "Prepare address for looping"
+<a href="http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Memory-Blocks.html" class="bare">http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Memory-Blocks.html</a>
+Given a string, return the correct Data Stack parameters for
+a DO/LOOP loop; over its characters. This is realized as
+OVER + SWAP in Forth, but we do it a lot faster in assembler</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>buffblocknum</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali block</em> (&#8201;&#8212;&#8201;addr ) "Push address of variable holding block in buffer"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>buffer</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS block</em> ( u&#8201;&#8212;&#8201;a-addr ) "Get a buffer for a block"
+<a href="https://forth-standard.org/standard/block/BUFFER" class="bare">https://forth-standard.org/standard/block/BUFFER</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>buffer:</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( u "&lt;name&gt;"&#8201;&#8212;&#8201;;&#8201;&#8212;&#8201;addr ) "Create an uninitialized buffer"
+<a href="https://forth-standard.org/standard/core/BUFFERColon" class="bare">https://forth-standard.org/standard/core/BUFFERColon</a>
+Create a buffer of size u that puts its address on the stack
+when its name is used.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>buffstatus</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali block</em> (&#8201;&#8212;&#8201;addr ) "Push address of variable holding buffer status"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>bye</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS tools ext</em> (&#8201;&#8212;&#8201;) "Break"
+<a href="https://forth-standard.org/standard/tools/BYE" class="bare">https://forth-standard.org/standard/tools/BYE</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>c!</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( c addr&#8201;&#8212;&#8201;) "Store character at address given"
+<a href="https://forth-standard.org/standard/core/CStore" class="bare">https://forth-standard.org/standard/core/CStore</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>c,</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( c&#8201;&#8212;&#8201;) "Store one byte/char in the Dictionary"
+<a href="https://forth-standard.org/standard/core/CComma" class="bare">https://forth-standard.org/standard/core/CComma</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>c@</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( addr&#8201;&#8212;&#8201;c ) "Get a character/byte from given address"
+<a href="https://forth-standard.org/standard/core/CFetch" class="bare">https://forth-standard.org/standard/core/CFetch</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>case</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> (C:&#8201;&#8212;&#8201;0) (&#8201;&#8212;&#8201;) "Conditional flow control"
+<a href="http://forth-standard.org/standard/core/CASE" class="bare">http://forth-standard.org/standard/core/CASE</a>
+This is a dummy header, CASE shares the actual code with ZERO.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>cell+</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( u&#8201;&#8212;&#8201;u ) "Add cell size in bytes"
+<a href="https://forth-standard.org/standard/core/CELLPlus" class="bare">https://forth-standard.org/standard/core/CELLPlus</a>
+Add the number of bytes ("address units") that one cell needs.
+Since this is an 8 bit machine with 16 bit cells, we add two bytes.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>cells</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( u&#8201;&#8212;&#8201;u ) "Convert cells to size in bytes"
+<a href="https://forth-standard.org/standard/core/CELLS" class="bare">https://forth-standard.org/standard/core/CELLS</a>
+Dummy entry for the CELLS word, the code is the same as for
+2*, which is where the header directs us to</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>char</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( "c"&#8201;&#8212;&#8201;u ) "Convert character to ASCII value"
+<a href="https://forth-standard.org/standard/core/CHAR" class="bare">https://forth-standard.org/standard/core/CHAR</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>char+</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( addr&#8201;&#8212;&#8201;addr+1 ) "Add the size of a character unit to address"
+<a href="https://forth-standard.org/standard/core/CHARPlus" class="bare">https://forth-standard.org/standard/core/CHARPlus</a>
+This is a dummy entry, the code is shared with ONE_PLUS</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>chars</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n&#8201;&#8212;&#8201;n ) "Number of bytes that n chars need"
+<a href="https://forth-standard.org/standard/core/CHARS" class="bare">https://forth-standard.org/standard/core/CHARS</a>
+Return how many address units n chars are. Since this is an 8 bit
+machine, this does absolutely nothing and is included for
+compatibility with other Forth versions</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>cleave</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> ( addr u&#8201;&#8212;&#8201;addr2 u2 addr1 u1 ) "Split off word from string"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>cmove</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS string</em> ( addr1 addr2 u&#8201;&#8212;&#8201;) "Copy bytes going from low to high"
+<a href="https://forth-standard.org/standard/string/CMOVE" class="bare">https://forth-standard.org/standard/string/CMOVE</a>
+Copy u bytes from addr1 to addr2, going low to high (addr2 is
+larger than addr1). Based on code in Leventhal, Lance A.
+6502 Assembly Language Routines", p. 201, where it is called
+move left". There are no official tests for this word.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>cmove&gt;</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS string</em> ( add1 add2 u&#8201;&#8212;&#8201;) "Copy bytes from high to low"
+<a href="https://forth-standard.org/standard/string/CMOVEtop" class="bare">https://forth-standard.org/standard/string/CMOVEtop</a>
+Based on code in Leventhal, Lance A. "6502 Assembly Language
+Routines", p. 201, where it is called "move right". There are
+no official tests for this word.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>cold</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;) "Reset the Forth system"
+Reset the Forth system. Does not restart the kernel,
+use the 65c02 reset for that. Flows into ABORT.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>compare</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS string</em> ( addr1 u1 addr2 u2&#8201;&#8212;&#8201;-1 | 0 | 1) "Compare two strings"
+<a href="https://forth-standard.org/standard/string/COMPARE" class="bare">https://forth-standard.org/standard/string/COMPARE</a>
+Compare string1 (denoted by addr1 u1) to string2 (denoted by
+addr2 u2).  Return -1 if string1 &lt; string2, 0 if string1 = string2
+and 1 if string1 &gt; string2 (ASCIIbetical comparison).  A string
+that entirely matches the beginning of the other string, but is
+shorter, is considered less than the longer string.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>compile,</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( xt&#8201;&#8212;&#8201;) "Compile xt"
+<a href="https://forth-standard.org/standard/core/COMPILEComma" class="bare">https://forth-standard.org/standard/core/COMPILEComma</a>
+Compile the given xt in the current word definition. It is an
+error if we are not in the compile state. Because we are using
+subroutine threading, we can&#8217;t use , (COMMA) to compile new words
+the traditional way. By default, native compiled is allowed, unless
+there is a NN (Never Native) flag associated. If not, we use the
+value NC_LIMIT (from definitions.tasm) to decide if the code
+is too large to be natively coded: If the size is larger than
+NC_LIMIT, we silently use subroutine coding. If the AN (Always
+Native) flag is set, the word is always natively compiled</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>compile-only</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;) "Mark most recent word as COMPILE-ONLY"
+Set the Compile Only flag (CO) of the most recently defined
+word. The alternative way to do this is to define a word
+?COMPILE that makes sure  we&#8217;re in compile mode</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>constant</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n "name"&#8201;&#8212;&#8201;) "Define a constant"
+<a href="https://forth-standard.org/standard/core/CONSTANT" class="bare">https://forth-standard.org/standard/core/CONSTANT</a>
+Forth equivalent is  CREATE , DOES&gt; @  but we do
+more in assembler and let CREATE do the heavy lifting.
+See <a href="http://www.bradrodriguez.com/papers/moving3.htm" class="bare">http://www.bradrodriguez.com/papers/moving3.htm</a> for
+a primer on how this works in various Forths. This is the
+same code as VALUE in our case.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>count</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( c-addr&#8201;&#8212;&#8201;addr u ) "Convert character string to normal format"
+<a href="https://forth-standard.org/standard/core/COUNT" class="bare">https://forth-standard.org/standard/core/COUNT</a>
+Convert old-style character string to address-length pair. Note
+that the length of the string c-addr ist stored in character length
+(8 bit), not cell length (16 bit). This is rarely used these days,
+though COUNT can also be used to step through a string character by
+character.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>cr</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Print a line feed"
+<a href="https://forth-standard.org/standard/core/CR" class="bare">https://forth-standard.org/standard/core/CR</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>create</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( "name"&#8201;&#8212;&#8201;) "Create Dictionary entry for 'name'"
+<a href="https://forth-standard.org/standard/core/CREATE" class="bare">https://forth-standard.org/standard/core/CREATE</a>
+See the drawing in headers.asm for details on the header</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>d+</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS double</em> ( d d&#8201;&#8212;&#8201;d ) "Add two double-celled numbers"
+<a href="https://forth-standard.org/standard/double/DPlus" class="bare">https://forth-standard.org/standard/double/DPlus</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>d-</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS double</em> ( d d&#8201;&#8212;&#8201;d ) "Subtract two double-celled numbers"
+<a href="https://forth-standard.org/standard/double/DMinus" class="bare">https://forth-standard.org/standard/double/DMinus</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>d.</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS double</em> ( d&#8201;&#8212;&#8201;) "Print double"
+<a href="http://forth-standard.org/standard/double/Dd" class="bare">http://forth-standard.org/standard/double/Dd</a>
+From the Forth code:
+: D. TUCK DABS &lt;# #S ROT SIGN #&gt; TYPE SPACE</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>d.r</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS double</em> ( d u&#8201;&#8212;&#8201;) "Print double right-justified u wide"
+<a href="http://forth-standard.org/standard/double/DDotR" class="bare">http://forth-standard.org/standard/double/DDotR</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>d&gt;s</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS double</em> ( d&#8201;&#8212;&#8201;n ) "Convert a double number to single"
+<a href="https://forth-standard.org/standard/double/DtoS" class="bare">https://forth-standard.org/standard/double/DtoS</a>
+Though this is basically just DROP, we keep it
+separate so we can test for underflow</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>dabs</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS double</em> ( d&#8201;&#8212;&#8201;d ) "Return the absolute value of a double"
+<a href="https://forth-standard.org/standard/double/DABS" class="bare">https://forth-standard.org/standard/double/DABS</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>decimal</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Change radix base to decimal"
+<a href="https://forth-standard.org/standard/core/DECIMAL" class="bare">https://forth-standard.org/standard/core/DECIMAL</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>defer</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( "name"&#8201;&#8212;&#8201;) "Create a placeholder for words by name"
+<a href="https://forth-standard.org/standard/core/DEFER" class="bare">https://forth-standard.org/standard/core/DEFER</a>
+Reserve an name that can be linked to various xt by IS. The
+ANS reference implementation is
+CREATE ['] ABORT , DOES&gt; @ EXECUTE
+But we use this routine as a low-level word so things go faster</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>defer!</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( xt2 x1&#8201;&#8212;&#8201;) "Set xt1 to execute xt2"
+<a href="http://forth-standard.org/standard/core/DEFERStore" class="bare">http://forth-standard.org/standard/core/DEFERStore</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>defer@</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( xt1&#8201;&#8212;&#8201;xt2 ) "Get the current XT for a deferred word"
+<a href="http://forth-standard.org/standard/core/DEFERFetch" class="bare">http://forth-standard.org/standard/core/DEFERFetch</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>definitions</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS search</em> (&#8201;&#8212;&#8201;) "Make first wordlist in search order the current wordlist"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>depth</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;u ) "Get number of cells (not bytes) used by stack"
+<a href="https://forth-standard.org/standard/core/DEPTH" class="bare">https://forth-standard.org/standard/core/DEPTH</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>digit?</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> ( char&#8201;&#8212;&#8201;u f | char f ) "Convert ASCII char to number"
+Inspired by the pForth instruction DIGIT, see
+<a href="https://github.com/philburk/pforth/blob/master/fth/numberio.fth" class="bare">https://github.com/philburk/pforth/blob/master/fth/numberio.fth</a>
+Rewritten from DIGIT&gt;NUMBER in Tali Forth. Note in contrast to
+pForth, we get the base (radix) ourselves instead of having the
+user provide it. There is no standard name for this routine, which
+itself is not ANS; we use DIGIT? following pForth and Gforth.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>disasm</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> ( addr u&#8201;&#8212;&#8201;) "Disassemble a block of memory"
+Convert a segment of memory to assembler output. This
+word is vectored so people can add their own disassembler.
+Natively, this produces Simpler Assembly Notation (SAN)
+code, see the file disassembler.asm</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>dnegate</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS double</em> ( d&#8201;&#8212;&#8201;d ) "Negate double cell number"
+<a href="https://forth-standard.org/standard/double/DNEGATE" class="bare">https://forth-standard.org/standard/double/DNEGATE</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>do</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( limit start&#8201;&#8212;&#8201;)(R:&#8201;&#8212;&#8201;limit start)  "Start a loop"
+<a href="https://forth-standard.org/standard/core/DO" class="bare">https://forth-standard.org/standard/core/DO</a>
+Compile-time part of DO. Could be realized in Forth as
+: DO POSTPONE (DO) HERE ; IMMEDIATE COMPILE-ONLY
+but we do it in assembler for speed. To work with LEAVE, we compile
+a routine that pushes the end address to the Return Stack at run
+time. This is based on a suggestion by Garth Wilson, see
+docs/loops.txt for details. This may not be native compile. Don&#8217;t
+check for a stack underflow</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>does&gt;</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Add payload when defining new words"
+<a href="https://forth-standard.org/standard/core/DOES" class="bare">https://forth-standard.org/standard/core/DOES</a>
+Create the payload for defining new defining words. See
+<a href="http://www.bradrodriguez.com/papers/moving3.htm" class="bare">http://www.bradrodriguez.com/papers/moving3.htm</a> and
+docs/create-does.txt for a discussion of
+DOES&gt;'s internal workings. This uses tmp1 and tmp2</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>drop</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( u&#8201;&#8212;&#8201;) "Pop top entry on Data Stack"
+<a href="https://forth-standard.org/standard/core/DROP" class="bare">https://forth-standard.org/standard/core/DROP</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>dump</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS tools</em> ( addr u&#8201;&#8212;&#8201;) "Display a memory region"
+<a href="https://forth-standard.org/standard/tools/DUMP" class="bare">https://forth-standard.org/standard/tools/DUMP</a>
+DUMP&#8217;s exact output is defined as "implementation dependent".
+This is in assembler because it is
+useful for testing and development, so we want to have it work
+as soon as possible. Uses TMP2</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>dup</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( u&#8201;&#8212;&#8201;u u ) "Duplicate TOS"
+<a href="https://forth-standard.org/standard/core/DUP" class="bare">https://forth-standard.org/standard/core/DUP</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>ed</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;u ) "Line-based editor"
+Start the line-based editor ed6502. See separate file
+for details.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>editor-wordlist</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Editor</em> (&#8201;&#8212;&#8201;u ) "WID for the Editor wordlist"
+This is a dummy entry, the code is shared with ONE</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>el</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Editor</em> ( line#&#8201;&#8212;&#8201;) "Erase the given line number"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>else</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (C: orig&#8201;&#8212;&#8201;orig) (&#8201;&#8212;&#8201;) "Conditional flow control"
+<a href="http://forth-standard.org/standard/core/ELSE" class="bare">http://forth-standard.org/standard/core/ELSE</a>
+The code is shared with ENDOF</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>emit</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( char&#8201;&#8212;&#8201;) "Print character to current output"
+<a href="https://forth-standard.org/standard/core/EMIT" class="bare">https://forth-standard.org/standard/core/EMIT</a>
+Run-time default for EMIT. The user can revector this by changing
+the value of the OUTPUT variable. We ignore the MSB completely, and
+do not check to see if we have been given a valid ASCII character.
+Don&#8217;t make this native compile</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>empty-buffers</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS block ext</em> (&#8201;&#8212;&#8201;) "Empty all buffers without saving"
+<a href="https://forth-standard.org/standard/block/EMPTY-BUFFERS" class="bare">https://forth-standard.org/standard/block/EMPTY-BUFFERS</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>endcase</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> (C: case-sys&#8201;&#8212;&#8201;) ( x&#8201;&#8212;&#8201;) "Conditional flow control"
+<a href="http://forth-standard.org/standard/core/ENDCASE" class="bare">http://forth-standard.org/standard/core/ENDCASE</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>endof</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> (C: case-sys1 of-sys1-- case-sys2) (&#8201;&#8212;&#8201;) "Conditional flow control"
+<a href="http://forth-standard.org/standard/core/ENDOF" class="bare">http://forth-standard.org/standard/core/ENDOF</a>
+This is a dummy entry, the code is shared with ELSE</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>enter-screen</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Editor</em> ( scr#&#8201;&#8212;&#8201;) "Enter all lines for given screen"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>environment?</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( addr u&#8201;&#8212;&#8201;0 | i*x true )  "Return system information"
+<a href="https://forth-standard.org/standard/core/ENVIRONMENTq" class="bare">https://forth-standard.org/standard/core/ENVIRONMENTq</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>erase</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( addr u&#8201;&#8212;&#8201;) "Fill memory region with zeros"
+<a href="https://forth-standard.org/standard/core/ERASE" class="bare">https://forth-standard.org/standard/core/ERASE</a>
+Note that ERASE works with "address" units
+(bytes), not cells.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>erase-screen</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Editor</em> ( scr#&#8201;&#8212;&#8201;) "Erase all lines for given screen"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>evaluate</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( addr u&#8201;&#8212;&#8201;) "Execute a string"
+<a href="https://forth-standard.org/standard/core/EVALUATE" class="bare">https://forth-standard.org/standard/core/EVALUATE</a>
+Set SOURCE-ID to -1, make addr u the input source, set &gt;IN to zero.
+After processing the line, revert to old input source. We use this
+to compile high-level Forth words and user-defined words during
+start up and cold boot. In contrast to ACCEPT, we need to, uh,
+accept more than 255 characters here, even though it&#8217;s a pain in
+8-bit.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>execute</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( xt&#8201;&#8212;&#8201;) "Jump to word based on execution token"
+<a href="https://forth-standard.org/standard/core/EXECUTE" class="bare">https://forth-standard.org/standard/core/EXECUTE</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>execute-parsing</code>
+</td>
+<td class="hdlist2">
+<p><em>Gforth</em> ( addr u xt&#8201;&#8212;&#8201;) "Pass a string to a parsing word"
+<a href="https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/The-Input-Stream.html" class="bare">https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/The-Input-Stream.html</a>
+Execute the parsing word defined by the execution token (xt) on the
+string as if it were passed on the command line. See the file
+tests/tali.fs for examples. Note that this word is coded completely
+different in its Gforth version, see the file execute-parsing.fs
+(in /usr/share/gforth/0.7.3/compat/ on Ubuntu 18.04 LTS) for details.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>exit</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Return control to the calling word immediately"
+<a href="https://forth-standard.org/standard/core/EXIT" class="bare">https://forth-standard.org/standard/core/EXIT</a>
+If we&#8217;re in a loop, we need to UNLOOP first and get everything
+we we might have put on the Return Stack off as well. This should
+be natively compiled</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>false</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> (&#8201;&#8212;&#8201;f ) "Push flag FALSE to Data Stack"
+<a href="https://forth-standard.org/standard/core/FALSE" class="bare">https://forth-standard.org/standard/core/FALSE</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>fill</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( addr u char&#8201;&#8212;&#8201;) "Fill a memory region with a character"
+<a href="https://forth-standard.org/standard/core/FILL" class="bare">https://forth-standard.org/standard/core/FILL</a>
+Fill u bytes of memory with char starting at addr. Note that
+this works on bytes, not on cells. On an 8-bit machine such as the
+65c02, this is a serious pain in the rear. It is not defined what
+happens when we reach the end of the address space</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>find</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( caddr&#8201;&#8212;&#8201;addr 0 | xt 1 | xt -1 ) "Find word in Dictionary"
+<a href="https://forth-standard.org/standard/core/FIND" class="bare">https://forth-standard.org/standard/core/FIND</a>
+Included for backwards compatibility only, because it still
+can be found in so may examples. It should, however, be replaced
+by FIND-NAME. Counted string either returns address with a FALSE
+flag if not found in the Dictionary, or the xt with a flag to
+indicate if this is immediate or not. FIND is a wrapper around
+FIND-NAME, we get this all over with as quickly as possible. See
+<a href="https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Word-Lists.html" class="bare">https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Word-Lists.html</a>
+<a href="https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html" class="bare">https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>find-name</code>
+</td>
+<td class="hdlist2">
+<p><em>Gforth</em> ( addr u&#8201;&#8212;&#8201;nt|0 ) "Get the name token of input word"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>flush</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS block</em> (&#8201;&#8212;&#8201;) "Save dirty buffers and empty buffers"
+<a href="https://forth-standard.org/standard/block/FLUSH" class="bare">https://forth-standard.org/standard/block/FLUSH</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>fm/mod</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( d n1 &#8201;&#8212;&#8201;rem n2 ) "Floored signed division"
+<a href="https://forth-standard.org/standard/core/FMDivMOD" class="bare">https://forth-standard.org/standard/core/FMDivMOD</a>
+There are various ways to realize this. We follow EForth with
+DUP 0&lt; DUP &gt;R  IF NEGATE &gt;R DNEGATE R&gt; THEN &gt;R DUP
+0&lt;  IF R@ + THEN  R&gt; UM/MOD R&gt; IF SWAP NEGATE SWAP THEN
+See (<a href="http://www.forth.org/eforth.html" class="bare">http://www.forth.org/eforth.html</a>). However you can also
+go FM/MOD via SM/REM (<a href="http://www.figuk.plus.com/build/arith.htm" class="bare">http://www.figuk.plus.com/build/arith.htm</a>):
+DUP &gt;R  SM/REM DUP 0&lt; IF SWAP R&gt; + SWAP 1+ ELSE  R&gt; DROP THEN
+Note that by default, Tali Forth uses SM/REM for most things.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>forth</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS search ext</em> (&#8201;&#8212;&#8201;) "Replace first WID in search order with Forth-Wordlist"
+<a href="https://forth-standard.org/standard/search/FORTH" class="bare">https://forth-standard.org/standard/search/FORTH</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>forth-wordlist</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS search</em> (&#8201;&#8212;&#8201;u ) "WID for the Forth Wordlist"
+<a href="https://forth-standard.org/standard/search/FORTH-WORDLIST" class="bare">https://forth-standard.org/standard/search/FORTH-WORDLIST</a>
+This is a dummy entry, the actual code is shared with ZERO.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>get-current</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS search</em> (&#8201;&#8212;&#8201;wid ) "Get the id of the compilation wordlist"
+<a href="https://forth-standard.org/standard/search/GET-CURRENT" class="bare">https://forth-standard.org/standard/search/GET-CURRENT</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>get-order</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS search</em> (&#8201;&#8212;&#8201;wid_n .. wid_1 n) "Get the current search order"
+<a href="https://forth-standard.org/standard/search/GET-ORDER" class="bare">https://forth-standard.org/standard/search/GET-ORDER</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>here</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;addr ) "Put Compiler Pointer on Data Stack"
+<a href="https://forth-standard.org/standard/core/HERE" class="bare">https://forth-standard.org/standard/core/HERE</a>
+This code is also used by the assembler directive ARROW
+("&#8594;") though as immediate</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>hex</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> (&#8201;&#8212;&#8201;) "Change base radix to hexadecimal"
+<a href="https://forth-standard.org/standard/core/HEX" class="bare">https://forth-standard.org/standard/core/HEX</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>hexstore</code>
+</td>
+<td class="hdlist2">
+<p>_Tali _ ( addr1 u1 addr2&#8201;&#8212;&#8201;u2 ) "Change base radix to hexadecimal"
+Given a string addr1 u1 with numbers in the current base seperated
+by spaces, store the numbers at the address addr2, returning the
+number of elements. Non-number elements are skipped, an zero-length
+string produces a zero output.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>hold</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( char&#8201;&#8212;&#8201;) "Insert character at current output"
+<a href="https://forth-standard.org/standard/core/HOLD" class="bare">https://forth-standard.org/standard/core/HOLD</a>
+Insert a character at the current position of a pictured numeric
+output string on
+<a href="https://github.com/philburk/pforth/blob/master/fth/numberio.fth" class="bare">https://github.com/philburk/pforth/blob/master/fth/numberio.fth</a>
+Forth code is : HOLD  -1 HLD +!  HLD @ C! ;  We use the the internal
+variable tohold instead of HLD.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>i</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;n )(R: n&#8201;&#8212;&#8201;n)  "Copy loop counter to stack"
+<a href="https://forth-standard.org/standard/core/I" class="bare">https://forth-standard.org/standard/core/I</a>
+Note that this is not the same as R@ because we use a fudge
+factor for loop control; see docs/loop.txt for details. We
+should make this native compile for speed.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>if</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (C:&#8201;&#8212;&#8201;orig) (flag&#8201;&#8212;&#8201;) "Conditional flow control"
+<a href="http://forth-standard.org/standard/core/IF" class="bare">http://forth-standard.org/standard/core/IF</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>immediate</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Mark most recent word as IMMEDIATE"
+<a href="https://forth-standard.org/standard/core/IMMEDIATE" class="bare">https://forth-standard.org/standard/core/IMMEDIATE</a>
+Make sure the most recently defined word is immediate. Will only
+affect the last word in the dictionary. Note that if the word is
+defined in ROM, this will have no affect, but will not produce an
+error message.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>input</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;addr ) "Return address of input vector"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>input&gt;r</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;) ( R:&#8201;&#8212;&#8201;n n n n ) "Save input state to the Return Stack"
+Save the current input state as defined by insrc, cib, ciblen, and
+toin to the Return Stack. Used by EVALUTE. The naive way of doing
+this is to push each two-byte variable to the stack in the form of</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>int&gt;name</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> ( xt&#8201;&#8212;&#8201;nt ) "Get name token from execution token"
+www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html
+This is called &gt;NAME in Gforth, but we change it to
+INT&gt;NAME to match NAME&gt;INT</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>invert</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n&#8201;&#8212;&#8201;n ) "Complement of TOS"
+<a href="https://forth-standard.org/standard/core/INVERT" class="bare">https://forth-standard.org/standard/core/INVERT</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>is</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( xt "name"&#8201;&#8212;&#8201;) "Set named word to execute xt"
+<a href="http://forth-standard.org/standard/core/IS" class="bare">http://forth-standard.org/standard/core/IS</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>j</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;n ) (R: n&#8201;&#8212;&#8201;n ) "Copy second loop counter to stack"
+<a href="https://forth-standard.org/standard/core/J" class="bare">https://forth-standard.org/standard/core/J</a>
+Copy second loop counter from Return Stack to stack. Note we use
+a fudge factor for loop control; see docs/loop.txt for more details.
+At this point, we have the "I" counter/limit and the LEAVE address
+on the stack above this (three entries), whereas the ideal Forth
+implementation would just have two. Make this native compiled for
+speed</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>key</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;char ) "Get one character from the input"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>l</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Editor</em> (&#8201;&#8212;&#8201;) "List the current screen"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>latestnt</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;nt ) "Push most recent nt to the stack"
+www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html
+The Gforth version of this word is called LATEST</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>latestxt</code>
+</td>
+<td class="hdlist2">
+<p><em>Gforth</em> (&#8201;&#8212;&#8201;xt ) "Push most recent xt to the stack"
+<a href="http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Anonymous-Definitions.html" class="bare">http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Anonymous-Definitions.html</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>leave</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Leave DO/LOOP construct"
+<a href="https://forth-standard.org/standard/core/LEAVE" class="bare">https://forth-standard.org/standard/core/LEAVE</a>
+Note that this does not work with  anything but a DO/LOOP in
+contrast to other versions such as discussed at
+<a href="http://blogs.msdn.com/b/ashleyf/archive/2011/02/06/loopty-do-i-loop.aspx" class="bare">http://blogs.msdn.com/b/ashleyf/archive/2011/02/06/loopty-do-i-loop.aspx</a>
+: LEAVE POSTPONE BRANCH HERE SWAP 0 , ; IMMEDIATE COMPILE-ONLY
+See docs/loops.txt on details of how this works. This must be native
+compile and not IMMEDIATE</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>line</code>
+</td>
+<td class="hdlist2">
+<p><em>Tali Editor</em> ( line#&#8201;&#8212;&#8201;c-addr ) "Turn a line number into address in current screen"</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>list</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS block ext</em> ( scr# scr#&#8201;&#8212;&#8201;) "Load screens in the given range"
+<a href="https://forth-standard.org/standard/block/LIST" class="bare">https://forth-standard.org/standard/block/LIST</a>
+<a href="https://forth-standard.org/standard/block/THRU" class="bare">https://forth-standard.org/standard/block/THRU</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>literal</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n&#8201;&#8212;&#8201;) "Store TOS to be push on stack during runtime"
+<a href="https://forth-standard.org/standard/core/LITERAL" class="bare">https://forth-standard.org/standard/core/LITERAL</a>
+Compile-only word to store TOS so that it is pushed on stack
+during runtime. This is a immediate, compile-only word. At runtime,
+it works by calling literal_runtime by compling JSR LITERAL_RT.
+Note the cmpl_ routines use TMPTOS</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>load</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS block</em> ( scr#&#8201;&#8212;&#8201;) "Load the Forth code in a screen/block"
+<a href="https://forth-standard.org/standard/block/LOAD" class="bare">https://forth-standard.org/standard/block/LOAD</a>
+Note: LOAD current works because there is only one buffer.
+if/when multiple buffers are supported, we&#8217;ll have to deal
+with the fact that it might re-load the old block into a
+different buffer.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>loop</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Finish loop construct"
+<a href="https://forth-standard.org/standard/core/LOOP" class="bare">https://forth-standard.org/standard/core/LOOP</a>
+Compile-time part of LOOP. This does nothing more but push 1 on
+the stack and then call +LOOP. In Forth, this is
+: LOOP  POSTPONE 1 POSTPONE (+LOOP) , POSTPONE UNLOOP
+IMMEDIATE ; COMPILE-ONLY
+This drops through to +LOOP</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>lshift</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( x u&#8201;&#8212;&#8201;u ) "Shift TOS left"
+<a href="https://forth-standard.org/standard/core/LSHIFT" class="bare">https://forth-standard.org/standard/core/LSHIFT</a></p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>m*</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;d ) "16 * 16 -&#8594; 32"
+<a href="https://forth-standard.org/standard/core/MTimes" class="bare">https://forth-standard.org/standard/core/MTimes</a>
+Multiply two 16 bit numbers, producing a 32 bit result. All
+values are signed. Adapted from FIG Forth for Tali Forth. The
+original Forth is : M* OVER OVER XOR &gt;R ABS SWAP ABS UM* R&gt; D+-
+with  : D+- O&lt; IF DNEGATE THEN</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>marker</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core ext</em> ( "name"&#8201;&#8212;&#8201;) "Create a deletion boundry"
+<a href="https://forth-standard.org/standard/core/MARKER" class="bare">https://forth-standard.org/standard/core/MARKER</a>
+This word replaces FORGET in earlier Forths. Old entries are not
+actually deleted, but merely overwritten by restoring CP and DP. To
+do this, we want to end up with something that jumps to a run-time
+component with a link to the original CP and DP values:</p>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>jsr marker_runtime
+&lt;Original CP MSB&gt;
+&lt;Original CP LSB&gt;
+&lt;Original DP MSB&gt; ( for CURRENT wordlist )
+&lt;Original DP LSB&gt;
+&lt; USER variables from offset 4 to 39 &gt;</p>
+</div>
+<div class="paragraph">
+<p>The user variables include:
+CURRENT (byte variable)
+&lt;All wordlists&gt; (currently 12) (cell array)
+&lt;#ORDER&gt; (byte variable)
+&lt;All search order&gt; (currently 9) (byte array)</p>
+</div>
+<div class="paragraph">
+<p>This code uses tmp1 and tmp2</p>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><code>max</code></dt>
+<dd>
+<p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;n ) "Keep larger of two numbers"
+<a href="https://forth-standard.org/standard/core/MAX" class="bare">https://forth-standard.org/standard/core/MAX</a>
+Compare TOS and NOS and keep which one is larger. Adapted from
+Lance A. Leventhal "6502 Assembly Language Subroutines". Negative
+Flag indicates which number is larger. See also
+<a href="http://6502.org/tutorials/compare_instructions.html" class="bare">http://6502.org/tutorials/compare_instructions.html</a> and
+<a href="http://www.righto.com/2012/12/the-6502-overflow-flag-explained.html" class="bare">http://www.righto.com/2012/12/the-6502-overflow-flag-explained.html</a></p>
+</dd>
+<dt class="hdlist1"><code>min</code></dt>
+<dd>
+<p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;n ) "Keep smaller of two numbers"
+<a href="https://forth-standard.org/standard/core/MIN" class="bare">https://forth-standard.org/standard/core/MIN</a>
+Adapted from Lance A. Leventhal "6502 Assembly Language
+Subroutines." Negative Flag indicateds which number is larger. See
+<a href="http://www.righto.com/2012/12/the-6502-overflow-flag-explained.html" class="bare">http://www.righto.com/2012/12/the-6502-overflow-flag-explained.html</a></p>
+</dd>
+<dt class="hdlist1"><code>mod</code></dt>
+<dd>
+<p><em>ANS core</em> ( n1 n2&#8201;&#8212;&#8201;n ) "Divide NOS by TOS and return the remainder"
+<a href="https://forth-standard.org/standard/core/MOD" class="bare">https://forth-standard.org/standard/core/MOD</a>
+The Forth definition of this word is  : MOD /MOD DROP
+so we just jump to xt_slash_mod and dump the actual result.</p>
+</dd>
+<dt class="hdlist1"><code>move</code></dt>
+<dd>
+<p><em>ANS core</em> ( addr1 addr2 u&#8201;&#8212;&#8201;) "Copy bytes"
+<a href="https://forth-standard.org/standard/core/MOVE" class="bare">https://forth-standard.org/standard/core/MOVE</a>
+Copy u "address units" from addr1 to addr2. Since our address
+units are bytes, this is just a front-end for CMOVE and CMOVE&gt;. This
+is actually the only one of these three words that is in the CORE
+set. This word must not be natively compiled</p>
+</dd>
+<dt class="hdlist1"><code>name&gt;int</code></dt>
+<dd>
+<p><em>Gforth</em> ( nt&#8201;&#8212;&#8201;xt ) "Convert Name Token to Execute Token"
+See
+<a href="https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html" class="bare">https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html</a></p>
+</dd>
+<dt class="hdlist1"><code>name&gt;string</code></dt>
+<dd>
+<p><em>Gforth</em> ( nt&#8201;&#8212;&#8201;addr u ) "Given a name token, return string of word"
+<a href="http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html" class="bare">http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html</a></p>
+</dd>
+<dt class="hdlist1"><code>nc-limit</code></dt>
+<dd>
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;addr ) "Return address where NC-LIMIT value is kept"</p>
+</dd>
+<dt class="hdlist1"><code>negate</code></dt>
+<dd>
+<p><em>ANS core</em> ( n&#8201;&#8212;&#8201;n ) "Two&#8217;s complement"
+<a href="https://forth-standard.org/standard/core/NEGATE" class="bare">https://forth-standard.org/standard/core/NEGATE</a></p>
+</dd>
+<dt class="hdlist1"><code>never-native</code></dt>
+<dd>
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;) "Flag last word as never natively compiled"</p>
+</dd>
+<dt class="hdlist1"><code>nip</code></dt>
+<dd>
+<p><em>ANS core ext</em> ( b a&#8201;&#8212;&#8201;a ) "Delete NOS"
+<a href="https://forth-standard.org/standard/core/NIP" class="bare">https://forth-standard.org/standard/core/NIP</a></p>
+</dd>
+<dt class="hdlist1"><code>number</code></dt>
+<dd>
+<p><em>Tali Forth</em> ( addr u&#8201;&#8212;&#8201;u | d ) "Convert a number string"
+Convert a number string to a double or single cell number. This
+is a wrapper for &gt;NUMBER and follows the convention set out in the
+Forth Programmer&#8217;s Handbook" (Conklin &amp; Rather) 3rd edition p. 87.
+Based in part on the "Starting Forth" code
+<a href="https://www.forth.com/starting-forth/10-input-output-operators/" class="bare">https://www.forth.com/starting-forth/10-input-output-operators/</a>
+Gforth uses S&gt;NUMBER? and S&gt;UNUMBER? which return numbers and a flag
+<a href="https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Number-Conversion.html" class="bare">https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Number-Conversion.html</a>
+Another difference to Gforth is that we follow ANS Forth that the
+dot to signal a double cell number is required to be the last
+character of the string. Number calls &gt;NUMBER which in turn calls UM*,
+which uses tmp1, tmp2, and tmp3, so we can&#8217;t use them here, which is
+a pain.</p>
+</dd>
+<dt class="hdlist1"><code>o</code></dt>
+<dd>
+<p><em>Tali Editor</em> ( line#&#8201;&#8212;&#8201;) "Overwrite the given line"</p>
+</dd>
+<dt class="hdlist1"><code>of</code></dt>
+<dd>
+<p><em>ANS core ext</em> (C:&#8201;&#8212;&#8201;of-sys) (x1 x2&#8201;&#8212;&#8201;|x1) "Conditional flow control"
+<a href="http://forth-standard.org/standard/core/OF" class="bare">http://forth-standard.org/standard/core/OF</a></p>
+</dd>
+<dt class="hdlist1"><code>only</code></dt>
+<dd>
+<p><em>ANS search ext</em> (&#8201;&#8212;&#8201;) "Set earch order to minimum wordlist"
+<a href="https://forth-standard.org/standard/search/ONLY" class="bare">https://forth-standard.org/standard/search/ONLY</a></p>
+</dd>
+<dt class="hdlist1"><code>or</code></dt>
+<dd>
+<p><em>ANS core</em> ( m n&#8201;&#8212;&#8201;n ) "Logically OR TOS and NOS"
+<a href="https://forth-standard.org/standard/core/OR" class="bare">https://forth-standard.org/standard/core/OR</a></p>
+</dd>
+<dt class="hdlist1"><code>order</code></dt>
+<dd>
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Print current word order list and current WID"
+<a href="https://forth-standard.org/standard/search/ORDER" class="bare">https://forth-standard.org/standard/search/ORDER</a>
+A Forth implementation of this word is:</p>
+</dd>
+<dt class="hdlist1"><code>output</code></dt>
+<dd>
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;addr ) "Return the address of the EMIT vector address"</p>
+</dd>
+<dt class="hdlist1"><code>over</code></dt>
+<dd>
+<p><em>ANS core</em> ( b a&#8201;&#8212;&#8201;b a b ) "Copy NOS to TOS"
+<a href="https://forth-standard.org/standard/core/OVER" class="bare">https://forth-standard.org/standard/core/OVER</a></p>
+</dd>
+<dt class="hdlist1"><code>pad</code></dt>
+<dd>
+<p><em>ANS core ext</em> (&#8201;&#8212;&#8201;addr ) "Return address of user scratchpad"
+<a href="https://forth-standard.org/standard/core/PAD" class="bare">https://forth-standard.org/standard/core/PAD</a>
+Return address to a temporary area in free memory for user. Must
+be at least 84 bytes in size (says ANS). It is located relative to
+the compile area pointer (CP) and therefore varies in position.
+This area is reserved for the user and not used by the system</p>
+</dd>
+<dt class="hdlist1"><code>page</code></dt>
+<dd>
+<p><em>ANS facility</em> (&#8201;&#8212;&#8201;) "Clear the screen"
+<a href="https://forth-standard.org/standard/facility/PAGE" class="bare">https://forth-standard.org/standard/facility/PAGE</a>
+Clears a page if supported by ANS terminal codes. This is
+Clear Screen ("ESC[2J") plus moving the cursor to the top
+left of the screen</p>
+</dd>
+<dt class="hdlist1"><code>parse</code></dt>
+<dd>
+<p><em>ANS core ext</em> ( "name" c&#8201;&#8212;&#8201;addr u ) "Parse input with delimiter character"
+<a href="https://forth-standard.org/standard/core/PARSE" class="bare">https://forth-standard.org/standard/core/PARSE</a>
+Find word in input string delimited by character given. Do not
+skip leading delimiters&#8201;&#8212;&#8201;this is the main difference to PARSE-NAME.
+PARSE and PARSE-NAME replace WORD in modern systems. ANS discussion
+<a href="http://www.forth200x.org/documents/html3/rationale.html#rat:core:PARSE" class="bare">http://www.forth200x.org/documents/html3/rationale.html#rat:core:PARSE</a></p>
+</dd>
+</dl>
+</div>
+<div class="paragraph">
+<p>cib  cib+toin   cib+ciblen
+v      v            v
+|<mark><mark></mark><mark></mark></mark><mark><mark></mark></mark>###|</p>
+</div>
+<div class="paragraph">
+<p>|-----&#8594;|  toin (&gt;IN)
+|------------------&#8594;|  ciblen</p>
+</div>
+<div class="paragraph">
+<p>The input string is stored starting at the address in the Current
+Input Buffer (CIB), the length of which is in CIBLEN. While searching
+for the delimiter, TOIN (&gt;IN) points to the where we currently are.
+Since PARSE does not skip leading delimiters, we assume we are on a
+useful string if there are any characters at all. As with
+PARSE-NAME, we must be able to handle strings with a length of
+16-bit for EVALUTE, which is a pain on an 8-bit machine.</p>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><code>parse-name</code></dt>
+<dd>
+<p><em>ANS core ext</em> ( "name"&#8201;&#8212;&#8201;addr u ) "Parse the input"
+<a href="https://forth-standard.org/standard/core/PARSE-NAME" class="bare">https://forth-standard.org/standard/core/PARSE-NAME</a>
+Find next word in input string, skipping leading whitespace. This is
+a special form of PARSE and drops through to that word. See PARSE
+for more detail. We use this word internally for the interpreter
+because it is a lot easier to use. Reference implementations at
+<a href="http://forth-standard.org/standard/core/PARSE-NAME" class="bare">http://forth-standard.org/standard/core/PARSE-NAME</a> and
+<a href="http://www.forth200x.org/reference-implementations/parse-name.fs" class="bare">http://www.forth200x.org/reference-implementations/parse-name.fs</a>
+Roughly, the word is comparable to BL WORD COUNT.&#8201;&#8212;&#8201;Note that
+though the ANS standard talks about skipping "spaces", whitespace
+is actually perfectly legal (see for example
+<a href="http://forth-standard.org/standard/usage#subsubsection.3.4.1.1" class="bare">http://forth-standard.org/standard/usage#subsubsection.3.4.1.1</a>).
+Otherwise, PARSE-NAME chokes on tabs.</p>
+</dd>
+<dt class="hdlist1"><code>pick</code></dt>
+<dd>
+<p><em>ANS core ext</em> ( n n u&#8201;&#8212;&#8201;n n n ) "Move element u of the stack to TOS"
+<a href="https://forth-standard.org/standard/core/PICK" class="bare">https://forth-standard.org/standard/core/PICK</a>
+Take the u-th element out of the stack and put it on TOS,
+overwriting the original TOS. 0 PICK is equivalent to DUP, 1 PICK to
+OVER. Note that using PICK is considered poor coding form. Also note
+that FIG Forth has a different behavior for PICK than ANS Forth.</p>
+</dd>
+<dt class="hdlist1"><code>postpone</code></dt>
+<dd>
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Change IMMEDIATE status (it&#8217;s complicated)"
+<a href="https://forth-standard.org/standard/core/POSTPONE" class="bare">https://forth-standard.org/standard/core/POSTPONE</a>
+Add the compilation behavior of a word to a new word at
+compile time. If the word that follows it is immediate, include
+it so that it will be compiled when the word being defined is
+itself used for a new word. Tricky, but very useful. Because
+POSTPONE expects a word (not an xt) in the input stream (not
+on the Data Stack). This means we cannot build words with
+jsr xt_postpone, jsr &lt;word&gt;" directly.</p>
+</dd>
+<dt class="hdlist1"><code>previous</code></dt>
+<dd>
+<p><em>ANS search ext</em> (&#8201;&#8212;&#8201;) "Remove the first wordlist in the search order"
+<a href="http://forth-standard.org/standard/search/PREVIOUS" class="bare">http://forth-standard.org/standard/search/PREVIOUS</a></p>
+</dd>
+<dt class="hdlist1"><code>quit</code></dt>
+<dd>
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Reset the input and get new input"
+<a href="https://forth-standard.org/standard/core/QUIT" class="bare">https://forth-standard.org/standard/core/QUIT</a>
+Rest the input and start command loop</p>
+</dd>
+<dt class="hdlist1"><code>r&gt;</code></dt>
+<dd>
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;n )(R: n --) "Move top of Return Stack to TOS"
+<a href="https://forth-standard.org/standard/core/Rfrom" class="bare">https://forth-standard.org/standard/core/Rfrom</a>
+Move Top of Return Stack to Top of Data Stack. We have to move
+the RTS address out of the way first. This word is handled
+differently for native and and subroutine compilation, see COMPILE,
+This is a compile-only word</p>
+</dd>
+<dt class="hdlist1"><code>r&gt;input</code></dt>
+<dd>
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;) ( R: n n n n&#8201;&#8212;&#8201;) "Restore input state from Return Stack"
+Restore the current input state as defined by insrc, cib, ciblen,
+and toin from the Return Stack. See INPUT_TO_R for a discussion of
+this word. Uses tmp1</p>
+</dd>
+<dt class="hdlist1"><code>r@</code></dt>
+<dd>
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;n ) "Get copy of top of Return Stack"
+<a href="https://forth-standard.org/standard/core/RFetch" class="bare">https://forth-standard.org/standard/core/RFetch</a>
+This word is Compile Only in Tali Forth, though Gforth has it
+work normally as well&#8201;&#8212;&#8201;An alternative way to write this word
+would be to access the elements on the stack directly like 2R@
+does, these versions should be compared at some point.</p>
+</dd>
+<dt class="hdlist1"><code>recurse</code></dt>
+<dd>
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Copy recursive call to word being defined"
+<a href="https://forth-standard.org/standard/core/RECURSE" class="bare">https://forth-standard.org/standard/core/RECURSE</a>
+This word may not be natively compiled</p>
+</dd>
+<dt class="hdlist1"><code>refill</code></dt>
+<dd>
+<p><em>ANS core ext</em> (&#8201;&#8212;&#8201;f ) "Refill the input buffer"
+<a href="https://forth-standard.org/standard/core/REFILL" class="bare">https://forth-standard.org/standard/core/REFILL</a>
+Attempt to fill the input buffer from the input source, returning
+a true flag if successful. When the input source is the user input
+device, attempt to receive input into the terminal input buffer. If
+successful, make the result the input buffer, set &gt;IN to zero, and
+return true. Receipt of a line containing no characters is considered
+successful. If there is no input available from the current input
+source, return false. When the input source is a string from EVALUATE,
+return false and perform no other action." See
+<a href="https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/The-Input-Stream.html" class="bare">https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/The-Input-Stream.html</a>
+and Conklin &amp; Rather p. 156</p>
+</dd>
+<dt class="hdlist1"><code>repeat</code></dt>
+<dd>
+<p><em>ANS core</em> (C: orig dest&#8201;&#8212;&#8201;) (&#8201;&#8212;&#8201;) "Loop flow control"
+<a href="http://forth-standard.org/standard/core/REPEAT" class="bare">http://forth-standard.org/standard/core/REPEAT</a></p>
+</dd>
+<dt class="hdlist1"><code>root-wordlist</code></dt>
+<dd>
+<p><em>Tali Editor</em> (&#8201;&#8212;&#8201;u ) "WID for the Root (minimal) wordlist"</p>
+</dd>
+<dt class="hdlist1"><code>rot</code></dt>
+<dd>
+<p><em>ANS core</em> ( a b c&#8201;&#8212;&#8201;b c a ) "Rotate first three stack entries downwards"
+<a href="https://forth-standard.org/standard/core/ROT" class="bare">https://forth-standard.org/standard/core/ROT</a>
+Remember "R for 'Revolution'" - the bottom entry comes out
+on top!</p>
+</dd>
+<dt class="hdlist1"><code>rshift</code></dt>
+<dd>
+<p><em>ANS core</em> ( x u&#8201;&#8212;&#8201;x ) "Shift TOS to the right"
+<a href="https://forth-standard.org/standard/core/RSHIFT" class="bare">https://forth-standard.org/standard/core/RSHIFT</a></p>
+</dd>
+<dt class="hdlist1"><code>s"</code></dt>
+<dd>
+<p><em>ANS core</em> ( "string"&#8201;&#8212;&#8201;)(&#8201;&#8212;&#8201;addr u ) "Store string in memory"
+<a href="https://forth-standard.org/standard/core/Sq" class="bare">https://forth-standard.org/standard/core/Sq</a>
+Store address and length of string given, returning ( addr u ).
+ANS core claims this is compile-only, but the file set expands it
+to be interpreted, so it is a state-sensitive word, which in theory
+are evil. We follow general usage. Can also be realized as
+: S" [CHAR] " PARSE POSTPONE SLITERAL ; IMMEDIATE
+but it is used so much we want it in code.</p>
+</dd>
+<dt class="hdlist1"><code>s&gt;d</code></dt>
+<dd>
+<p><em>ANS core</em> ( u&#8201;&#8212;&#8201;d ) "Convert single cell number to double cell"
+<a href="https://forth-standard.org/standard/core/StoD" class="bare">https://forth-standard.org/standard/core/StoD</a></p>
+</dd>
+<dt class="hdlist1"><code>s\"</code></dt>
+<dd>
+<p><em>ANS core</em> ( "string"&#8201;&#8212;&#8201;)(&#8201;&#8212;&#8201;addr u ) "Store string in memory"
+<a href="https://forth-standard.org/standard/core/Seq" class="bare">https://forth-standard.org/standard/core/Seq</a>
+Store address and length of string given, returning ( addr u ).
+ANS core claims this is compile-only, but the file set expands it
+to be interpreted, so it is a state-sensitive word, which in theory
+are evil. We follow general usage.  This is just like S" except
+that it allows for some special escaped characters.</p>
+</dd>
+<dt class="hdlist1"><code>save-buffers</code></dt>
+<dd>
+<p><em>ANS block</em> (&#8201;&#8212;&#8201;) "Save all dirty buffers to storage"
+<a href="https://forth-standard.org/standard/block/SAVE-BUFFERS" class="bare">https://forth-standard.org/standard/block/SAVE-BUFFERS</a></p>
+</dd>
+<dt class="hdlist1"><code>scr</code></dt>
+<dd>
+<p><em>ANS block ext</em> (&#8201;&#8212;&#8201;addr ) "Push address of variable holding last screen listed"
+<a href="https://forth-standard.org/standard/block/SCR" class="bare">https://forth-standard.org/standard/block/SCR</a></p>
+</dd>
+<dt class="hdlist1"><code>search</code></dt>
+<dd>
+<p><em>ANS string</em> ( addr1 u1 addr2 u2&#8201;&#8212;&#8201;addr3 u3 flag) "Search for a substring"
+<a href="https://forth-standard.org/standard/string/SEARCH" class="bare">https://forth-standard.org/standard/string/SEARCH</a>
+Search for string2 (denoted by addr2 u2) in string1 (denoted by
+addr1 u1).  If a match is found the flag will be true and
+addr3 will have the address of the start of the match and u3 will have
+the number of characters remaining from the match point to the end
+of the original string1.  If a match is not found, the flag will be
+false and addr3 and u3 will be the original string1&#8217;s addr1 and u1.</p>
+</dd>
+<dt class="hdlist1"><code>search-wordlist</code></dt>
+<dd>
+<p><em>ANS search</em> ( caddr u wid&#8201;&#8212;&#8201;0 | xt 1 | xt -1) "Search for a word in a wordlist"
+<a href="https://forth-standard.org/standard/search/SEARCH_WORDLIST" class="bare">https://forth-standard.org/standard/search/SEARCH_WORDLIST</a></p>
+</dd>
+<dt class="hdlist1"><code>see</code></dt>
+<dd>
+<p><em>ANS tools</em> ( "name"&#8201;&#8212;&#8201;) "Print information about a Forth word"
+<a href="https://forth-standard.org/standard/tools/SEE" class="bare">https://forth-standard.org/standard/tools/SEE</a>
+SEE takes the name of a word and prints its name token (nt),
+execution token (xt), size in bytes, flags used, and then dumps the
+code and disassembles it.</p>
+</dd>
+<dt class="hdlist1"><code>set-current</code></dt>
+<dd>
+<p><em>ANS search</em> ( wid&#8201;&#8212;&#8201;) "Set the compilation wordlist"
+<a href="https://forth-standard.org/standard/search/SET-CURRENT" class="bare">https://forth-standard.org/standard/search/SET-CURRENT</a></p>
+</dd>
+<dt class="hdlist1"><code>set-order</code></dt>
+<dd>
+<p><em>ANS search</em> ( wid_n .. wid_1 n&#8201;&#8212;&#8201;) "Set the current search order"
+<a href="https://forth-standard.org/standard/search/SET-ORDER" class="bare">https://forth-standard.org/standard/search/SET-ORDER</a></p>
+</dd>
+<dt class="hdlist1"><code>sign</code></dt>
+<dd>
+<p><em>ANS core</em> ( n&#8201;&#8212;&#8201;) "Add minus to pictured output"
+<a href="https://forth-standard.org/standard/core/SIGN" class="bare">https://forth-standard.org/standard/core/SIGN</a>
+Code based on
+<a href="http://pforth.googlecode.com/svn/trunk/fth/numberio.fth" class="bare">http://pforth.googlecode.com/svn/trunk/fth/numberio.fth</a>
+Original Forth code is   0&lt; IF ASCII - HOLD THEN</p>
+</dd>
+<dt class="hdlist1"><code>sliteral</code></dt>
+<dd>
+<p><em>ANS string</em> ( addr u&#8201;&#8212;&#8201;)(&#8201;&#8212;&#8201;addr u ) "Compile a string for runtime"
+<a href="https://forth-standard.org/standard/string/SLITERAL" class="bare">https://forth-standard.org/standard/string/SLITERAL</a>
+Add the runtime for an existing string.</p>
+</dd>
+<dt class="hdlist1"><code>sm/rem</code></dt>
+<dd>
+<p><em>ANS core</em> ( d n1&#8201;&#8212;&#8201;n2 n3 ) "Symmetic signed division"
+<a href="https://forth-standard.org/standard/core/SMDivREM" class="bare">https://forth-standard.org/standard/core/SMDivREM</a>
+Symmetic signed division. Compare FM/MOD. Based on F-PC 3.6
+by Ulrich Hoffmann. See <a href="http://www.xlerb.de/uho/ansi.seq" class="bare">http://www.xlerb.de/uho/ansi.seq</a> Forth:
+OVER &gt;R 2DUP XOR 0&lt; &gt;R ABS &gt;R DABS R&gt; UM/MOD R&gt; ?NEGATE SWAP
+R&gt; ?NEGATE SWAP</p>
+</dd>
+<dt class="hdlist1"><code>source</code></dt>
+<dd>
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;addr u ) "Return location and size of input buffer""
+<a href="https://forth-standard.org/standard/core/SOURCE" class="bare">https://forth-standard.org/standard/core/SOURCE</a></p>
+</dd>
+<dt class="hdlist1"><code>source-id</code></dt>
+<dd>
+<p><em>ANS core ext</em> (&#8201;&#8212;&#8201;n ) "Return source identifier"
+<a href="https://forth-standard.org/standard/core/SOURCE-ID" class="bare">https://forth-standard.org/standard/core/SOURCE-ID</a>
+Identify the input source unless it is a block (s. Conklin &amp;
+Rather p. 156). Since we don&#8217;t have blocks (yet), this will give
+the input source: 0 is keyboard, -1 (0ffff) is character string,
+and a text file gives the fileid.</p>
+</dd>
+<dt class="hdlist1"><code>space</code></dt>
+<dd>
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Print a single space"
+<a href="https://forth-standard.org/standard/core/SPACE" class="bare">https://forth-standard.org/standard/core/SPACE</a></p>
+</dd>
+<dt class="hdlist1"><code>spaces</code></dt>
+<dd>
+<p><em>ANS core</em> ( u&#8201;&#8212;&#8201;) "Print a number of spaces"
+<a href="https://forth-standard.org/standard/core/SPACES" class="bare">https://forth-standard.org/standard/core/SPACES</a></p>
+</dd>
+<dt class="hdlist1"><code>state</code></dt>
+<dd>
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;addr ) "Return the address of compilation state flag"
+<a href="https://forth-standard.org/standard/core/STATE" class="bare">https://forth-standard.org/standard/core/STATE</a>
+STATE is true when in compilation state, false otherwise. Note
+we do not return the state itself, but only the address where
+it lives. The state should not be changed directly by the user; see
+<a href="http://forth.sourceforge.net/standard/dpans/dpans6.htm#6.1.2250" class="bare">http://forth.sourceforge.net/standard/dpans/dpans6.htm#6.1.2250</a></p>
+</dd>
+<dt class="hdlist1"><code>strip-underflow</code></dt>
+<dd>
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;addr ) "Return address where underflow status is kept"
+STRIP_UNDERFLOW contains a flag that determines if underflow
+checking should be removed during the compilation of new words.
+Default is false.</p>
+</dd>
+<dt class="hdlist1"><code>swap</code></dt>
+<dd>
+<p><em>ANS core</em> ( b a&#8201;&#8212;&#8201;a b ) "Exchange TOS and NOS"
+<a href="https://forth-standard.org/standard/core/SWAP" class="bare">https://forth-standard.org/standard/core/SWAP</a></p>
+</dd>
+<dt class="hdlist1"><code>then</code></dt>
+<dd>
+<p><em>ANS core</em> (C: orig&#8201;&#8212;&#8201;) (&#8201;&#8212;&#8201;) "Conditional flow control"
+<a href="http://forth-standard.org/standard/core/THEN" class="bare">http://forth-standard.org/standard/core/THEN</a></p>
+</dd>
+<dt class="hdlist1"><code>to</code></dt>
+<dd>
+<p><em>ANS core ext</em> ( n "name"&#8201;&#8212;&#8201;) or ( "name") "Change a value"
+<a href="https://forth-standard.org/standard/core/TO" class="bare">https://forth-standard.org/standard/core/TO</a>
+Gives a new value to a, uh, VALUE. One possible Forth
+implementation is  ' &gt;BODY !  but given the problems we have
+with &gt;BODY on STC Forths, we do this the hard way. Since
+Tali Forth uses the same code for CONSTANTs and VALUEs, you
+could use this to redefine a CONSTANT, but that is a no-no.</p>
+</dd>
+</dl>
+</div>
+<div class="paragraph">
+<p>Note that the standard has different behaviors for TO depending
+on the state (<a href="https://forth-standard.org/standard/core/TO" class="bare">https://forth-standard.org/standard/core/TO</a>).
+This makes TO state-dependent (which is bad) and also rather
+complex (see the Gforth implementation for comparison). This
+word may not be natively compiled and must be immediate. Frankly,
+it would have made more sense to have two words for this.</p>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><code>true</code></dt>
+<dd>
+<p><em>ANS core ext</em> (&#8201;&#8212;&#8201;f ) "Push TRUE flag to Data Stack"
+<a href="https://forth-standard.org/standard/core/TRUE" class="bare">https://forth-standard.org/standard/core/TRUE</a></p>
+</dd>
+<dt class="hdlist1"><code>tuck</code></dt>
+<dd>
+<p><em>ANS core ext</em> ( b a&#8201;&#8212;&#8201;a b a ) "Copy TOS below NOS"
+<a href="https://forth-standard.org/standard/core/TUCK" class="bare">https://forth-standard.org/standard/core/TUCK</a></p>
+</dd>
+<dt class="hdlist1"><code>type</code></dt>
+<dd>
+<p><em>ANS core</em> ( addr u&#8201;&#8212;&#8201;) "Print string"
+<a href="https://forth-standard.org/standard/core/TYPE" class="bare">https://forth-standard.org/standard/core/TYPE</a>
+Works through EMIT to allow OUTPUT revectoring. Currently, only
+strings of up to 255 characters are printed</p>
+</dd>
+<dt class="hdlist1"><code>u.</code></dt>
+<dd>
+<p><em>ANS core</em> ( u&#8201;&#8212;&#8201;) "Print TOS as unsigned number"
+<a href="https://forth-standard.org/standard/core/Ud" class="bare">https://forth-standard.org/standard/core/Ud</a>
+This is : U. 0 &lt;# #S #&gt; TYPE SPACE ; in Forth
+We use the internal assembler function print_u followed
+by a single space</p>
+</dd>
+<dt class="hdlist1"><code>u.r</code></dt>
+<dd>
+<p><em>ANS core ext</em> ( u u&#8201;&#8212;&#8201;) "Print NOS as unsigned number with TOS with"
+<a href="https://forth-standard.org/standard/core/UDotR" class="bare">https://forth-standard.org/standard/core/UDotR</a></p>
+</dd>
+<dt class="hdlist1"><code>u&lt;</code></dt>
+<dd>
+<p><em>ANS core</em> ( n m&#8201;&#8212;&#8201;f ) "Return true if NOS &lt; TOS (unsigned)"
+<a href="https://forth-standard.org/standard/core/Uless" class="bare">https://forth-standard.org/standard/core/Uless</a></p>
+</dd>
+<dt class="hdlist1"><code>u&gt;</code></dt>
+<dd>
+<p><em>ANS core ext</em> ( n m&#8201;&#8212;&#8201;f ) "Return true if NOS &gt; TOS (unsigned)"
+<a href="https://forth-standard.org/standard/core/Umore" class="bare">https://forth-standard.org/standard/core/Umore</a></p>
+</dd>
+<dt class="hdlist1"><code>ud.</code></dt>
+<dd>
+<p><em>Tali double</em> ( d&#8201;&#8212;&#8201;) "Print double as unsigned"
+Based on the Forth code  : UD. &lt;# #S #&gt; TYPE SPACE</p>
+</dd>
+<dt class="hdlist1"><code>ud.r</code></dt>
+<dd>
+<p><em>Tali double</em> ( d u&#8201;&#8212;&#8201;) "Print unsigned double right-justified u wide"
+Based on the Forth code : UD.R  &gt;R &lt;# #S #&gt; R&gt; OVER - SPACES TYPE</p>
+</dd>
+<dt class="hdlist1"><code>um*</code></dt>
+<dd>
+<p><em>ANS core</em> ( u u&#8201;&#8212;&#8201;ud ) "Multiply 16 x 16 &#8594; 32"
+<a href="https://forth-standard.org/standard/core/UMTimes" class="bare">https://forth-standard.org/standard/core/UMTimes</a>
+Multiply two unsigned 16 bit numbers, producing a 32 bit result.
+This is based on modified FIG Forth code by Dr. Jefyll, see
+<a href="http://forum.6502.org/viewtopic.php?f=9&amp;t=689" class="bare">http://forum.6502.org/viewtopic.php?f=9&amp;t=689</a> for a detailed
+discussion. We don&#8217;t use the system scratch pad (SYSPAD) for temp
+storage because &gt;NUMBER uses it as well, but instead tmp1 to
+tmp3 (tmp1 is N in the original code, tmp1+1 is N+1, etc).
+Old Forth versions such as FIG Forth call this U*</p>
+</dd>
+</dl>
+</div>
+<div class="paragraph">
+<p>Consider switching to a table-supported version based on
+<a href="http://codebase64.org/doku.php?id=base:seriously_fast_multiplication" class="bare">http://codebase64.org/doku.php?id=base:seriously_fast_multiplication</a>
+<a href="http://codebase64.org/doku.php?id=magazines:chacking16#d_graphics_for_the_masseslib3d&gt" class="bare">http://codebase64.org/doku.php?id=magazines:chacking16#d_graphics_for_the_masseslib3d&gt</a>;
+<a href="http://forum.6502.org/viewtopic.php?p=205#p205" class="bare">http://forum.6502.org/viewtopic.php?p=205#p205</a>
+<a href="http://forum.6502.org/viewtopic.php?f=9&amp;t=689" class="bare">http://forum.6502.org/viewtopic.php?f=9&amp;t=689</a></p>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><code>um/mod</code></dt>
+<dd>
+<p><em>ANS core</em> ( ud u&#8201;&#8212;&#8201;ur u ) "32/16 &#8594; 16 division"
+<a href="https://forth-standard.org/standard/core/UMDivMOD" class="bare">https://forth-standard.org/standard/core/UMDivMOD</a>
+Divide double cell number by single cell number, returning the
+quotient as TOS and any remainder as NOS. All numbers are unsigned.
+This is the basic division operation all others use. Based on FIG
+Forth code, modified by Garth Wilson, see
+<a href="http://6502.org/source/integers/ummodfix/ummodfix.htm" class="bare">http://6502.org/source/integers/ummodfix/ummodfix.htm</a>
+This uses tmp1, tmp1+1, and tmptos</p>
+</dd>
+<dt class="hdlist1"><code>unloop</code></dt>
+<dd>
+<p><em>ANS core</em> (&#8201;&#8212;&#8201;)(R: n1 n2 n3 ---) "Drop loop control from Return stack"
+<a href="https://forth-standard.org/standard/core/UNLOOP" class="bare">https://forth-standard.org/standard/core/UNLOOP</a>
+Note that 6xPLA uses just as many bytes as a loop would</p>
+</dd>
+<dt class="hdlist1"><code>until</code></dt>
+<dd>
+<p><em>ANS core</em> (C: dest&#8201;&#8212;&#8201;) (&#8201;&#8212;&#8201;) "Loop flow control"
+<a href="http://forth-standard.org/standard/core/UNTIL" class="bare">http://forth-standard.org/standard/core/UNTIL</a></p>
+</dd>
+<dt class="hdlist1"><code>unused</code></dt>
+<dd>
+<p><em>ANS core ext</em> (&#8201;&#8212;&#8201;u ) "Return size of space available to Dictionary"
+<a href="https://forth-standard.org/standard/core/UNUSED" class="bare">https://forth-standard.org/standard/core/UNUSED</a>
+UNUSED does not include the ACCEPT history buffers. Total RAM
+should be HERE + UNUSED + &lt;history buffer size&gt;, the last of which
+defaults to $400</p>
+</dd>
+<dt class="hdlist1"><code>update</code></dt>
+<dd>
+<p><em>ANS block</em> (&#8201;&#8212;&#8201;) "Mark current block as dirty"
+<a href="https://forth-standard.org/standard/block/UPDATE" class="bare">https://forth-standard.org/standard/block/UPDATE</a></p>
+</dd>
+<dt class="hdlist1"><code>useraddr</code></dt>
+<dd>
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;addr ) "Push address of base address of user variables"</p>
+</dd>
+<dt class="hdlist1"><code>value</code></dt>
+<dd>
+<p><em>ANS core</em> ( n "name"&#8201;&#8212;&#8201;) "Define a value"
+<a href="https://forth-standard.org/standard/core/VALUE" class="bare">https://forth-standard.org/standard/core/VALUE</a>
+This is a dummy header for the WORDLIST. The actual code is
+identical to that of CONSTANT</p>
+</dd>
+<dt class="hdlist1"><code>variable</code></dt>
+<dd>
+<p><em>ANS core</em> ( "name"&#8201;&#8212;&#8201;) "Define a variable"
+<a href="https://forth-standard.org/standard/core/VARIABLE" class="bare">https://forth-standard.org/standard/core/VARIABLE</a>
+There are various Forth definitions for this word, such as
+CREATE 1 CELLS ALLOT  or  CREATE 0 ,  We use a variant of the
+second one so the variable is initialized to zero</p>
+</dd>
+<dt class="hdlist1"><code>while</code></dt>
+<dd>
+<p><em>ANS core</em> ( C: dest&#8201;&#8212;&#8201;orig dest ) ( x&#8201;&#8212;&#8201;) "Loop flow control"
+<a href="http://forth-standard.org/standard/core/WHILE" class="bare">http://forth-standard.org/standard/core/WHILE</a></p>
+</dd>
+<dt class="hdlist1"><code>within</code></dt>
+<dd>
+<p><em>ANS core ext</em> ( n1 n2 n3&#8201;&#8212;&#8201;) "See if within a range"
+<a href="https://forth-standard.org/standard/core/WITHIN" class="bare">https://forth-standard.org/standard/core/WITHIN</a>
+This an assembler version of the ANS Forth implementation
+at <a href="https://forth-standard.org/standard/core/WITHIN" class="bare">https://forth-standard.org/standard/core/WITHIN</a> which is
+OVER - &gt;R - R&gt; U&lt;  note there is an alternative high-level version
+ROT TUCK &gt; -ROT &gt; INVERT AND</p>
+</dd>
+<dt class="hdlist1"><code>word</code></dt>
+<dd>
+<p><em>ANS core</em> ( char "name "&#8201;&#8212;&#8201;caddr ) "Parse input stream"
+<a href="https://forth-standard.org/standard/core/WORD" class="bare">https://forth-standard.org/standard/core/WORD</a>
+Obsolete parsing word included for backwards compatibility only.
+Do not use this, use PARSE or PARSE-NAME. Skips leading delimiters
+and copies word to storage area for a maximum size of 255 bytes.
+Returns the result as a counted string (requires COUNT to convert
+to modern format), and inserts a space after the string. See "Forth
+Programmer&#8217;s Handbook" 3rd edition p. 159 and
+<a href="http://www.forth200x.org/documents/html/rationale.html#rat:core:PARSE" class="bare">http://www.forth200x.org/documents/html/rationale.html#rat:core:PARSE</a>
+for discussions of why you shouldn&#8217;t be using WORD anymore. Forth
+would be   PARSE DUP BUFFER1 C! OUTPUT 1+ SWAP MOVE BUFFER1
+We only allow input of 255 chars. Seriously, use PARSE-NAME.</p>
+</dd>
+<dt class="hdlist1"><code>wordlist</code></dt>
+<dd>
+<p><em>ANS search</em> (&#8201;&#8212;&#8201;wid ) "Create new wordlist (from pool of 8)"
+<a href="https://forth-standard.org/standard/search/WORDLIST" class="bare">https://forth-standard.org/standard/search/WORDLIST</a></p>
+</dd>
+<dt class="hdlist1"><code>words</code></dt>
+<dd>
+<p><em>ANS tools</em> (&#8201;&#8212;&#8201;) "Print known words from Dictionary"
+<a href="https://forth-standard.org/standard/tools/WORDS" class="bare">https://forth-standard.org/standard/tools/WORDS</a>
+This is pretty much only used at the command line so we can
+be slow and try to save space. DROP must always be the first word in a
+clean system (without Forth words), BYE the last. There is no reason
+why we couldn&#8217;t define this as a high level word except that it is
+really useful for testing</p>
+</dd>
+<dt class="hdlist1"><code>wordsize</code></dt>
+<dd>
+<p><em>Tali Forth</em> ( nt&#8201;&#8212;&#8201;u ) "Get size of word in bytes"
+Given an word&#8217;s name token (nt), return the size of the
+word&#8217;s payload size in bytes (CFA plus PFA) in bytes. Does not
+count the final RTS.</p>
+</dd>
+<dt class="hdlist1"><code>xor</code></dt>
+<dd>
+<p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;n ) "Logically XOR TOS and NOS"
+<a href="https://forth-standard.org/standard/core/XOR" class="bare">https://forth-standard.org/standard/core/XOR</a></p>
+</dd>
+</dl>
+</div>
+</div>
+</div>
+<div class="sect1">
 <h2 id="_reporting_problems">Reporting Problems</h2>
 <div class="sectionbody">
 <div class="paragraph">
@@ -6925,70 +9668,70 @@ who contributed the invaluable test suite and a whole lot of code.</p>
 <h2 id="_references_and_further_reading">References and Further Reading</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p><a id="FB"></a>[FB] <em>Masterminds of Programming</em>, Federico Biancuzzi,
+<p>[<a id="FB"></a>] <em>Masterminds of Programming</em>, Federico Biancuzzi,
 O&#8217;Reilly Media 1st edition, 2009.</p>
 </div>
 <div class="paragraph">
-<p><a id="CHM1"></a>[CHM1] "Charles H. Moore: Geek of the Week", redgate Hub 2009
+<p>[<a id="CHM1"></a>] "Charles H. Moore: Geek of the Week", redgate Hub 2009
 <a href="https://www.red-gate.com/simple-talk/opinion/geek-of-the-week/chuck-moore-geek" class="bare">https://www.red-gate.com/simple-talk/opinion/geek-of-the-week/chuck-moore-geek</a></p>
 </div>
 <div class="paragraph">
-<p><a id="CHM2"></a>[CHM2] "The Evolution of FORTH, an Unusual Language", Charles H. Moore,
+<p>[<a id="CHM2"></a>] "The Evolution of FORTH, an Unusual Language", Charles H. Moore,
 <em>Byte</em> 1980, <a href="https://wiki.forth-ev.de/doku.php/projects:the_evolution_of_forth" class="bare">https://wiki.forth-ev.de/doku.php/projects:the_evolution_of_forth</a></p>
 </div>
 <div class="paragraph">
-<p><a id="CnR"></a>[CnR] <em>Forth Programmer&#8217;s Handbook</em>, Edward K. Conklin and Elizabeth Rather,
+<p>[<a id="CnR"></a>] <em>Forth Programmer&#8217;s Handbook</em>, Edward K. Conklin and Elizabeth Rather,
 3rd edition 2010</p>
 </div>
 <div class="paragraph">
-<p><a id="DB"></a>[DB] <em>Forth Enzyclopedia</em>, Mitch Derick and Linda Baker,
+<p>[<a id="DB"></a>] <em>Forth Enzyclopedia</em>, Mitch Derick and Linda Baker,
 Mountain View Press 1982</p>
 </div>
 <div class="paragraph">
-<p><a id="DH"></a>[DH] "Some notes on Forth from a novice user", Douglas Hoffman, Feb 1988
+<p>[<a id="DH"></a>] "Some notes on Forth from a novice user", Douglas Hoffman, Feb 1988
 <a href="https://wiki.forth-ev.de/doku.php/projects:some_notes_on_forth_from_a_novice_user" class="bare">https://wiki.forth-ev.de/doku.php/projects:some_notes_on_forth_from_a_novice_user</a></p>
 </div>
 <div class="paragraph">
-<p><a id="DMR"></a>[DMR] "Reflections on Software Research", Dennis M. Ritchie, Turing Award
+<p>[<a id="DMR"></a>] "Reflections on Software Research", Dennis M. Ritchie, Turing Award
 Lecture in <em>Communications of the ACM</em> August 1984 Volume 27 Number 8
 <a href="http://www.valleytalk.org/wp-content/uploads/2011/10/p758-ritchie.pdf" class="bare">http://www.valleytalk.org/wp-content/uploads/2011/10/p758-ritchie.pdf</a></p>
 </div>
 <div class="paragraph">
-<p><a id="EnL"></a>[EnL] <em>Programming the 65816, including the 6502, 65C02 and 65802</em>,
+<p>[<a id="EnL"></a>] <em>Programming the 65816, including the 6502, 65C02 and 65802</em>,
 David Eyes and Ron Lichty
 (Currently not available from the WDC website)</p>
 </div>
 <div class="paragraph">
-<p><a id="EW"></a>[EW] "Forth: The Hacker&#8217;s Language", Elliot Williams,
+<p>[<a id="EW"></a>] "Forth: The Hacker&#8217;s Language", Elliot Williams,
 <a href="https://hackaday.com/2017/01/27/forth-the-hackers-language/" class="bare">https://hackaday.com/2017/01/27/forth-the-hackers-language/</a></p>
 </div>
 <div class="paragraph">
-<p><a id="GK"></a>[GK] "Forth System Comparisons", Guy Kelly, in <em>Forth Dimensions</em> V13N6,
+<p>[<a id="GK"></a>] "Forth System Comparisons", Guy Kelly, in <em>Forth Dimensions</em> V13N6,
 March/April 1992
 <a href="http://www.forth.org/fd/FD-V13N6.pdf}{http://www.forth.org/fd/FD-V13N6.pdf" class="bare">http://www.forth.org/fd/FD-V13N6.pdf}{http://www.forth.org/fd/FD-V13N6.pdf</a></p>
 </div>
 <div class="paragraph">
-<p><a id="JN"></a>[JN] <em>A Beginner&#8217;s Guide to Forth</em>, J.V. Nobel,
+<p>[<a id="JN"></a>] <em>A Beginner&#8217;s Guide to Forth</em>, J.V. Nobel,
 <a href="http://galileo.phys.virginia.edu/classes/551.jvn.fall01/primer.htm" class="bare">http://galileo.phys.virginia.edu/classes/551.jvn.fall01/primer.htm</a></p>
 </div>
 <div class="paragraph">
-<p><a id="BWK"></a>[BWK] <em>A Tutorial Introduction to the UNIX Text Editor</em>, B. W. Kernighan,
+<p>[<a id="BWK"></a>] <em>A Tutorial Introduction to the UNIX Text Editor</em>, B. W. Kernighan,
 <a href="http://www.psue.uni-hannover.de/wise2017_2018/material/ed.pdf" class="bare">http://www.psue.uni-hannover.de/wise2017_2018/material/ed.pdf</a></p>
 </div>
 <div class="paragraph">
-<p><a id="LB1"></a>[LB1] <em>Starting Forth</em>, Leo Brodie, new edition 2003,
+<p>[<a id="LB1"></a>] <em>Starting Forth</em>, Leo Brodie, new edition 2003,
 <a href="https://www.forth.com/starting-forth/}{https://www.forth.com/starting-forth/" class="bare">https://www.forth.com/starting-forth/}{https://www.forth.com/starting-forth/</a></p>
 </div>
 <div class="paragraph">
-<p><a id="LB2"></a>[LB2] <em>Thinking Forth</em>, Leo Brodie, 1984,
+<p>[<a id="LB2"></a>] <em>Thinking Forth</em>, Leo Brodie, 1984,
 <a href="http://thinking-forth.sourceforge.net/\#21CENTURY" class="bare">http://thinking-forth.sourceforge.net/\#21CENTURY</a></p>
 </div>
 <div class="paragraph">
-<p><a id="LL"></a>[LL] <em>6502 Assembly Language Programming</em>, Lance A. Leventhal,
+<p>[<a id="LL"></a>] <em>6502 Assembly Language Programming</em>, Lance A. Leventhal,
 OSBORNE/McGRAW-HILL 1979</p>
 </div>
 <div class="paragraph">
-<p><a id="PHS"></a>[PHS] "The Daemon, the Gnu and the Penguin", Peter H. Saulus,
+<p>[<a id="PHS"></a>] "The Daemon, the Gnu and the Penguin", Peter H. Saulus,
 22. April 2005, <a href="http://www.groklaw.net/article.php?story=20050422235450910" class="bare">http://www.groklaw.net/article.php?story=20050422235450910</a></p>
 </div>
 </div>
@@ -7029,7 +9772,7 @@ under <a href="https://www.ubuntu.com/">Ubuntu</a> Linux 16.04 LTS.</p>
 <div id="footer">
 <div id="footer-text">
 Version BETA<br>
-Last updated 2018-12-31 06:16:18 CET
+Last updated 2019-01-01 15:26:39 EST
 </div>
 </div>
 </body>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -6579,9 +6579,7 @@ order if you run it too many times.</p>
 <td class="hdlist2">
 <p><em>ANS core</em> ( ud&#8201;&#8212;&#8201;ud ) "Add character to pictured output string"
 <a href="https://forth-standard.org/standard/core/num" class="bare">https://forth-standard.org/standard/core/num</a>
-Add one char to the beginning of the pictured output string. Based
-on <a href="https://github.com/philburk/pforth/blob/master/fth/numberio.fth" class="bare">https://github.com/philburk/pforth/blob/master/fth/numberio.fth</a>
-Forth code  BASE @ UD/MOD ROT 9 OVER &lt; IF 7 + THEN [CHAR] 0 + HOLD</p>
+Add one char to the beginning of the pictured output string.</p>
 </td>
 </tr>
 <tr>
@@ -6592,9 +6590,7 @@ Forth code  BASE @ UD/MOD ROT 9 OVER &lt; IF 7 + THEN [CHAR] 0 + HOLD</p>
 <p><em>ANS core</em> ( d&#8201;&#8212;&#8201;addr u ) "Finish pictured number conversion"
 <a href="https://forth-standard.org/standard/core/num-end" class="bare">https://forth-standard.org/standard/core/num-end</a>
 Finish conversion of pictured number string, putting address and
-length on the Data Stack. Original Fort is  2DROP HLD @ PAD OVER -
-Based on
-<a href="https://github.com/philburk/pforth/blob/master/fth/numberio.fth" class="bare">https://github.com/philburk/pforth/blob/master/fth/numberio.fth</a></p>
+length on the Data Stack.</p>
 </td>
 </tr>
 <tr>
@@ -6604,9 +6600,7 @@ Based on
 <td class="hdlist2">
 <p><em>ANS core</em> ( d&#8201;&#8212;&#8201;addr u ) "Completely convert pictured output"
 <a href="https://forth-standard.org/standard/core/numS" class="bare">https://forth-standard.org/standard/core/numS</a>
-Completely convert number for pictured numerical output. Based on
-<a href="https://github.com/philburk/pforth/blob/master/fth/system.fth" class="bare">https://github.com/philburk/pforth/blob/master/fth/system.fth</a>
-Original Forth code  BEGIN # 2DUP OR 0= UNTIL</p>
+Completely convert number for pictured numerical output.</p>
 </td>
 </tr>
 <tr>
@@ -6634,8 +6628,7 @@ Original Forth code  BEGIN # 2DUP OR 0= UNTIL</p>
 <td class="hdlist2">
 <p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;n ) "16*16 -&#8594; 16 "
 <a href="https://forth-standard.org/standard/core/Times" class="bare">https://forth-standard.org/standard/core/Times</a>
-Multiply two signed 16 bit numbers, returning a 16 bit result.
-This is nothing  more than UM* DROP</p>
+Multiply two signed 16 bit numbers, returning a 16 bit result.</p>
 </td>
 </tr>
 <tr>
@@ -6646,9 +6639,7 @@ This is nothing  more than UM* DROP</p>
 <p><em>ANS core</em> ( n1 n2 n3&#8201;&#8212;&#8201;n4 ) "n1 * n2 / n3 -&#8594;  n"
 <a href="https://forth-standard.org/standard/core/TimesDiv" class="bare">https://forth-standard.org/standard/core/TimesDiv</a>
 Multiply n1 by n2 and divide by n3, returning the result
-without a remainder. This is */MOD without the mod, and
-can be defined in Fort as : */  */MOD SWAP DROP ; which is
-pretty much what we do here</p>
+without a remainder. This is */MOD without the mod.</p>
 </td>
 </tr>
 <tr>
@@ -6663,8 +6654,7 @@ Multiply n1 by n2 producing the intermediate double-cell result</p>
 <ol class="loweralpha" type="a">
 <li>
 <p>Divide d by n3 producing the single-cell remainder n4 and the
-single-cell quotient n5. In Forth, this is
-: <strong>/MOD  &gt;R M</strong> &gt;R SM/REM ;  Note that */ accesses this routine.</p>
+single-cell quotient n5.</p>
 </li>
 </ol>
 </div>
@@ -6694,14 +6684,7 @@ single-cell quotient n5. In Forth, this is
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Finish loop construct"
-<a href="https://forth-standard.org/standard/core/PlusLOOP" class="bare">https://forth-standard.org/standard/core/PlusLOOP</a>
-Compile-time part of +LOOP, also used for LOOP. Is usually
-: +LOOP POSTPONE (+LOOP) , POSTPONE UNLOOP ; IMMEDIATE
-COMPILE-ONLY
-in Forth. LOOP uses this routine as well. We jump here with the
-address for looping as TOS and the address for aborting the loop
-(LEAVE) as the second double-byte entry on the Return Stack (see
-DO and docs/loops.txt for details).</p>
+<a href="https://forth-standard.org/standard/core/PlusLOOP" class="bare">https://forth-standard.org/standard/core/PlusLOOP</a></p>
 </td>
 </tr>
 <tr>
@@ -6711,8 +6694,7 @@ DO and docs/loops.txt for details).</p>
 <td class="hdlist2">
 <p><em>ANS core</em> ( n&#8201;&#8212;&#8201;) "Allot and store one cell in memory"
 <a href="https://forth-standard.org/standard/core/Comma" class="bare">https://forth-standard.org/standard/core/Comma</a>
-Store TOS at current place in memory. Since this an eight-bit
-machine, we can ignore all alignment issures.</p>
+Store TOS at current place in memory.</p>
 </td>
 </tr>
 <tr>
@@ -6789,9 +6771,7 @@ uses it for everything. We follow the book here, and recommend
 </td>
 <td class="hdlist2">
 <p><em>ANS core ext</em> ( n u&#8201;&#8212;&#8201;) "Print NOS as unsigned number with TOS with"
-<a href="https://forth-standard.org/standard/core/DotR" class="bare">https://forth-standard.org/standard/core/DotR</a>
-Based on the Forth code
-: .R  &gt;R DUP ABS 0 &lt;# #S ROT SIGN #&gt; R&gt; OVER - SPACES TYPE</p>
+<a href="https://forth-standard.org/standard/core/DotR" class="bare">https://forth-standard.org/standard/core/DotR</a></p>
 </td>
 </tr>
 <tr>
@@ -6801,8 +6781,7 @@ Based on the Forth code
 <td class="hdlist2">
 <p>_ANS tools _ (&#8201;&#8212;&#8201;) "Print content of Data Stack"
 <a href="https://forth-standard.org/standard/tools/DotS" class="bare">https://forth-standard.org/standard/tools/DotS</a>
-Print content of Data Stack non-distructively. Since this is for
-humans, we don&#8217;t have to worry about speed. We follow the format
+Print content of Data Stack non-distructively. We follow the format
 of Gforth and print the number of elements first in brackets,
 followed by the Data Stack content (if any).</p>
 </td>
@@ -6813,11 +6792,7 @@ followed by the Data Stack content (if any).</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> ( n1 n2&#8201;&#8212;&#8201;n ) "Divide NOS by TOS"
-<a href="https://forth-standard.org/standard/core/Div" class="bare">https://forth-standard.org/standard/core/Div</a>
-Forth code is either  &gt;R S&gt;D R&gt; FM/MOD SWAP DROP
-or &gt;R S&gt;D R&gt; SM/REM SWAP DROP&#8201;&#8212;&#8201;we use SM/REM in Tali Forth.
-This code is currently unoptimized. This code without the SLASH
-DROP at the end is /MOD, so we share the code as far as possible.</p>
+<a href="https://forth-standard.org/standard/core/Div" class="bare">https://forth-standard.org/standard/core/Div</a></p>
 </td>
 </tr>
 <tr>
@@ -6826,8 +6801,7 @@ DROP at the end is /MOD, so we share the code as far as possible.</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> ( n1 n2&#8201;&#8212;&#8201;n3 n4 ) "Divide NOS by TOS with a remainder"
-<a href="https://forth-standard.org/standard/core/DivMOD" class="bare">https://forth-standard.org/standard/core/DivMOD</a>
-This is a dummy entry, the actual code is shared with SLASH</p>
+<a href="https://forth-standard.org/standard/core/DivMOD" class="bare">https://forth-standard.org/standard/core/DivMOD</a></p>
 </td>
 </tr>
 <tr>
@@ -6836,11 +6810,7 @@ This is a dummy entry, the actual code is shared with SLASH</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS string</em> ( addr u n&#8201;&#8212;&#8201;addr u ) "Shorten string by n"
-<a href="https://forth-standard.org/standard/string/DivSTRING" class="bare">https://forth-standard.org/standard/string/DivSTRING</a>
-Forth code is
-: /STRING ( ADDR U N&#8201;&#8212;&#8201;ADDR U ) ROT OVER + ROT ROT -
-Put differently, we need to add TOS and 3OS, and subtract
-TOS from NOS, and then drop TOS</p>
+<a href="https://forth-standard.org/standard/string/DivSTRING" class="bare">https://forth-standard.org/standard/string/DivSTRING</a></p>
 </td>
 </tr>
 <tr>
@@ -6848,10 +6818,7 @@ TOS from NOS, and then drop TOS</p>
 <code>0</code>
 </td>
 <td class="hdlist2">
-<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;0 ) "Push 0 to Data Stack"
-; """The disassembler assumes that this routine does not use Y. Note
-that CASE and FORTH-WORDLIST use the same routine, as the WD for Forth
-is 0.</p>
+<p><em>Tali Forth</em> (&#8201;&#8212;&#8201;0 ) "Push 0 to Data Stack"</p>
 </td>
 </tr>
 <tr>
@@ -6905,8 +6872,7 @@ This is also the code for EDITOR-WORDLIST</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> ( u&#8201;&#8212;&#8201;u+1 ) "Increase TOS by one"
-<a href="https://forth-standard.org/standard/core/OnePlus" class="bare">https://forth-standard.org/standard/core/OnePlus</a>
-Code is shared with CHAR-PLUS</p>
+<a href="https://forth-standard.org/standard/core/OnePlus" class="bare">https://forth-standard.org/standard/core/OnePlus</a></p>
 </td>
 </tr>
 <tr>
@@ -6964,10 +6930,7 @@ Also used for CELLS</p>
 <td class="hdlist2">
 <p><em>ANS core ext</em> ( n1 n2&#8201;&#8212;&#8201;)(R:&#8201;&#8212;&#8201;n1 n2 "Push top two entries to Return Stack"
 <a href="https://forth-standard.org/standard/core/TwotoR" class="bare">https://forth-standard.org/standard/core/TwotoR</a>
-Push top two entries to Return Stack. The same as SWAP &gt;R &gt;R
-except that if we jumped here, the return address will be in the
-way. May not be natively compiled unless we&#8217;re clever and use
-special routines.</p>
+Push top two entries to Return Stack.</p>
 </td>
 </tr>
 <tr>
@@ -6987,9 +6950,7 @@ the next byte. This is equvalent to  DUP CELL+ @ SWAP @</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS double</em> (C: d "name"&#8201;&#8212;&#8201;) (&#8201;&#8212;&#8201;d) "Create a constant for a double word"
-<a href="https://forth-standard.org/standard/double/TwoCONSTANT" class="bare">https://forth-standard.org/standard/double/TwoCONSTANT</a>
-Based on the Forth code
-: 2CONSTANT ( D&#8201;&#8212;&#8201;)  CREATE SWAP , , DOES&gt; DUP @ SWAP CELL+ @</p>
+<a href="https://forth-standard.org/standard/double/TwoCONSTANT" class="bare">https://forth-standard.org/standard/double/TwoCONSTANT</a></p>
 </td>
 </tr>
 <tr>
@@ -7037,11 +6998,7 @@ Based on the Forth code
 <td class="hdlist2">
 <p><em>ANS core ext</em> (&#8201;&#8212;&#8201;n1 n2 ) (R: n1 n2&#8201;&#8212;&#8201;) "Pull two cells from Return Stack"
 <a href="https://forth-standard.org/standard/core/TwoRfrom" class="bare">https://forth-standard.org/standard/core/TwoRfrom</a>
-Pull top two entries from Return Stack. Is the same as
-R&gt; R&gt; SWAP. As with R&gt;, the problem with the is word is that
-the top value on the ReturnStack for a STC Forth is the
-return address, which we need to get out of the way first.
-Native compile needs to be handled as a special case.</p>
+Pull top two entries from Return Stack.</p>
 </td>
 </tr>
 <tr>
@@ -7050,13 +7007,7 @@ Native compile needs to be handled as a special case.</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core ext</em> (&#8201;&#8212;&#8201;n n ) "Copy top two entries from Return Stack"
-<a href="https://forth-standard.org/standard/core/TwoRFetch" class="bare">https://forth-standard.org/standard/core/TwoRFetch</a>
-This is R&gt; R&gt; 2DUP &gt;R &gt;R SWAP but we can do it a lot faster in
-assembler. We use trickery to access the elements on the Return
-Stack instead of pulling the return address first and storing
-it somewhere else like for 2R&gt; and 2&gt;R. In this version, we leave
-it as Never Native; at some point, we should compare versions to
-see if an Always Native version would be better</p>
+<a href="https://forth-standard.org/standard/core/TwoRFetch" class="bare">https://forth-standard.org/standard/core/TwoRFetch</a></p>
 </td>
 </tr>
 <tr>
@@ -7075,10 +7026,7 @@ see if an Always Native version would be better</p>
 <td class="hdlist2">
 <p><em>ANS double</em> ( "name"&#8201;&#8212;&#8201;) "Create a variable for a double word"
 <a href="https://forth-standard.org/standard/double/TwoVARIABLE" class="bare">https://forth-standard.org/standard/double/TwoVARIABLE</a>
-This can be realized in Forth as either
-CREATE 2 CELLS ALLOT  or just  CREATE 0 , 0 ,
-Note that in this case, the variable is not initialized to
-zero</p>
+The variable is not initialized to zero.</p>
 </td>
 </tr>
 <tr>
@@ -7087,8 +7035,7 @@ zero</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> ( "name"&#8201;&#8212;&#8201;) "Start compilation of a new word"
-<a href="https://forth-standard.org/standard/core/Colon" class="bare">https://forth-standard.org/standard/core/Colon</a>
-Use the CREATE routine and fill in the rest by hand.</p>
+<a href="https://forth-standard.org/standard/core/Colon" class="bare">https://forth-standard.org/standard/core/Colon</a></p>
 </td>
 </tr>
 <tr>
@@ -7108,12 +7055,7 @@ Compile a word with no nt.  ";" will put its xt on the stack.</p>
 <td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;) "End compilation of new word"
 <a href="https://forth-standard.org/standard/core/Semi" class="bare">https://forth-standard.org/standard/core/Semi</a>
-End the compilation of a new word into the Dictionary. When we
-enter this, WORKWORD is pointing to the nt_ of this word in the
-Dictionary, DP to the previous word, and CP to the next free byte.
-A Forth definition would be (see "Starting Forth"):
-: POSTPONE EXIT  REVEAL POSTPONE ; [ ; IMMEDIATE  Following the
-practice of Gforth, we warn here if a word has been redefined.</p>
+End the compilation of a new word into the Dictionary.</p>
 </td>
 </tr>
 <tr>
@@ -7132,17 +7074,7 @@ practice of Gforth, we warn here if a word has been redefined.</p>
 <td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Start number conversion"
 <a href="https://forth-standard.org/standard/core/num-start" class="bare">https://forth-standard.org/standard/core/num-start</a>
-Start the process to create pictured numeric output. The new
-string is constructed from back to front, saving the new character
-at the beginning of the output string. Since we use PAD as a
-starting address and work backward (!), the string is constructed
-in the space between the end of the Dictionary (as defined by CP)
-and the PAD. This allows us to satisfy the ANS Forth condition that
-programs don&#8217;t fool around with the PAD but still use its address.
-Based on pForth
-<a href="http://pforth.googlecode.com/svn/trunk/fth/numberio.fth" class="bare">http://pforth.googlecode.com/svn/trunk/fth/numberio.fth</a>
-pForth is in the pubic domain. Forth is : &lt;# PAD HLD ! ; we use the
-internal variable tohold instead of HLD.</p>
+Start the process to create pictured numeric output.</p>
 </td>
 </tr>
 <tr>
@@ -7151,9 +7083,7 @@ internal variable tohold instead of HLD.</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core ext</em> ( n m&#8201;&#8212;&#8201;f ) "Return a true flag if TOS != NOS"
-<a href="https://forth-standard.org/standard/core/ne" class="bare">https://forth-standard.org/standard/core/ne</a>
-This is just a variant of EQUAL, we code it separately
-for speed.</p>
+<a href="https://forth-standard.org/standard/core/ne" class="bare">https://forth-standard.org/standard/core/ne</a></p>
 </td>
 </tr>
 <tr>
@@ -7183,11 +7113,7 @@ for speed.</p>
 <a href="https://forth-standard.org/standard/core/toBODY" class="bare">https://forth-standard.org/standard/core/toBODY</a>
 Given a word&#8217;s execution token (xt), return the address of the
 start of that word&#8217;s parameter field (PFA). This is defined as the
-address that HERE would return right after CREATE. This is a
-difficult word for STC Forths, because most words don&#8217;t actually
-have a Code Field Area (CFA) to skip. We solve this by having CREATE
-add a flag, "has CFA" (HC), in the header so &gt;BODY know to skip
-the subroutine jumps to DOVAR, DOCONST, or DODOES</p>
+address that HERE would return right after CREATE.</p>
 </td>
 </tr>
 <tr>
@@ -7242,9 +7168,7 @@ word.</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS tools</em> ( addr&#8201;&#8212;&#8201;) "Print content of a variable"
-<a href="https://forth-standard.org/standard/tools/q" class="bare">https://forth-standard.org/standard/tools/q</a>
-Only used interactively. Since humans are so slow, we
-save size and just go for the subroutine jumps</p>
+<a href="https://forth-standard.org/standard/tools/q" class="bare">https://forth-standard.org/standard/tools/q</a></p>
 </td>
 </tr>
 <tr>
@@ -7301,9 +7225,7 @@ This is an immediate and compile-only word</p>
 <p><em>ANS core</em> ( "c"&#8201;&#8212;&#8201;) "Compile character"
 <a href="https://forth-standard.org/standard/core/BracketCHAR" class="bare">https://forth-standard.org/standard/core/BracketCHAR</a>
 Compile the ASCII value of a character as a literal. This is an
-immediate, compile-only word. A definition given in
-<a href="http://forth-standard.org/standard/implement" class="bare">http://forth-standard.org/standard/implement</a> is
-: [CHAR]  CHAR POSTPONE LITERAL ; IMMEDIATE</p>
+immediate, compile-only word.</p>
 </td>
 </tr>
 <tr>
@@ -7396,10 +7318,16 @@ modern Forths.</p>
 <td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Make sure CP is aligned on word size"
 <a href="https://forth-standard.org/standard/core/ALIGN" class="bare">https://forth-standard.org/standard/core/ALIGN</a>
-On a 8-bit machine, this does nothing. ALIGNED uses
-this routine as well, and also does nothing
-<mark> ALIGNED ( addr&#8201;&#8212;&#8201;addr ) "Return the first aligned address
-</mark> "aligned"  auto  ANS core</p>
+On a 8-bit machine, this does nothing.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>aligned</code>
+</td>
+<td class="hdlist2">
+<p><em>ANS core</em> ( addr&#8201;&#8212;&#8201;addr ) "Return the first aligned address"
+<a href="https://forth-standard.org/standard/core/ALIGNED" class="bare">https://forth-standard.org/standard/core/ALIGNED</a></p>
 </td>
 </tr>
 <tr>
@@ -7467,8 +7395,7 @@ This is a dummy entry, the code is shared with TWO</p>
 <p><em>ANS facility</em> ( n m&#8201;&#8212;&#8201;) "Move cursor to position given"
 <a href="https://forth-standard.org/standard/facility/AT-XY" class="bare">https://forth-standard.org/standard/facility/AT-XY</a>
 On an ANS compatible terminal, place cursor at row n colum m.
-Code is ESC[&lt;n&gt;;&lt;m&gt;H Do not use U. to print the numbers because the
-trailing space will not work with xterm</p>
+Code is ESC[&lt;n&gt;;&lt;m&gt;H</p>
 </td>
 </tr>
 <tr>
@@ -7486,12 +7413,7 @@ trailing space will not work with xterm</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;addr ) "Mark entry point for loop"
-<a href="https://forth-standard.org/standard/core/BEGIN" class="bare">https://forth-standard.org/standard/core/BEGIN</a>
-This is just an immediate version of here which could just
-as well be coded in Forth as
-: BEGIN HERE ; IMMEDIATE COMPILE-ONLY
-Since this is a compiling word, we don&#8217;t care that much about
-about speed</p>
+<a href="https://forth-standard.org/standard/core/BEGIN" class="bare">https://forth-standard.org/standard/core/BEGIN</a></p>
 </td>
 </tr>
 <tr>
@@ -7547,7 +7469,7 @@ about speed</p>
 Create a RAM drive, with the given number of
 blocks, in the dictionary along with setting up the block words to
 use it.  The read/write routines do not provide bounds checking.
-Expected use: 4 block-ramdrive-init ( to create blocks 0-3 )</p>
+Expected use: <code>4 block-ramdrive-init</code> ( to create blocks 0-3 )</p>
 </td>
 </tr>
 <tr>
@@ -7602,7 +7524,7 @@ This word gives the address of the vector so it can be replaced.</p>
 <p><em>Gforth</em> ( addr u&#8201;&#8212;&#8201;addr+u addr ) "Prepare address for looping"
 <a href="http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Memory-Blocks.html" class="bare">http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Memory-Blocks.html</a>
 Given a string, return the correct Data Stack parameters for
-a DO/LOOP loop; over its characters. This is realized as
+a DO/LOOP loop over its characters. This is realized as
 OVER + SWAP in Forth, but we do it a lot faster in assembler</p>
 </td>
 </tr>
@@ -7684,8 +7606,7 @@ when its name is used.</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core ext</em> (C:&#8201;&#8212;&#8201;0) (&#8201;&#8212;&#8201;) "Conditional flow control"
-<a href="http://forth-standard.org/standard/core/CASE" class="bare">http://forth-standard.org/standard/core/CASE</a>
-This is a dummy header, CASE shares the actual code with ZERO.</p>
+<a href="http://forth-standard.org/standard/core/CASE" class="bare">http://forth-standard.org/standard/core/CASE</a></p>
 </td>
 </tr>
 <tr>
@@ -7705,9 +7626,7 @@ Since this is an 8 bit machine with 16 bit cells, we add two bytes.</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> ( u&#8201;&#8212;&#8201;u ) "Convert cells to size in bytes"
-<a href="https://forth-standard.org/standard/core/CELLS" class="bare">https://forth-standard.org/standard/core/CELLS</a>
-Dummy entry for the CELLS word, the code is the same as for
-2*, which is where the header directs us to</p>
+<a href="https://forth-standard.org/standard/core/CELLS" class="bare">https://forth-standard.org/standard/core/CELLS</a></p>
 </td>
 </tr>
 <tr>
@@ -7725,8 +7644,7 @@ Dummy entry for the CELLS word, the code is the same as for
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> ( addr&#8201;&#8212;&#8201;addr+1 ) "Add the size of a character unit to address"
-<a href="https://forth-standard.org/standard/core/CHARPlus" class="bare">https://forth-standard.org/standard/core/CHARPlus</a>
-This is a dummy entry, the code is shared with ONE_PLUS</p>
+<a href="https://forth-standard.org/standard/core/CHARPlus" class="bare">https://forth-standard.org/standard/core/CHARPlus</a></p>
 </td>
 </tr>
 <tr>
@@ -7759,7 +7677,7 @@ compatibility with other Forth versions</p>
 Copy u bytes from addr1 to addr2, going low to high (addr2 is
 larger than addr1). Based on code in Leventhal, Lance A.
 6502 Assembly Language Routines", p. 201, where it is called
-move left". There are no official tests for this word.</p>
+move left".</p>
 </td>
 </tr>
 <tr>
@@ -7770,8 +7688,7 @@ move left". There are no official tests for this word.</p>
 <p><em>ANS string</em> ( add1 add2 u&#8201;&#8212;&#8201;) "Copy bytes from high to low"
 <a href="https://forth-standard.org/standard/string/CMOVEtop" class="bare">https://forth-standard.org/standard/string/CMOVEtop</a>
 Based on code in Leventhal, Lance A. "6502 Assembly Language
-Routines", p. 201, where it is called "move right". There are
-no official tests for this word.</p>
+Routines", p. 201, where it is called "move right".</p>
 </td>
 </tr>
 <tr>
@@ -7823,8 +7740,7 @@ Native) flag is set, the word is always natively compiled</p>
 <td class="hdlist2">
 <p><em>Tali Forth</em> (&#8201;&#8212;&#8201;) "Mark most recent word as COMPILE-ONLY"
 Set the Compile Only flag (CO) of the most recently defined
-word. The alternative way to do this is to define a word
-?COMPILE that makes sure  we&#8217;re in compile mode</p>
+word.</p>
 </td>
 </tr>
 <tr>
@@ -7833,12 +7749,7 @@ word. The alternative way to do this is to define a word
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> ( n "name"&#8201;&#8212;&#8201;) "Define a constant"
-<a href="https://forth-standard.org/standard/core/CONSTANT" class="bare">https://forth-standard.org/standard/core/CONSTANT</a>
-Forth equivalent is  CREATE , DOES&gt; @  but we do
-more in assembler and let CREATE do the heavy lifting.
-See <a href="http://www.bradrodriguez.com/papers/moving3.htm" class="bare">http://www.bradrodriguez.com/papers/moving3.htm</a> for
-a primer on how this works in various Forths. This is the
-same code as VALUE in our case.</p>
+<a href="https://forth-standard.org/standard/core/CONSTANT" class="bare">https://forth-standard.org/standard/core/CONSTANT</a></p>
 </td>
 </tr>
 <tr>
@@ -7849,7 +7760,7 @@ same code as VALUE in our case.</p>
 <p><em>ANS core</em> ( c-addr&#8201;&#8212;&#8201;addr u ) "Convert character string to normal format"
 <a href="https://forth-standard.org/standard/core/COUNT" class="bare">https://forth-standard.org/standard/core/COUNT</a>
 Convert old-style character string to address-length pair. Note
-that the length of the string c-addr ist stored in character length
+that the length of the string c-addr is stored in character length
 (8 bit), not cell length (16 bit). This is rarely used these days,
 though COUNT can also be used to step through a string character by
 character.</p>
@@ -7870,8 +7781,7 @@ character.</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> ( "name"&#8201;&#8212;&#8201;) "Create Dictionary entry for 'name'"
-<a href="https://forth-standard.org/standard/core/CREATE" class="bare">https://forth-standard.org/standard/core/CREATE</a>
-See the drawing in headers.asm for details on the header</p>
+<a href="https://forth-standard.org/standard/core/CREATE" class="bare">https://forth-standard.org/standard/core/CREATE</a></p>
 </td>
 </tr>
 <tr>
@@ -7898,9 +7808,7 @@ See the drawing in headers.asm for details on the header</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS double</em> ( d&#8201;&#8212;&#8201;) "Print double"
-<a href="http://forth-standard.org/standard/double/Dd" class="bare">http://forth-standard.org/standard/double/Dd</a>
-From the Forth code:
-: D. TUCK DABS &lt;# #S ROT SIGN #&gt; TYPE SPACE</p>
+<a href="http://forth-standard.org/standard/double/Dd" class="bare">http://forth-standard.org/standard/double/Dd</a></p>
 </td>
 </tr>
 <tr>
@@ -7948,10 +7856,7 @@ separate so we can test for underflow</p>
 <td class="hdlist2">
 <p><em>ANS core ext</em> ( "name"&#8201;&#8212;&#8201;) "Create a placeholder for words by name"
 <a href="https://forth-standard.org/standard/core/DEFER" class="bare">https://forth-standard.org/standard/core/DEFER</a>
-Reserve an name that can be linked to various xt by IS. The
-ANS reference implementation is
-CREATE ['] ABORT , DOES&gt; @ EXECUTE
-But we use this routine as a low-level word so things go faster</p>
+Reserve an name that can be linked to various xt by IS.</p>
 </td>
 </tr>
 <tr>
@@ -8030,14 +7935,7 @@ code, see the file disassembler.asm</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> ( limit start&#8201;&#8212;&#8201;)(R:&#8201;&#8212;&#8201;limit start)  "Start a loop"
-<a href="https://forth-standard.org/standard/core/DO" class="bare">https://forth-standard.org/standard/core/DO</a>
-Compile-time part of DO. Could be realized in Forth as
-: DO POSTPONE (DO) HERE ; IMMEDIATE COMPILE-ONLY
-but we do it in assembler for speed. To work with LEAVE, we compile
-a routine that pushes the end address to the Return Stack at run
-time. This is based on a suggestion by Garth Wilson, see
-docs/loops.txt for details. This may not be native compile. Don&#8217;t
-check for a stack underflow</p>
+<a href="https://forth-standard.org/standard/core/DO" class="bare">https://forth-standard.org/standard/core/DO</a></p>
 </td>
 </tr>
 <tr>
@@ -8050,7 +7948,7 @@ check for a stack underflow</p>
 Create the payload for defining new defining words. See
 <a href="http://www.bradrodriguez.com/papers/moving3.htm" class="bare">http://www.bradrodriguez.com/papers/moving3.htm</a> and
 docs/create-does.txt for a discussion of
-DOES&gt;'s internal workings. This uses tmp1 and tmp2</p>
+DOES&gt;'s internal workings.</p>
 </td>
 </tr>
 <tr>
@@ -8068,11 +7966,7 @@ DOES&gt;'s internal workings. This uses tmp1 and tmp2</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS tools</em> ( addr u&#8201;&#8212;&#8201;) "Display a memory region"
-<a href="https://forth-standard.org/standard/tools/DUMP" class="bare">https://forth-standard.org/standard/tools/DUMP</a>
-DUMP&#8217;s exact output is defined as "implementation dependent".
-This is in assembler because it is
-useful for testing and development, so we want to have it work
-as soon as possible. Uses TMP2</p>
+<a href="https://forth-standard.org/standard/tools/DUMP" class="bare">https://forth-standard.org/standard/tools/DUMP</a></p>
 </td>
 </tr>
 <tr>
@@ -8091,7 +7985,7 @@ as soon as possible. Uses TMP2</p>
 <td class="hdlist2">
 <p><em>Tali Forth</em> (&#8201;&#8212;&#8201;u ) "Line-based editor"
 Start the line-based editor ed6502. See separate file
-for details.</p>
+ed.asm or the manual for details.</p>
 </td>
 </tr>
 <tr>
@@ -8099,8 +7993,7 @@ for details.</p>
 <code>editor-wordlist</code>
 </td>
 <td class="hdlist2">
-<p><em>Tali Editor</em> (&#8201;&#8212;&#8201;u ) "WID for the Editor wordlist"
-This is a dummy entry, the code is shared with ONE</p>
+<p><em>Tali Editor</em> (&#8201;&#8212;&#8201;u ) "WID for the Editor wordlist"</p>
 </td>
 </tr>
 <tr>
@@ -8117,8 +8010,7 @@ This is a dummy entry, the code is shared with ONE</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> (C: orig&#8201;&#8212;&#8201;orig) (&#8201;&#8212;&#8201;) "Conditional flow control"
-<a href="http://forth-standard.org/standard/core/ELSE" class="bare">http://forth-standard.org/standard/core/ELSE</a>
-The code is shared with ENDOF</p>
+<a href="http://forth-standard.org/standard/core/ELSE" class="bare">http://forth-standard.org/standard/core/ELSE</a></p>
 </td>
 </tr>
 <tr>
@@ -8131,7 +8023,7 @@ The code is shared with ENDOF</p>
 Run-time default for EMIT. The user can revector this by changing
 the value of the OUTPUT variable. We ignore the MSB completely, and
 do not check to see if we have been given a valid ASCII character.
-Don&#8217;t make this native compile</p>
+Don&#8217;t make this native compile.</p>
 </td>
 </tr>
 <tr>
@@ -8231,9 +8123,7 @@ accept more than 255 characters here, even though it&#8217;s a pain in
 <a href="https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/The-Input-Stream.html" class="bare">https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/The-Input-Stream.html</a>
 Execute the parsing word defined by the execution token (xt) on the
 string as if it were passed on the command line. See the file
-tests/tali.fs for examples. Note that this word is coded completely
-different in its Gforth version, see the file execute-parsing.fs
-(in /usr/share/gforth/0.7.3/compat/ on Ubuntu 18.04 LTS) for details.</p>
+tests/tali.fs for examples.</p>
 </td>
 </tr>
 <tr>
@@ -8245,7 +8135,7 @@ different in its Gforth version, see the file execute-parsing.fs
 <a href="https://forth-standard.org/standard/core/EXIT" class="bare">https://forth-standard.org/standard/core/EXIT</a>
 If we&#8217;re in a loop, we need to UNLOOP first and get everything
 we we might have put on the Return Stack off as well. This should
-be natively compiled</p>
+be natively compiled.</p>
 </td>
 </tr>
 <tr>
@@ -8311,12 +8201,6 @@ FIND-NAME, we get this all over with as quickly as possible. See
 <td class="hdlist2">
 <p><em>ANS core</em> ( d n1 &#8201;&#8212;&#8201;rem n2 ) "Floored signed division"
 <a href="https://forth-standard.org/standard/core/FMDivMOD" class="bare">https://forth-standard.org/standard/core/FMDivMOD</a>
-There are various ways to realize this. We follow EForth with
-DUP 0&lt; DUP &gt;R  IF NEGATE &gt;R DNEGATE R&gt; THEN &gt;R DUP
-0&lt;  IF R@ + THEN  R&gt; UM/MOD R&gt; IF SWAP NEGATE SWAP THEN
-See (<a href="http://www.forth.org/eforth.html" class="bare">http://www.forth.org/eforth.html</a>). However you can also
-go FM/MOD via SM/REM (<a href="http://www.figuk.plus.com/build/arith.htm" class="bare">http://www.figuk.plus.com/build/arith.htm</a>):
-DUP &gt;R  SM/REM DUP 0&lt; IF SWAP R&gt; + SWAP 1+ ELSE  R&gt; DROP THEN
 Note that by default, Tali Forth uses SM/REM for most things.</p>
 </td>
 </tr>
@@ -8398,9 +8282,7 @@ string produces a zero output.</p>
 <a href="https://forth-standard.org/standard/core/HOLD" class="bare">https://forth-standard.org/standard/core/HOLD</a>
 Insert a character at the current position of a pictured numeric
 output string on
-<a href="https://github.com/philburk/pforth/blob/master/fth/numberio.fth" class="bare">https://github.com/philburk/pforth/blob/master/fth/numberio.fth</a>
-Forth code is : HOLD  -1 HLD +!  HLD @ C! ;  We use the the internal
-variable tohold instead of HLD.</p>
+<a href="https://github.com/philburk/pforth/blob/master/fth/numberio.fth" class="bare">https://github.com/philburk/pforth/blob/master/fth/numberio.fth</a></p>
 </td>
 </tr>
 <tr>
@@ -8411,8 +8293,7 @@ variable tohold instead of HLD.</p>
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;n )(R: n&#8201;&#8212;&#8201;n)  "Copy loop counter to stack"
 <a href="https://forth-standard.org/standard/core/I" class="bare">https://forth-standard.org/standard/core/I</a>
 Note that this is not the same as R@ because we use a fudge
-factor for loop control; see docs/loop.txt for details. We
-should make this native compile for speed.</p>
+factor for loop control; see docs/loop.txt for details.</p>
 </td>
 </tr>
 <tr>
@@ -8452,8 +8333,7 @@ error message.</p>
 <td class="hdlist2">
 <p><em>Tali Forth</em> (&#8201;&#8212;&#8201;) ( R:&#8201;&#8212;&#8201;n n n n ) "Save input state to the Return Stack"
 Save the current input state as defined by insrc, cib, ciblen, and
-toin to the Return Stack. Used by EVALUTE. The naive way of doing
-this is to push each two-byte variable to the stack in the form of</p>
+toin to the Return Stack. Used by EVALUTE.</p>
 </td>
 </tr>
 <tr>
@@ -8544,10 +8424,7 @@ The Gforth version of this word is called LATEST</p>
 <a href="https://forth-standard.org/standard/core/LEAVE" class="bare">https://forth-standard.org/standard/core/LEAVE</a>
 Note that this does not work with  anything but a DO/LOOP in
 contrast to other versions such as discussed at
-<a href="http://blogs.msdn.com/b/ashleyf/archive/2011/02/06/loopty-do-i-loop.aspx" class="bare">http://blogs.msdn.com/b/ashleyf/archive/2011/02/06/loopty-do-i-loop.aspx</a>
-: LEAVE POSTPONE BRANCH HERE SWAP 0 , ; IMMEDIATE COMPILE-ONLY
-See docs/loops.txt on details of how this works. This must be native
-compile and not IMMEDIATE</p>
+<a href="http://blogs.msdn.com/b/ashleyf/archive/2011/02/06/loopty-do-i-loop.aspx" class="bare">http://blogs.msdn.com/b/ashleyf/archive/2011/02/06/loopty-do-i-loop.aspx</a></p>
 </td>
 </tr>
 <tr>
@@ -8577,8 +8454,7 @@ compile and not IMMEDIATE</p>
 <a href="https://forth-standard.org/standard/core/LITERAL" class="bare">https://forth-standard.org/standard/core/LITERAL</a>
 Compile-only word to store TOS so that it is pushed on stack
 during runtime. This is a immediate, compile-only word. At runtime,
-it works by calling literal_runtime by compling JSR LITERAL_RT.
-Note the cmpl_ routines use TMPTOS</p>
+it works by calling literal_runtime by compling JSR LITERAL_RT.</p>
 </td>
 </tr>
 <tr>
@@ -8587,11 +8463,7 @@ Note the cmpl_ routines use TMPTOS</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS block</em> ( scr#&#8201;&#8212;&#8201;) "Load the Forth code in a screen/block"
-<a href="https://forth-standard.org/standard/block/LOAD" class="bare">https://forth-standard.org/standard/block/LOAD</a>
-Note: LOAD current works because there is only one buffer.
-if/when multiple buffers are supported, we&#8217;ll have to deal
-with the fact that it might re-load the old block into a
-different buffer.</p>
+<a href="https://forth-standard.org/standard/block/LOAD" class="bare">https://forth-standard.org/standard/block/LOAD</a></p>
 </td>
 </tr>
 <tr>
@@ -8602,10 +8474,7 @@ different buffer.</p>
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Finish loop construct"
 <a href="https://forth-standard.org/standard/core/LOOP" class="bare">https://forth-standard.org/standard/core/LOOP</a>
 Compile-time part of LOOP. This does nothing more but push 1 on
-the stack and then call +LOOP. In Forth, this is
-: LOOP  POSTPONE 1 POSTPONE (+LOOP) , POSTPONE UNLOOP
-IMMEDIATE ; COMPILE-ONLY
-This drops through to +LOOP</p>
+the stack and then call +LOOP.</p>
 </td>
 </tr>
 <tr>
@@ -8625,9 +8494,7 @@ This drops through to +LOOP</p>
 <p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;d ) "16 * 16 -&#8594; 32"
 <a href="https://forth-standard.org/standard/core/MTimes" class="bare">https://forth-standard.org/standard/core/MTimes</a>
 Multiply two 16 bit numbers, producing a 32 bit result. All
-values are signed. Adapted from FIG Forth for Tali Forth. The
-original Forth is : M* OVER OVER XOR &gt;R ABS SWAP ABS UM* R&gt; D+-
-with  : D+- O&lt; IF DNEGATE THEN</p>
+values are signed. Adapted from FIG Forth for Tali Forth.</p>
 </td>
 </tr>
 <tr>
@@ -8676,9 +8543,7 @@ Subroutines." Negative Flag indicateds which number is larger. See
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> ( n1 n2&#8201;&#8212;&#8201;n ) "Divide NOS by TOS and return the remainder"
-<a href="https://forth-standard.org/standard/core/MOD" class="bare">https://forth-standard.org/standard/core/MOD</a>
-The Forth definition of this word is  : MOD /MOD DROP
-so we just jump to xt_slash_mod and dump the actual result.</p>
+<a href="https://forth-standard.org/standard/core/MOD" class="bare">https://forth-standard.org/standard/core/MOD</a></p>
 </td>
 </tr>
 <tr>
@@ -8691,7 +8556,7 @@ so we just jump to xt_slash_mod and dump the actual result.</p>
 Copy u "address units" from addr1 to addr2. Since our address
 units are bytes, this is just a front-end for CMOVE and CMOVE&gt;. This
 is actually the only one of these three words that is in the CORE
-set. This word must not be natively compiled</p>
+set.</p>
 </td>
 </tr>
 <tr>
@@ -8762,9 +8627,7 @@ Gforth uses S&gt;NUMBER? and S&gt;UNUMBER? which return numbers and a flag
 <a href="https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Number-Conversion.html" class="bare">https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Number-Conversion.html</a>
 Another difference to Gforth is that we follow ANS Forth that the
 dot to signal a double cell number is required to be the last
-character of the string. Number calls &gt;NUMBER which in turn calls UM*,
-which uses tmp1, tmp2, and tmp3, so we can&#8217;t use them here, which is
-a pain.</p>
+character of the string.</p>
 </td>
 </tr>
 <tr>
@@ -8809,7 +8672,9 @@ a pain.</p>
 <td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Print current word order list and current WID"
 <a href="https://forth-standard.org/standard/search/ORDER" class="bare">https://forth-standard.org/standard/search/ORDER</a>
-A Forth implementation of this word is:</p>
+Note the search order is displayed from first search to last
+searched and is therefore exactly the reverse of the order in which
+Forth stacks are displayed.</p>
 </td>
 </tr>
 <tr>
@@ -8910,10 +8775,7 @@ that FIG Forth has a different behavior for PICK than ANS Forth.</p>
 Add the compilation behavior of a word to a new word at
 compile time. If the word that follows it is immediate, include
 it so that it will be compiled when the word being defined is
-itself used for a new word. Tricky, but very useful. Because
-POSTPONE expects a word (not an xt) in the input stream (not
-on the Data Stack). This means we cannot build words with
-jsr xt_postpone, jsr &lt;word&gt;" directly.</p>
+itself used for a new word. Tricky, but very useful.</p>
 </td>
 </tr>
 <tr>
@@ -8942,10 +8804,7 @@ Rest the input and start command loop</p>
 <td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;n )(R: n --) "Move top of Return Stack to TOS"
 <a href="https://forth-standard.org/standard/core/Rfrom" class="bare">https://forth-standard.org/standard/core/Rfrom</a>
-Move Top of Return Stack to Top of Data Stack. We have to move
-the RTS address out of the way first. This word is handled
-differently for native and and subroutine compilation, see COMPILE,
-This is a compile-only word</p>
+Move Top of Return Stack to Top of Data Stack.</p>
 </td>
 </tr>
 <tr>
@@ -8955,8 +8814,7 @@ This is a compile-only word</p>
 <td class="hdlist2">
 <p><em>Tali Forth</em> (&#8201;&#8212;&#8201;) ( R: n n n n&#8201;&#8212;&#8201;) "Restore input state from Return Stack"
 Restore the current input state as defined by insrc, cib, ciblen,
-and toin from the Return Stack. See INPUT_TO_R for a discussion of
-this word. Uses tmp1</p>
+and toin from the Return Stack.</p>
 </td>
 </tr>
 <tr>
@@ -8967,9 +8825,7 @@ this word. Uses tmp1</p>
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;n ) "Get copy of top of Return Stack"
 <a href="https://forth-standard.org/standard/core/RFetch" class="bare">https://forth-standard.org/standard/core/RFetch</a>
 This word is Compile Only in Tali Forth, though Gforth has it
-work normally as well&#8201;&#8212;&#8201;An alternative way to write this word
-would be to access the elements on the stack directly like 2R@
-does, these versions should be compared at some point.</p>
+work normally as well</p>
 </td>
 </tr>
 <tr>
@@ -8978,8 +8834,7 @@ does, these versions should be compared at some point.</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Copy recursive call to word being defined"
-<a href="https://forth-standard.org/standard/core/RECURSE" class="bare">https://forth-standard.org/standard/core/RECURSE</a>
-This word may not be natively compiled</p>
+<a href="https://forth-standard.org/standard/core/RECURSE" class="bare">https://forth-standard.org/standard/core/RECURSE</a></p>
 </td>
 </tr>
 <tr>
@@ -9048,9 +8903,7 @@ on top!</p>
 Store address and length of string given, returning ( addr u ).
 ANS core claims this is compile-only, but the file set expands it
 to be interpreted, so it is a state-sensitive word, which in theory
-are evil. We follow general usage. Can also be realized as
-: S" [CHAR] " PARSE POSTPONE SLITERAL ; IMMEDIATE
-but it is used so much we want it in code.</p>
+are evil. We follow general usage.</p>
 </td>
 </tr>
 <tr>
@@ -9154,10 +9007,7 @@ code and disassembles it.</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> ( n&#8201;&#8212;&#8201;) "Add minus to pictured output"
-<a href="https://forth-standard.org/standard/core/SIGN" class="bare">https://forth-standard.org/standard/core/SIGN</a>
-Code based on
-<a href="http://pforth.googlecode.com/svn/trunk/fth/numberio.fth" class="bare">http://pforth.googlecode.com/svn/trunk/fth/numberio.fth</a>
-Original Forth code is   0&lt; IF ASCII - HOLD THEN</p>
+<a href="https://forth-standard.org/standard/core/SIGN" class="bare">https://forth-standard.org/standard/core/SIGN</a></p>
 </td>
 </tr>
 <tr>
@@ -9178,9 +9028,7 @@ Add the runtime for an existing string.</p>
 <p><em>ANS core</em> ( d n1&#8201;&#8212;&#8201;n2 n3 ) "Symmetic signed division"
 <a href="https://forth-standard.org/standard/core/SMDivREM" class="bare">https://forth-standard.org/standard/core/SMDivREM</a>
 Symmetic signed division. Compare FM/MOD. Based on F-PC 3.6
-by Ulrich Hoffmann. See <a href="http://www.xlerb.de/uho/ansi.seq" class="bare">http://www.xlerb.de/uho/ansi.seq</a> Forth:
-OVER &gt;R 2DUP XOR 0&lt; &gt;R ABS &gt;R DABS R&gt; UM/MOD R&gt; ?NEGATE SWAP
-R&gt; ?NEGATE SWAP</p>
+by Ulrich Hoffmann. See <a href="http://www.xlerb.de/uho/ansi.seq" class="bare">http://www.xlerb.de/uho/ansi.seq</a></p>
 </td>
 </tr>
 <tr>
@@ -9300,8 +9148,7 @@ Gives a new value to a, uh, VALUE.</p>
 <td class="hdlist2">
 <p><em>ANS core</em> ( addr u&#8201;&#8212;&#8201;) "Print string"
 <a href="https://forth-standard.org/standard/core/TYPE" class="bare">https://forth-standard.org/standard/core/TYPE</a>
-Works through EMIT to allow OUTPUT revectoring. Currently, only
-strings of up to 255 characters are printed</p>
+Works through EMIT to allow OUTPUT revectoring.</p>
 </td>
 </tr>
 <tr>
@@ -9310,10 +9157,7 @@ strings of up to 255 characters are printed</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> ( u&#8201;&#8212;&#8201;) "Print TOS as unsigned number"
-<a href="https://forth-standard.org/standard/core/Ud" class="bare">https://forth-standard.org/standard/core/Ud</a>
-This is : U. 0 &lt;# #S #&gt; TYPE SPACE ; in Forth
-We use the internal assembler function print_u followed
-by a single space</p>
+<a href="https://forth-standard.org/standard/core/Ud" class="bare">https://forth-standard.org/standard/core/Ud</a></p>
 </td>
 </tr>
 <tr>
@@ -9383,8 +9227,7 @@ Divide double cell number by single cell number, returning the
 quotient as TOS and any remainder as NOS. All numbers are unsigned.
 This is the basic division operation all others use. Based on FIG
 Forth code, modified by Garth Wilson, see
-<a href="http://6502.org/source/integers/ummodfix/ummodfix.htm" class="bare">http://6502.org/source/integers/ummodfix/ummodfix.htm</a>
-This uses tmp1, tmp1+1, and tmptos</p>
+<a href="http://6502.org/source/integers/ummodfix/ummodfix.htm" class="bare">http://6502.org/source/integers/ummodfix/ummodfix.htm</a></p>
 </td>
 </tr>
 <tr>
@@ -9393,8 +9236,7 @@ This uses tmp1, tmp1+1, and tmptos</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;)(R: n1 n2 n3 ---) "Drop loop control from Return stack"
-<a href="https://forth-standard.org/standard/core/UNLOOP" class="bare">https://forth-standard.org/standard/core/UNLOOP</a>
-Note that 6xPLA uses just as many bytes as a loop would</p>
+<a href="https://forth-standard.org/standard/core/UNLOOP" class="bare">https://forth-standard.org/standard/core/UNLOOP</a></p>
 </td>
 </tr>
 <tr>
@@ -9441,9 +9283,7 @@ defaults to $400</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core</em> ( n "name"&#8201;&#8212;&#8201;) "Define a value"
-<a href="https://forth-standard.org/standard/core/VALUE" class="bare">https://forth-standard.org/standard/core/VALUE</a>
-This is a dummy header for the WORDLIST. The actual code is
-identical to that of CONSTANT</p>
+<a href="https://forth-standard.org/standard/core/VALUE" class="bare">https://forth-standard.org/standard/core/VALUE</a></p>
 </td>
 </tr>
 <tr>
@@ -9454,7 +9294,7 @@ identical to that of CONSTANT</p>
 <p><em>ANS core</em> ( "name"&#8201;&#8212;&#8201;) "Define a variable"
 <a href="https://forth-standard.org/standard/core/VARIABLE" class="bare">https://forth-standard.org/standard/core/VARIABLE</a>
 There are various Forth definitions for this word, such as
-CREATE 1 CELLS ALLOT  or  CREATE 0 ,  We use a variant of the
+<code>CREATE 1 CELLS ALLOT</code>  or  <code>CREATE 0 ,</code>  We use a variant of the
 second one so the variable is initialized to zero</p>
 </td>
 </tr>
@@ -9473,11 +9313,7 @@ second one so the variable is initialized to zero</p>
 </td>
 <td class="hdlist2">
 <p><em>ANS core ext</em> ( n1 n2 n3&#8201;&#8212;&#8201;) "See if within a range"
-<a href="https://forth-standard.org/standard/core/WITHIN" class="bare">https://forth-standard.org/standard/core/WITHIN</a>
-This an assembler version of the ANS Forth implementation
-at <a href="https://forth-standard.org/standard/core/WITHIN" class="bare">https://forth-standard.org/standard/core/WITHIN</a> which is
-OVER - &gt;R - R&gt; U&lt;  note there is an alternative high-level version
-ROT TUCK &gt; -ROT &gt; INVERT AND</p>
+<a href="https://forth-standard.org/standard/core/WITHIN" class="bare">https://forth-standard.org/standard/core/WITHIN</a></p>
 </td>
 </tr>
 <tr>
@@ -9494,9 +9330,7 @@ Returns the result as a counted string (requires COUNT to convert
 to modern format), and inserts a space after the string. See "Forth
 Programmer&#8217;s Handbook" 3rd edition p. 159 and
 <a href="http://www.forth200x.org/documents/html/rationale.html#rat:core:PARSE" class="bare">http://www.forth200x.org/documents/html/rationale.html#rat:core:PARSE</a>
-for discussions of why you shouldn&#8217;t be using WORD anymore. Forth
-would be   PARSE DUP BUFFER1 C! OUTPUT 1+ SWAP MOVE BUFFER1
-We only allow input of 255 chars. Seriously, use PARSE-NAME.</p>
+for discussions of why you shouldn&#8217;t be using WORD anymore.</p>
 </td>
 </tr>
 <tr>
@@ -9513,13 +9347,7 @@ We only allow input of 255 chars. Seriously, use PARSE-NAME.</p>
 <code>words</code>
 </td>
 <td class="hdlist2">
-<p><em>ANS tools</em> (&#8201;&#8212;&#8201;) "Print known words from Dictionary"
-<a href="https://forth-standard.org/standard/tools/WORDS" class="bare">https://forth-standard.org/standard/tools/WORDS</a>
-This is pretty much only used at the command line so we can
-be slow and try to save space. DROP must always be the first word in a
-clean system (without Forth words), BYE the last. There is no reason
-why we couldn&#8217;t define this as a high level word except that it is
-really useful for testing</p>
+<p><em>ANS tools</em> (&#8201;&#8212;&#8201;) "Print known words from Dictionary"</p>
 </td>
 </tr>
 <tr>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -8638,35 +8638,17 @@ with  : D+- O&lt; IF DNEGATE THEN</p>
 <p><em>ANS core ext</em> ( "name"&#8201;&#8212;&#8201;) "Create a deletion boundry"
 <a href="https://forth-standard.org/standard/core/MARKER" class="bare">https://forth-standard.org/standard/core/MARKER</a>
 This word replaces FORGET in earlier Forths. Old entries are not
-actually deleted, but merely overwritten by restoring CP and DP. To
-do this, we want to end up with something that jumps to a run-time
-component with a link to the original CP and DP values:</p>
+actually deleted, but merely overwritten by restoring CP and DP.
+Run the named word at a later time to restore all of the wordlists
+to their state when the word was created with marker.  Any words
+created after the marker (including the marker) will be forgotten.</p>
 </td>
 </tr>
-</table>
-</div>
-<div class="paragraph">
-<p>jsr marker_runtime
-&lt;Original CP MSB&gt;
-&lt;Original CP LSB&gt;
-&lt;Original DP MSB&gt; ( for CURRENT wordlist )
-&lt;Original DP LSB&gt;
-&lt; USER variables from offset 4 to 39 &gt;</p>
-</div>
-<div class="paragraph">
-<p>The user variables include:
-CURRENT (byte variable)
-&lt;All wordlists&gt; (currently 12) (cell array)
-&lt;#ORDER&gt; (byte variable)
-&lt;All search order&gt; (currently 9) (byte array)</p>
-</div>
-<div class="paragraph">
-<p>This code uses tmp1 and tmp2</p>
-</div>
-<div class="dlist">
-<dl>
-<dt class="hdlist1"><code>max</code></dt>
-<dd>
+<tr>
+<td class="hdlist1">
+<code>max</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;n ) "Keep larger of two numbers"
 <a href="https://forth-standard.org/standard/core/MAX" class="bare">https://forth-standard.org/standard/core/MAX</a>
 Compare TOS and NOS and keep which one is larger. Adapted from
@@ -8674,62 +8656,102 @@ Lance A. Leventhal "6502 Assembly Language Subroutines". Negative
 Flag indicates which number is larger. See also
 <a href="http://6502.org/tutorials/compare_instructions.html" class="bare">http://6502.org/tutorials/compare_instructions.html</a> and
 <a href="http://www.righto.com/2012/12/the-6502-overflow-flag-explained.html" class="bare">http://www.righto.com/2012/12/the-6502-overflow-flag-explained.html</a></p>
-</dd>
-<dt class="hdlist1"><code>min</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>min</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;n ) "Keep smaller of two numbers"
 <a href="https://forth-standard.org/standard/core/MIN" class="bare">https://forth-standard.org/standard/core/MIN</a>
 Adapted from Lance A. Leventhal "6502 Assembly Language
 Subroutines." Negative Flag indicateds which number is larger. See
 <a href="http://www.righto.com/2012/12/the-6502-overflow-flag-explained.html" class="bare">http://www.righto.com/2012/12/the-6502-overflow-flag-explained.html</a></p>
-</dd>
-<dt class="hdlist1"><code>mod</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>mod</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( n1 n2&#8201;&#8212;&#8201;n ) "Divide NOS by TOS and return the remainder"
 <a href="https://forth-standard.org/standard/core/MOD" class="bare">https://forth-standard.org/standard/core/MOD</a>
 The Forth definition of this word is  : MOD /MOD DROP
 so we just jump to xt_slash_mod and dump the actual result.</p>
-</dd>
-<dt class="hdlist1"><code>move</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>move</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( addr1 addr2 u&#8201;&#8212;&#8201;) "Copy bytes"
 <a href="https://forth-standard.org/standard/core/MOVE" class="bare">https://forth-standard.org/standard/core/MOVE</a>
 Copy u "address units" from addr1 to addr2. Since our address
 units are bytes, this is just a front-end for CMOVE and CMOVE&gt;. This
 is actually the only one of these three words that is in the CORE
 set. This word must not be natively compiled</p>
-</dd>
-<dt class="hdlist1"><code>name&gt;int</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>name&gt;int</code>
+</td>
+<td class="hdlist2">
 <p><em>Gforth</em> ( nt&#8201;&#8212;&#8201;xt ) "Convert Name Token to Execute Token"
 See
 <a href="https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html" class="bare">https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html</a></p>
-</dd>
-<dt class="hdlist1"><code>name&gt;string</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>name&gt;string</code>
+</td>
+<td class="hdlist2">
 <p><em>Gforth</em> ( nt&#8201;&#8212;&#8201;addr u ) "Given a name token, return string of word"
 <a href="http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html" class="bare">http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Name-token.html</a></p>
-</dd>
-<dt class="hdlist1"><code>nc-limit</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>nc-limit</code>
+</td>
+<td class="hdlist2">
 <p><em>Tali Forth</em> (&#8201;&#8212;&#8201;addr ) "Return address where NC-LIMIT value is kept"</p>
-</dd>
-<dt class="hdlist1"><code>negate</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>negate</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( n&#8201;&#8212;&#8201;n ) "Two&#8217;s complement"
 <a href="https://forth-standard.org/standard/core/NEGATE" class="bare">https://forth-standard.org/standard/core/NEGATE</a></p>
-</dd>
-<dt class="hdlist1"><code>never-native</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>never-native</code>
+</td>
+<td class="hdlist2">
 <p><em>Tali Forth</em> (&#8201;&#8212;&#8201;) "Flag last word as never natively compiled"</p>
-</dd>
-<dt class="hdlist1"><code>nip</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>nip</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core ext</em> ( b a&#8201;&#8212;&#8201;a ) "Delete NOS"
 <a href="https://forth-standard.org/standard/core/NIP" class="bare">https://forth-standard.org/standard/core/NIP</a></p>
-</dd>
-<dt class="hdlist1"><code>number</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>number</code>
+</td>
+<td class="hdlist2">
 <p><em>Tali Forth</em> ( addr u&#8201;&#8212;&#8201;u | d ) "Convert a number string"
 Convert a number string to a double or single cell number. This
 is a wrapper for &gt;NUMBER and follows the convention set out in the
@@ -8743,91 +8765,113 @@ dot to signal a double cell number is required to be the last
 character of the string. Number calls &gt;NUMBER which in turn calls UM*,
 which uses tmp1, tmp2, and tmp3, so we can&#8217;t use them here, which is
 a pain.</p>
-</dd>
-<dt class="hdlist1"><code>o</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>o</code>
+</td>
+<td class="hdlist2">
 <p><em>Tali Editor</em> ( line#&#8201;&#8212;&#8201;) "Overwrite the given line"</p>
-</dd>
-<dt class="hdlist1"><code>of</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>of</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core ext</em> (C:&#8201;&#8212;&#8201;of-sys) (x1 x2&#8201;&#8212;&#8201;|x1) "Conditional flow control"
 <a href="http://forth-standard.org/standard/core/OF" class="bare">http://forth-standard.org/standard/core/OF</a></p>
-</dd>
-<dt class="hdlist1"><code>only</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>only</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS search ext</em> (&#8201;&#8212;&#8201;) "Set earch order to minimum wordlist"
 <a href="https://forth-standard.org/standard/search/ONLY" class="bare">https://forth-standard.org/standard/search/ONLY</a></p>
-</dd>
-<dt class="hdlist1"><code>or</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>or</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( m n&#8201;&#8212;&#8201;n ) "Logically OR TOS and NOS"
 <a href="https://forth-standard.org/standard/core/OR" class="bare">https://forth-standard.org/standard/core/OR</a></p>
-</dd>
-<dt class="hdlist1"><code>order</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>order</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Print current word order list and current WID"
 <a href="https://forth-standard.org/standard/search/ORDER" class="bare">https://forth-standard.org/standard/search/ORDER</a>
 A Forth implementation of this word is:</p>
-</dd>
-<dt class="hdlist1"><code>output</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>output</code>
+</td>
+<td class="hdlist2">
 <p><em>Tali Forth</em> (&#8201;&#8212;&#8201;addr ) "Return the address of the EMIT vector address"</p>
-</dd>
-<dt class="hdlist1"><code>over</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>over</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( b a&#8201;&#8212;&#8201;b a b ) "Copy NOS to TOS"
 <a href="https://forth-standard.org/standard/core/OVER" class="bare">https://forth-standard.org/standard/core/OVER</a></p>
-</dd>
-<dt class="hdlist1"><code>pad</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>pad</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core ext</em> (&#8201;&#8212;&#8201;addr ) "Return address of user scratchpad"
 <a href="https://forth-standard.org/standard/core/PAD" class="bare">https://forth-standard.org/standard/core/PAD</a>
 Return address to a temporary area in free memory for user. Must
 be at least 84 bytes in size (says ANS). It is located relative to
 the compile area pointer (CP) and therefore varies in position.
 This area is reserved for the user and not used by the system</p>
-</dd>
-<dt class="hdlist1"><code>page</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>page</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS facility</em> (&#8201;&#8212;&#8201;) "Clear the screen"
 <a href="https://forth-standard.org/standard/facility/PAGE" class="bare">https://forth-standard.org/standard/facility/PAGE</a>
 Clears a page if supported by ANS terminal codes. This is
 Clear Screen ("ESC[2J") plus moving the cursor to the top
 left of the screen</p>
-</dd>
-<dt class="hdlist1"><code>parse</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>parse</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core ext</em> ( "name" c&#8201;&#8212;&#8201;addr u ) "Parse input with delimiter character"
 <a href="https://forth-standard.org/standard/core/PARSE" class="bare">https://forth-standard.org/standard/core/PARSE</a>
 Find word in input string delimited by character given. Do not
 skip leading delimiters&#8201;&#8212;&#8201;this is the main difference to PARSE-NAME.
 PARSE and PARSE-NAME replace WORD in modern systems. ANS discussion
 <a href="http://www.forth200x.org/documents/html3/rationale.html#rat:core:PARSE" class="bare">http://www.forth200x.org/documents/html3/rationale.html#rat:core:PARSE</a></p>
-</dd>
-</dl>
-</div>
-<div class="paragraph">
-<p>cib  cib+toin   cib+ciblen
-v      v            v
-|<mark><mark></mark><mark></mark></mark><mark><mark></mark></mark>###|</p>
-</div>
-<div class="paragraph">
-<p>|-----&#8594;|  toin (&gt;IN)
-|------------------&#8594;|  ciblen</p>
-</div>
-<div class="paragraph">
-<p>The input string is stored starting at the address in the Current
-Input Buffer (CIB), the length of which is in CIBLEN. While searching
-for the delimiter, TOIN (&gt;IN) points to the where we currently are.
-Since PARSE does not skip leading delimiters, we assume we are on a
-useful string if there are any characters at all. As with
-PARSE-NAME, we must be able to handle strings with a length of
-16-bit for EVALUTE, which is a pain on an 8-bit machine.</p>
-</div>
-<div class="dlist">
-<dl>
-<dt class="hdlist1"><code>parse-name</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>parse-name</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core ext</em> ( "name"&#8201;&#8212;&#8201;addr u ) "Parse the input"
 <a href="https://forth-standard.org/standard/core/PARSE-NAME" class="bare">https://forth-standard.org/standard/core/PARSE-NAME</a>
 Find next word in input string, skipping leading whitespace. This is
@@ -8841,18 +8885,26 @@ though the ANS standard talks about skipping "spaces", whitespace
 is actually perfectly legal (see for example
 <a href="http://forth-standard.org/standard/usage#subsubsection.3.4.1.1" class="bare">http://forth-standard.org/standard/usage#subsubsection.3.4.1.1</a>).
 Otherwise, PARSE-NAME chokes on tabs.</p>
-</dd>
-<dt class="hdlist1"><code>pick</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>pick</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core ext</em> ( n n u&#8201;&#8212;&#8201;n n n ) "Move element u of the stack to TOS"
 <a href="https://forth-standard.org/standard/core/PICK" class="bare">https://forth-standard.org/standard/core/PICK</a>
 Take the u-th element out of the stack and put it on TOS,
 overwriting the original TOS. 0 PICK is equivalent to DUP, 1 PICK to
 OVER. Note that using PICK is considered poor coding form. Also note
 that FIG Forth has a different behavior for PICK than ANS Forth.</p>
-</dd>
-<dt class="hdlist1"><code>postpone</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>postpone</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Change IMMEDIATE status (it&#8217;s complicated)"
 <a href="https://forth-standard.org/standard/core/POSTPONE" class="bare">https://forth-standard.org/standard/core/POSTPONE</a>
 Add the compilation behavior of a word to a new word at
@@ -8862,51 +8914,79 @@ itself used for a new word. Tricky, but very useful. Because
 POSTPONE expects a word (not an xt) in the input stream (not
 on the Data Stack). This means we cannot build words with
 jsr xt_postpone, jsr &lt;word&gt;" directly.</p>
-</dd>
-<dt class="hdlist1"><code>previous</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>previous</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS search ext</em> (&#8201;&#8212;&#8201;) "Remove the first wordlist in the search order"
 <a href="http://forth-standard.org/standard/search/PREVIOUS" class="bare">http://forth-standard.org/standard/search/PREVIOUS</a></p>
-</dd>
-<dt class="hdlist1"><code>quit</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>quit</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Reset the input and get new input"
 <a href="https://forth-standard.org/standard/core/QUIT" class="bare">https://forth-standard.org/standard/core/QUIT</a>
 Rest the input and start command loop</p>
-</dd>
-<dt class="hdlist1"><code>r&gt;</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>r&gt;</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;n )(R: n --) "Move top of Return Stack to TOS"
 <a href="https://forth-standard.org/standard/core/Rfrom" class="bare">https://forth-standard.org/standard/core/Rfrom</a>
 Move Top of Return Stack to Top of Data Stack. We have to move
 the RTS address out of the way first. This word is handled
 differently for native and and subroutine compilation, see COMPILE,
 This is a compile-only word</p>
-</dd>
-<dt class="hdlist1"><code>r&gt;input</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>r&gt;input</code>
+</td>
+<td class="hdlist2">
 <p><em>Tali Forth</em> (&#8201;&#8212;&#8201;) ( R: n n n n&#8201;&#8212;&#8201;) "Restore input state from Return Stack"
 Restore the current input state as defined by insrc, cib, ciblen,
 and toin from the Return Stack. See INPUT_TO_R for a discussion of
 this word. Uses tmp1</p>
-</dd>
-<dt class="hdlist1"><code>r@</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>r@</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;n ) "Get copy of top of Return Stack"
 <a href="https://forth-standard.org/standard/core/RFetch" class="bare">https://forth-standard.org/standard/core/RFetch</a>
 This word is Compile Only in Tali Forth, though Gforth has it
 work normally as well&#8201;&#8212;&#8201;An alternative way to write this word
 would be to access the elements on the stack directly like 2R@
 does, these versions should be compared at some point.</p>
-</dd>
-<dt class="hdlist1"><code>recurse</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>recurse</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Copy recursive call to word being defined"
 <a href="https://forth-standard.org/standard/core/RECURSE" class="bare">https://forth-standard.org/standard/core/RECURSE</a>
 This word may not be natively compiled</p>
-</dd>
-<dt class="hdlist1"><code>refill</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>refill</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core ext</em> (&#8201;&#8212;&#8201;f ) "Refill the input buffer"
 <a href="https://forth-standard.org/standard/core/REFILL" class="bare">https://forth-standard.org/standard/core/REFILL</a>
 Attempt to fill the input buffer from the input source, returning
@@ -8919,30 +8999,50 @@ source, return false. When the input source is a string from EVALUATE,
 return false and perform no other action." See
 <a href="https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/The-Input-Stream.html" class="bare">https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/The-Input-Stream.html</a>
 and Conklin &amp; Rather p. 156</p>
-</dd>
-<dt class="hdlist1"><code>repeat</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>repeat</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> (C: orig dest&#8201;&#8212;&#8201;) (&#8201;&#8212;&#8201;) "Loop flow control"
 <a href="http://forth-standard.org/standard/core/REPEAT" class="bare">http://forth-standard.org/standard/core/REPEAT</a></p>
-</dd>
-<dt class="hdlist1"><code>root-wordlist</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>root-wordlist</code>
+</td>
+<td class="hdlist2">
 <p><em>Tali Editor</em> (&#8201;&#8212;&#8201;u ) "WID for the Root (minimal) wordlist"</p>
-</dd>
-<dt class="hdlist1"><code>rot</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>rot</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( a b c&#8201;&#8212;&#8201;b c a ) "Rotate first three stack entries downwards"
 <a href="https://forth-standard.org/standard/core/ROT" class="bare">https://forth-standard.org/standard/core/ROT</a>
 Remember "R for 'Revolution'" - the bottom entry comes out
 on top!</p>
-</dd>
-<dt class="hdlist1"><code>rshift</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>rshift</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( x u&#8201;&#8212;&#8201;x ) "Shift TOS to the right"
 <a href="https://forth-standard.org/standard/core/RSHIFT" class="bare">https://forth-standard.org/standard/core/RSHIFT</a></p>
-</dd>
-<dt class="hdlist1"><code>s"</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>s"</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( "string"&#8201;&#8212;&#8201;)(&#8201;&#8212;&#8201;addr u ) "Store string in memory"
 <a href="https://forth-standard.org/standard/core/Sq" class="bare">https://forth-standard.org/standard/core/Sq</a>
 Store address and length of string given, returning ( addr u ).
@@ -8951,14 +9051,22 @@ to be interpreted, so it is a state-sensitive word, which in theory
 are evil. We follow general usage. Can also be realized as
 : S" [CHAR] " PARSE POSTPONE SLITERAL ; IMMEDIATE
 but it is used so much we want it in code.</p>
-</dd>
-<dt class="hdlist1"><code>s&gt;d</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>s&gt;d</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( u&#8201;&#8212;&#8201;d ) "Convert single cell number to double cell"
 <a href="https://forth-standard.org/standard/core/StoD" class="bare">https://forth-standard.org/standard/core/StoD</a></p>
-</dd>
-<dt class="hdlist1"><code>s\"</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>s\"</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( "string"&#8201;&#8212;&#8201;)(&#8201;&#8212;&#8201;addr u ) "Store string in memory"
 <a href="https://forth-standard.org/standard/core/Seq" class="bare">https://forth-standard.org/standard/core/Seq</a>
 Store address and length of string given, returning ( addr u ).
@@ -8966,19 +9074,31 @@ ANS core claims this is compile-only, but the file set expands it
 to be interpreted, so it is a state-sensitive word, which in theory
 are evil. We follow general usage.  This is just like S" except
 that it allows for some special escaped characters.</p>
-</dd>
-<dt class="hdlist1"><code>save-buffers</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>save-buffers</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS block</em> (&#8201;&#8212;&#8201;) "Save all dirty buffers to storage"
 <a href="https://forth-standard.org/standard/block/SAVE-BUFFERS" class="bare">https://forth-standard.org/standard/block/SAVE-BUFFERS</a></p>
-</dd>
-<dt class="hdlist1"><code>scr</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>scr</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS block ext</em> (&#8201;&#8212;&#8201;addr ) "Push address of variable holding last screen listed"
 <a href="https://forth-standard.org/standard/block/SCR" class="bare">https://forth-standard.org/standard/block/SCR</a></p>
-</dd>
-<dt class="hdlist1"><code>search</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>search</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS string</em> ( addr1 u1 addr2 u2&#8201;&#8212;&#8201;addr3 u3 flag) "Search for a substring"
 <a href="https://forth-standard.org/standard/string/SEARCH" class="bare">https://forth-standard.org/standard/string/SEARCH</a>
 Search for string2 (denoted by addr2 u2) in string1 (denoted by
@@ -8987,200 +9107,276 @@ addr3 will have the address of the start of the match and u3 will have
 the number of characters remaining from the match point to the end
 of the original string1.  If a match is not found, the flag will be
 false and addr3 and u3 will be the original string1&#8217;s addr1 and u1.</p>
-</dd>
-<dt class="hdlist1"><code>search-wordlist</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>search-wordlist</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS search</em> ( caddr u wid&#8201;&#8212;&#8201;0 | xt 1 | xt -1) "Search for a word in a wordlist"
 <a href="https://forth-standard.org/standard/search/SEARCH_WORDLIST" class="bare">https://forth-standard.org/standard/search/SEARCH_WORDLIST</a></p>
-</dd>
-<dt class="hdlist1"><code>see</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>see</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS tools</em> ( "name"&#8201;&#8212;&#8201;) "Print information about a Forth word"
 <a href="https://forth-standard.org/standard/tools/SEE" class="bare">https://forth-standard.org/standard/tools/SEE</a>
 SEE takes the name of a word and prints its name token (nt),
 execution token (xt), size in bytes, flags used, and then dumps the
 code and disassembles it.</p>
-</dd>
-<dt class="hdlist1"><code>set-current</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>set-current</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS search</em> ( wid&#8201;&#8212;&#8201;) "Set the compilation wordlist"
 <a href="https://forth-standard.org/standard/search/SET-CURRENT" class="bare">https://forth-standard.org/standard/search/SET-CURRENT</a></p>
-</dd>
-<dt class="hdlist1"><code>set-order</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>set-order</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS search</em> ( wid_n .. wid_1 n&#8201;&#8212;&#8201;) "Set the current search order"
 <a href="https://forth-standard.org/standard/search/SET-ORDER" class="bare">https://forth-standard.org/standard/search/SET-ORDER</a></p>
-</dd>
-<dt class="hdlist1"><code>sign</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>sign</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( n&#8201;&#8212;&#8201;) "Add minus to pictured output"
 <a href="https://forth-standard.org/standard/core/SIGN" class="bare">https://forth-standard.org/standard/core/SIGN</a>
 Code based on
 <a href="http://pforth.googlecode.com/svn/trunk/fth/numberio.fth" class="bare">http://pforth.googlecode.com/svn/trunk/fth/numberio.fth</a>
 Original Forth code is   0&lt; IF ASCII - HOLD THEN</p>
-</dd>
-<dt class="hdlist1"><code>sliteral</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>sliteral</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS string</em> ( addr u&#8201;&#8212;&#8201;)(&#8201;&#8212;&#8201;addr u ) "Compile a string for runtime"
 <a href="https://forth-standard.org/standard/string/SLITERAL" class="bare">https://forth-standard.org/standard/string/SLITERAL</a>
 Add the runtime for an existing string.</p>
-</dd>
-<dt class="hdlist1"><code>sm/rem</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>sm/rem</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( d n1&#8201;&#8212;&#8201;n2 n3 ) "Symmetic signed division"
 <a href="https://forth-standard.org/standard/core/SMDivREM" class="bare">https://forth-standard.org/standard/core/SMDivREM</a>
 Symmetic signed division. Compare FM/MOD. Based on F-PC 3.6
 by Ulrich Hoffmann. See <a href="http://www.xlerb.de/uho/ansi.seq" class="bare">http://www.xlerb.de/uho/ansi.seq</a> Forth:
 OVER &gt;R 2DUP XOR 0&lt; &gt;R ABS &gt;R DABS R&gt; UM/MOD R&gt; ?NEGATE SWAP
 R&gt; ?NEGATE SWAP</p>
-</dd>
-<dt class="hdlist1"><code>source</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>source</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;addr u ) "Return location and size of input buffer""
 <a href="https://forth-standard.org/standard/core/SOURCE" class="bare">https://forth-standard.org/standard/core/SOURCE</a></p>
-</dd>
-<dt class="hdlist1"><code>source-id</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>source-id</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core ext</em> (&#8201;&#8212;&#8201;n ) "Return source identifier"
 <a href="https://forth-standard.org/standard/core/SOURCE-ID" class="bare">https://forth-standard.org/standard/core/SOURCE-ID</a>
 Identify the input source unless it is a block (s. Conklin &amp;
 Rather p. 156). Since we don&#8217;t have blocks (yet), this will give
 the input source: 0 is keyboard, -1 (0ffff) is character string,
 and a text file gives the fileid.</p>
-</dd>
-<dt class="hdlist1"><code>space</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>space</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;) "Print a single space"
 <a href="https://forth-standard.org/standard/core/SPACE" class="bare">https://forth-standard.org/standard/core/SPACE</a></p>
-</dd>
-<dt class="hdlist1"><code>spaces</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>spaces</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( u&#8201;&#8212;&#8201;) "Print a number of spaces"
 <a href="https://forth-standard.org/standard/core/SPACES" class="bare">https://forth-standard.org/standard/core/SPACES</a></p>
-</dd>
-<dt class="hdlist1"><code>state</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>state</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;addr ) "Return the address of compilation state flag"
 <a href="https://forth-standard.org/standard/core/STATE" class="bare">https://forth-standard.org/standard/core/STATE</a>
 STATE is true when in compilation state, false otherwise. Note
 we do not return the state itself, but only the address where
 it lives. The state should not be changed directly by the user; see
 <a href="http://forth.sourceforge.net/standard/dpans/dpans6.htm#6.1.2250" class="bare">http://forth.sourceforge.net/standard/dpans/dpans6.htm#6.1.2250</a></p>
-</dd>
-<dt class="hdlist1"><code>strip-underflow</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>strip-underflow</code>
+</td>
+<td class="hdlist2">
 <p><em>Tali Forth</em> (&#8201;&#8212;&#8201;addr ) "Return address where underflow status is kept"
 STRIP_UNDERFLOW contains a flag that determines if underflow
 checking should be removed during the compilation of new words.
 Default is false.</p>
-</dd>
-<dt class="hdlist1"><code>swap</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>swap</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( b a&#8201;&#8212;&#8201;a b ) "Exchange TOS and NOS"
 <a href="https://forth-standard.org/standard/core/SWAP" class="bare">https://forth-standard.org/standard/core/SWAP</a></p>
-</dd>
-<dt class="hdlist1"><code>then</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>then</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> (C: orig&#8201;&#8212;&#8201;) (&#8201;&#8212;&#8201;) "Conditional flow control"
 <a href="http://forth-standard.org/standard/core/THEN" class="bare">http://forth-standard.org/standard/core/THEN</a></p>
-</dd>
-<dt class="hdlist1"><code>to</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>to</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core ext</em> ( n "name"&#8201;&#8212;&#8201;) or ( "name") "Change a value"
 <a href="https://forth-standard.org/standard/core/TO" class="bare">https://forth-standard.org/standard/core/TO</a>
-Gives a new value to a, uh, VALUE. One possible Forth
-implementation is  ' &gt;BODY !  but given the problems we have
-with &gt;BODY on STC Forths, we do this the hard way. Since
-Tali Forth uses the same code for CONSTANTs and VALUEs, you
-could use this to redefine a CONSTANT, but that is a no-no.</p>
-</dd>
-</dl>
-</div>
-<div class="paragraph">
-<p>Note that the standard has different behaviors for TO depending
-on the state (<a href="https://forth-standard.org/standard/core/TO" class="bare">https://forth-standard.org/standard/core/TO</a>).
-This makes TO state-dependent (which is bad) and also rather
-complex (see the Gforth implementation for comparison). This
-word may not be natively compiled and must be immediate. Frankly,
-it would have made more sense to have two words for this.</p>
-</div>
-<div class="dlist">
-<dl>
-<dt class="hdlist1"><code>true</code></dt>
-<dd>
+Gives a new value to a, uh, VALUE.</p>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>true</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core ext</em> (&#8201;&#8212;&#8201;f ) "Push TRUE flag to Data Stack"
 <a href="https://forth-standard.org/standard/core/TRUE" class="bare">https://forth-standard.org/standard/core/TRUE</a></p>
-</dd>
-<dt class="hdlist1"><code>tuck</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>tuck</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core ext</em> ( b a&#8201;&#8212;&#8201;a b a ) "Copy TOS below NOS"
 <a href="https://forth-standard.org/standard/core/TUCK" class="bare">https://forth-standard.org/standard/core/TUCK</a></p>
-</dd>
-<dt class="hdlist1"><code>type</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>type</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( addr u&#8201;&#8212;&#8201;) "Print string"
 <a href="https://forth-standard.org/standard/core/TYPE" class="bare">https://forth-standard.org/standard/core/TYPE</a>
 Works through EMIT to allow OUTPUT revectoring. Currently, only
 strings of up to 255 characters are printed</p>
-</dd>
-<dt class="hdlist1"><code>u.</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>u.</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( u&#8201;&#8212;&#8201;) "Print TOS as unsigned number"
 <a href="https://forth-standard.org/standard/core/Ud" class="bare">https://forth-standard.org/standard/core/Ud</a>
 This is : U. 0 &lt;# #S #&gt; TYPE SPACE ; in Forth
 We use the internal assembler function print_u followed
 by a single space</p>
-</dd>
-<dt class="hdlist1"><code>u.r</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>u.r</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core ext</em> ( u u&#8201;&#8212;&#8201;) "Print NOS as unsigned number with TOS with"
 <a href="https://forth-standard.org/standard/core/UDotR" class="bare">https://forth-standard.org/standard/core/UDotR</a></p>
-</dd>
-<dt class="hdlist1"><code>u&lt;</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>u&lt;</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( n m&#8201;&#8212;&#8201;f ) "Return true if NOS &lt; TOS (unsigned)"
 <a href="https://forth-standard.org/standard/core/Uless" class="bare">https://forth-standard.org/standard/core/Uless</a></p>
-</dd>
-<dt class="hdlist1"><code>u&gt;</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>u&gt;</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core ext</em> ( n m&#8201;&#8212;&#8201;f ) "Return true if NOS &gt; TOS (unsigned)"
 <a href="https://forth-standard.org/standard/core/Umore" class="bare">https://forth-standard.org/standard/core/Umore</a></p>
-</dd>
-<dt class="hdlist1"><code>ud.</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>ud.</code>
+</td>
+<td class="hdlist2">
 <p><em>Tali double</em> ( d&#8201;&#8212;&#8201;) "Print double as unsigned"
 Based on the Forth code  : UD. &lt;# #S #&gt; TYPE SPACE</p>
-</dd>
-<dt class="hdlist1"><code>ud.r</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>ud.r</code>
+</td>
+<td class="hdlist2">
 <p><em>Tali double</em> ( d u&#8201;&#8212;&#8201;) "Print unsigned double right-justified u wide"
 Based on the Forth code : UD.R  &gt;R &lt;# #S #&gt; R&gt; OVER - SPACES TYPE</p>
-</dd>
-<dt class="hdlist1"><code>um*</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>um*</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( u u&#8201;&#8212;&#8201;ud ) "Multiply 16 x 16 &#8594; 32"
 <a href="https://forth-standard.org/standard/core/UMTimes" class="bare">https://forth-standard.org/standard/core/UMTimes</a>
 Multiply two unsigned 16 bit numbers, producing a 32 bit result.
-This is based on modified FIG Forth code by Dr. Jefyll, see
-<a href="http://forum.6502.org/viewtopic.php?f=9&amp;t=689" class="bare">http://forum.6502.org/viewtopic.php?f=9&amp;t=689</a> for a detailed
-discussion. We don&#8217;t use the system scratch pad (SYSPAD) for temp
-storage because &gt;NUMBER uses it as well, but instead tmp1 to
-tmp3 (tmp1 is N in the original code, tmp1+1 is N+1, etc).
 Old Forth versions such as FIG Forth call this U*</p>
-</dd>
-</dl>
-</div>
-<div class="paragraph">
-<p>Consider switching to a table-supported version based on
-<a href="http://codebase64.org/doku.php?id=base:seriously_fast_multiplication" class="bare">http://codebase64.org/doku.php?id=base:seriously_fast_multiplication</a>
-<a href="http://codebase64.org/doku.php?id=magazines:chacking16#d_graphics_for_the_masseslib3d&gt" class="bare">http://codebase64.org/doku.php?id=magazines:chacking16#d_graphics_for_the_masseslib3d&gt</a>;
-<a href="http://forum.6502.org/viewtopic.php?p=205#p205" class="bare">http://forum.6502.org/viewtopic.php?p=205#p205</a>
-<a href="http://forum.6502.org/viewtopic.php?f=9&amp;t=689" class="bare">http://forum.6502.org/viewtopic.php?f=9&amp;t=689</a></p>
-</div>
-<div class="dlist">
-<dl>
-<dt class="hdlist1"><code>um/mod</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>um/mod</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( ud u&#8201;&#8212;&#8201;ur u ) "32/16 &#8594; 16 division"
 <a href="https://forth-standard.org/standard/core/UMDivMOD" class="bare">https://forth-standard.org/standard/core/UMDivMOD</a>
 Divide double cell number by single cell number, returning the
@@ -9189,66 +9385,106 @@ This is the basic division operation all others use. Based on FIG
 Forth code, modified by Garth Wilson, see
 <a href="http://6502.org/source/integers/ummodfix/ummodfix.htm" class="bare">http://6502.org/source/integers/ummodfix/ummodfix.htm</a>
 This uses tmp1, tmp1+1, and tmptos</p>
-</dd>
-<dt class="hdlist1"><code>unloop</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>unloop</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> (&#8201;&#8212;&#8201;)(R: n1 n2 n3 ---) "Drop loop control from Return stack"
 <a href="https://forth-standard.org/standard/core/UNLOOP" class="bare">https://forth-standard.org/standard/core/UNLOOP</a>
 Note that 6xPLA uses just as many bytes as a loop would</p>
-</dd>
-<dt class="hdlist1"><code>until</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>until</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> (C: dest&#8201;&#8212;&#8201;) (&#8201;&#8212;&#8201;) "Loop flow control"
 <a href="http://forth-standard.org/standard/core/UNTIL" class="bare">http://forth-standard.org/standard/core/UNTIL</a></p>
-</dd>
-<dt class="hdlist1"><code>unused</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>unused</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core ext</em> (&#8201;&#8212;&#8201;u ) "Return size of space available to Dictionary"
 <a href="https://forth-standard.org/standard/core/UNUSED" class="bare">https://forth-standard.org/standard/core/UNUSED</a>
 UNUSED does not include the ACCEPT history buffers. Total RAM
 should be HERE + UNUSED + &lt;history buffer size&gt;, the last of which
 defaults to $400</p>
-</dd>
-<dt class="hdlist1"><code>update</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>update</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS block</em> (&#8201;&#8212;&#8201;) "Mark current block as dirty"
 <a href="https://forth-standard.org/standard/block/UPDATE" class="bare">https://forth-standard.org/standard/block/UPDATE</a></p>
-</dd>
-<dt class="hdlist1"><code>useraddr</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>useraddr</code>
+</td>
+<td class="hdlist2">
 <p><em>Tali Forth</em> (&#8201;&#8212;&#8201;addr ) "Push address of base address of user variables"</p>
-</dd>
-<dt class="hdlist1"><code>value</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>value</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( n "name"&#8201;&#8212;&#8201;) "Define a value"
 <a href="https://forth-standard.org/standard/core/VALUE" class="bare">https://forth-standard.org/standard/core/VALUE</a>
 This is a dummy header for the WORDLIST. The actual code is
 identical to that of CONSTANT</p>
-</dd>
-<dt class="hdlist1"><code>variable</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>variable</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( "name"&#8201;&#8212;&#8201;) "Define a variable"
 <a href="https://forth-standard.org/standard/core/VARIABLE" class="bare">https://forth-standard.org/standard/core/VARIABLE</a>
 There are various Forth definitions for this word, such as
 CREATE 1 CELLS ALLOT  or  CREATE 0 ,  We use a variant of the
 second one so the variable is initialized to zero</p>
-</dd>
-<dt class="hdlist1"><code>while</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>while</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( C: dest&#8201;&#8212;&#8201;orig dest ) ( x&#8201;&#8212;&#8201;) "Loop flow control"
 <a href="http://forth-standard.org/standard/core/WHILE" class="bare">http://forth-standard.org/standard/core/WHILE</a></p>
-</dd>
-<dt class="hdlist1"><code>within</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>within</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core ext</em> ( n1 n2 n3&#8201;&#8212;&#8201;) "See if within a range"
 <a href="https://forth-standard.org/standard/core/WITHIN" class="bare">https://forth-standard.org/standard/core/WITHIN</a>
 This an assembler version of the ANS Forth implementation
 at <a href="https://forth-standard.org/standard/core/WITHIN" class="bare">https://forth-standard.org/standard/core/WITHIN</a> which is
 OVER - &gt;R - R&gt; U&lt;  note there is an alternative high-level version
 ROT TUCK &gt; -ROT &gt; INVERT AND</p>
-</dd>
-<dt class="hdlist1"><code>word</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>word</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( char "name "&#8201;&#8212;&#8201;caddr ) "Parse input stream"
 <a href="https://forth-standard.org/standard/core/WORD" class="bare">https://forth-standard.org/standard/core/WORD</a>
 Obsolete parsing word included for backwards compatibility only.
@@ -9261,14 +9497,22 @@ Programmer&#8217;s Handbook" 3rd edition p. 159 and
 for discussions of why you shouldn&#8217;t be using WORD anymore. Forth
 would be   PARSE DUP BUFFER1 C! OUTPUT 1+ SWAP MOVE BUFFER1
 We only allow input of 255 chars. Seriously, use PARSE-NAME.</p>
-</dd>
-<dt class="hdlist1"><code>wordlist</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>wordlist</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS search</em> (&#8201;&#8212;&#8201;wid ) "Create new wordlist (from pool of 8)"
 <a href="https://forth-standard.org/standard/search/WORDLIST" class="bare">https://forth-standard.org/standard/search/WORDLIST</a></p>
-</dd>
-<dt class="hdlist1"><code>words</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>words</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS tools</em> (&#8201;&#8212;&#8201;) "Print known words from Dictionary"
 <a href="https://forth-standard.org/standard/tools/WORDS" class="bare">https://forth-standard.org/standard/tools/WORDS</a>
 This is pretty much only used at the command line so we can
@@ -9276,20 +9520,29 @@ be slow and try to save space. DROP must always be the first word in a
 clean system (without Forth words), BYE the last. There is no reason
 why we couldn&#8217;t define this as a high level word except that it is
 really useful for testing</p>
-</dd>
-<dt class="hdlist1"><code>wordsize</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>wordsize</code>
+</td>
+<td class="hdlist2">
 <p><em>Tali Forth</em> ( nt&#8201;&#8212;&#8201;u ) "Get size of word in bytes"
 Given an word&#8217;s name token (nt), return the size of the
 word&#8217;s payload size in bytes (CFA plus PFA) in bytes. Does not
 count the final RTS.</p>
-</dd>
-<dt class="hdlist1"><code>xor</code></dt>
-<dd>
+</td>
+</tr>
+<tr>
+<td class="hdlist1">
+<code>xor</code>
+</td>
+<td class="hdlist2">
 <p><em>ANS core</em> ( n n&#8201;&#8212;&#8201;n ) "Logically XOR TOS and NOS"
 <a href="https://forth-standard.org/standard/core/XOR" class="bare">https://forth-standard.org/standard/core/XOR</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+</table>
 </div>
 </div>
 </div>

--- a/native_words.asm
+++ b/native_words.asm
@@ -6897,7 +6897,7 @@ z_or:           rts
         ; 	           . ( just print the number )
         ; 	then then then then ;
         ;
-	    ; : ORDER ( -- )
+        ; : ORDER ( -- )
         ; 	cr get-order 0 ?do .wid loop
         ; 	space space get-current .wid ;
         ;

--- a/native_words.asm
+++ b/native_words.asm
@@ -5867,9 +5867,13 @@ z_m_star:       rts
 ; ## "marker"  auto  ANS core ext
         ; """https://forth-standard.org/standard/core/MARKER
         ; This word replaces FORGET in earlier Forths. Old entries are not
-        ; actually deleted, but merely overwritten by restoring CP and DP. To
-        ; do this, we want to end up with something that jumps to a run-time
-        ; component with a link to the original CP and DP values:
+        ; actually deleted, but merely overwritten by restoring CP and DP.
+        ; Run the named word at a later time to restore all of the wordlists
+        ; to their state when the word was created with marker.  Any words
+        ; created after the marker (including the marker) will be forgotten.
+
+        ; To do this, we want to end up with something that jumps to a
+        ; run-time component with a link to the original CP and DP values:
         ;
         ;       jsr marker_runtime
         ;       <Original CP MSB>
@@ -7144,6 +7148,7 @@ _char_found:
         ; skip leading delimiters -- this is the main difference to PARSE-NAME.
         ; PARSE and PARSE-NAME replace WORD in modern systems. ANS discussion
         ; http://www.forth200x.org/documents/html3/rationale.html#rat:core:PARSE 
+
         ;
         ;     cib  cib+toin   cib+ciblen
         ;      v      v            v
@@ -9744,7 +9749,9 @@ z_tick:         rts
 ; ## TO ( n "name" -- ) or ( "name") "Change a value"
 ; ## "to"  auto  ANS core ext
         ; """https://forth-standard.org/standard/core/TO
-        ; Gives a new value to a, uh, VALUE. One possible Forth
+        ; Gives a new value to a, uh, VALUE.
+
+        ; One possible Forth
         ; implementation is  ' >BODY !  but given the problems we have
         ; with >BODY on STC Forths, we do this the hard way. Since 
         ; Tali Forth uses the same code for CONSTANTs and VALUEs, you
@@ -10878,12 +10885,15 @@ z_um_slash_mod: rts
 ; ## "um*"  auto  ANS core
         ; """https://forth-standard.org/standard/core/UMTimes
         ; Multiply two unsigned 16 bit numbers, producing a 32 bit result.
+        ; Old Forth versions such as FIG Forth call this U*
+        
         ; This is based on modified FIG Forth code by Dr. Jefyll, see
         ; http://forum.6502.org/viewtopic.php?f=9&t=689 for a detailed
-        ; discussion. We don't use the system scratch pad (SYSPAD) for temp
+        ; discussion.
+        ;
+        ; We don't use the system scratch pad (SYSPAD) for temp
         ; storage because >NUMBER uses it as well, but instead tmp1 to
         ; tmp3 (tmp1 is N in the original code, tmp1+1 is N+1, etc).
-        ; Old Forth versions such as FIG Forth call this U* 
         ;
         ; Consider switching to a table-supported version based on
         ; http://codebase64.org/doku.php?id=base:seriously_fast_multiplication

--- a/native_words.asm
+++ b/native_words.asm
@@ -738,10 +738,13 @@ z_again:        rts
 ; ## ALIGN ( -- ) "Make sure CP is aligned on word size"
 ; ## "align"  auto  ANS core
         ; """https://forth-standard.org/standard/core/ALIGN
-        ; On a 8-bit machine, this does nothing. ALIGNED uses
-        ; this routine as well, and also does nothing
+        ; On a 8-bit machine, this does nothing.
+        ;
+        ; ALIGNED uses this routine as well, and also does nothing
+        
 ; ## ALIGNED ( addr -- addr ) "Return the first aligned address"
 ; ## "aligned"  auto  ANS core
+        ; """https://forth-standard.org/standard/core/ALIGNED"""
 .scope
 xt_align:
 xt_aligned:
@@ -943,7 +946,9 @@ z_and:          rts
 ; ## "at-xy"  tested  ANS facility
         ; """https://forth-standard.org/standard/facility/AT-XY
         ; On an ANS compatible terminal, place cursor at row n colum m. 
-        ; Code is ESC[<n>;<m>H Do not use U. to print the numbers because the 
+        ; Code is ESC[<n>;<m>H
+        ;
+        ; Do not use U. to print the numbers because the 
         ; trailing space will not work with xterm 
         ; """
 xt_at_xy:       
@@ -992,6 +997,7 @@ z_base:         rts
 ; ## BEGIN ( -- addr ) "Mark entry point for loop"
 ; ## "begin"  auto  ANS core
         ; """https://forth-standard.org/standard/core/BEGIN
+        ; 
         ; This is just an immediate version of here which could just
         ; as well be coded in Forth as
         ;       : BEGIN HERE ; IMMEDIATE COMPILE-ONLY
@@ -1147,7 +1153,7 @@ z_block:        rts
         ; """Create a RAM drive, with the given number of
         ; blocks, in the dictionary along with setting up the block words to
         ; use it.  The read/write routines do not provide bounds checking.
-        ; Expected use: 4 block-ramdrive-init ( to create blocks 0-3 )
+        ; Expected use: `4 block-ramdrive-init` ( to create blocks 0-3 )
         ; """
 .scope
 xt_block_ramdrive_init:
@@ -1279,7 +1285,7 @@ z_block_write_vector:
 ; ## "bounds"  auto  Gforth
         ; """http://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Memory-Blocks.html
         ; Given a string, return the correct Data Stack parameters for
-        ; a DO/LOOP loop; over its characters. This is realized as
+        ; a DO/LOOP loop over its characters. This is realized as
         ; OVER + SWAP in Forth, but we do it a lot faster in assembler
         ; """
 xt_bounds:
@@ -1305,7 +1311,9 @@ z_bounds:       rts
 ; ## "[char]"  auto  ANS core
         ; """https://forth-standard.org/standard/core/BracketCHAR
         ; Compile the ASCII value of a character as a literal. This is an
-        ; immediate, compile-only word. A definition given in 
+        ; immediate, compile-only word.
+        ;
+        ; A definition given in 
         ; http://forth-standard.org/standard/implement is 
         ; : [CHAR]  CHAR POSTPONE LITERAL ; IMMEDIATE
         ; """
@@ -1479,6 +1487,7 @@ z_c_store:      rts
 ; ## CASE (C: -- 0) ( -- ) "Conditional flow control"
 ; ## "case"  auto  ANS core ext
         ; """http://forth-standard.org/standard/core/CASE
+        ;
         ; This is a dummy header, CASE shares the actual code with ZERO.
         ; """
 
@@ -1508,6 +1517,7 @@ z_cell_plus:    rts
 ; ## CELLS ( u -- u ) "Convert cells to size in bytes"
 ; ## "cells"  auto  ANS core
         ; """https://forth-standard.org/standard/core/CELLS
+        ;
         ; Dummy entry for the CELLS word, the code is the same as for 
         ; 2*, which is where the header directs us to
         ; """
@@ -1545,6 +1555,7 @@ z_char:         rts
 ; ## CHAR_PLUS ( addr -- addr+1 ) "Add the size of a character unit to address"
 ; ## "char+"  auto  ANS core
         ; """https://forth-standard.org/standard/core/CHARPlus
+        ;
         ; This is a dummy entry, the code is shared with ONE_PLUS
         ; """ 
 
@@ -1572,11 +1583,12 @@ z_chars:        rts
 
         ; """Given a range of memory with words delimited by whitespace,return
         ; the first word at the top of the stack and the rest of the word
-        ; following it. Example: 
-
+        ; following it.
+        ;
+        ; Example: 
         ; s" w1 w2 w3" cleave  -> "w2 w3" "w1"
         ; s" w1" cleave        -> "" "w1"
-
+        ;
         ; Since it will be used in loops a lot, we want it to work in pure
         ; assembler and be as fast as we can make it. Calls PARSE-NAME so we
         ; strip leading delimiters.
@@ -1660,7 +1672,9 @@ z_cleave:       rts
         ; Copy u bytes from addr1 to addr2, going low to high (addr2 is
         ; larger than addr1). Based on code in Leventhal, Lance A. 
         ; "6502 Assembly Language Routines", p. 201, where it is called 
-        ; "move left". There are no official tests for this word.
+        ; "move left".
+        ;
+        ; There are no official tests for this word.
         ; """
 .scope
 xt_cmove:
@@ -1716,8 +1730,9 @@ z_cmove:        rts
 ; ## "cmove>"  auto  ANS string
         ; """https://forth-standard.org/standard/string/CMOVEtop
         ; Based on code in Leventhal, Lance A. "6502 Assembly Language
-        ; Routines", p. 201, where it is called "move right". There are 
-        ; no official tests for this word.
+        ; Routines", p. 201, where it is called "move right".
+        ;
+        ; There are no official tests for this word.
         ; """
 .scope
 xt_cmove_up:
@@ -1773,6 +1788,7 @@ z_cmove_up:     rts
 ; ## COLON ( "name" -- ) "Start compilation of a new word"
 ; ## ":"  auto  ANS core
         ; """https://forth-standard.org/standard/core/Colon
+        ;
         ; Use the CREATE routine and fill in the rest by hand.
         ; """
 .scope
@@ -1881,8 +1897,9 @@ z_colon_noname:        rts
 ; ## COMMA ( n -- ) "Allot and store one cell in memory"
 ; ## ","  auto  ANS core
         ; """https://forth-standard.org/standard/core/Comma
-        ; Store TOS at current place in memory. Since this an eight-bit
-        ; machine, we can ignore all alignment issures.
+        ; Store TOS at current place in memory.
+        ;
+        ; Since this an eight-bit machine, we can ignore all alignment issues.
         ; """
 .scope
 xt_comma:
@@ -2314,7 +2331,9 @@ z_compile_comma:
 ; ## COMPILE_ONLY ( -- ) "Mark most recent word as COMPILE-ONLY"
 ; ## "compile-only"  tested  Tali Forth
         ; """Set the Compile Only flag (CO) of the most recently defined
-        ; word. The alternative way to do this is to define a word 
+        ; word.
+        ;
+        ; The alternative way to do this is to define a word 
         ; ?COMPILE that makes sure  we're in compile mode
         ; """
 .scope
@@ -2332,6 +2351,7 @@ z_compile_only: rts
 ; ## CONSTANT ( n "name" -- ) "Define a constant"
 ; ## "constant"  auto  ANS core
         ; """https://forth-standard.org/standard/core/CONSTANT
+        ;
         ; Forth equivalent is  CREATE , DOES> @  but we do
         ; more in assembler and let CREATE do the heavy lifting.
         ; See http://www.bradrodriguez.com/papers/moving3.htm for
@@ -2398,7 +2418,7 @@ z_constant:     rts
 ; ## "count"  auto  ANS core
         ; """https://forth-standard.org/standard/core/COUNT
         ; Convert old-style character string to address-length pair. Note
-        ; that the length of the string c-addr ist stored in character length
+        ; that the length of the string c-addr is stored in character length
         ; (8 bit), not cell length (16 bit). This is rarely used these days,
         ; though COUNT can also be used to step through a string character by
         ; character. 
@@ -2436,6 +2456,7 @@ z_cr:           rts
 ; ## CREATE ( "name" -- ) "Create Dictionary entry for 'name'"
 ; ## "create"  auto  ANS core
         ; """https://forth-standard.org/standard/core/CREATE
+        ;
         ; See the drawing in headers.asm for details on the header
         ; """
 .scope
@@ -2792,8 +2813,9 @@ z_decimal:      rts
 ; ## DEFER ( "name" -- ) "Create a placeholder for words by name"
 ; ## "defer"  auto  ANS core ext
         ; """https://forth-standard.org/standard/core/DEFER
-        ; Reserve an name that can be linked to various xt by IS. The
-        ; ANS reference implementation is 
+        ; Reserve an name that can be linked to various xt by IS.
+        ; 
+        ; The ANS reference implementation is 
         ;       CREATE ['] ABORT , DOES> @ EXECUTE ;
         ; But we use this routine as a low-level word so things go faster
 .scope
@@ -3021,6 +3043,7 @@ xt_question_do:
 ; ## DO ( limit start -- )(R: -- limit start)  "Start a loop"
 ; ## "do"  auto  ANS core
         ; """https://forth-standard.org/standard/core/DO
+        ; 
         ; Compile-time part of DO. Could be realized in Forth as
         ;       : DO POSTPONE (DO) HERE ; IMMEDIATE COMPILE-ONLY
         ; but we do it in assembler for speed. To work with LEAVE, we compile
@@ -3201,7 +3224,9 @@ question_do_runtime_end:
         ; Create the payload for defining new defining words. See
         ; http://www.bradrodriguez.com/papers/moving3.htm and 
         ; docs/create-does.txt for a discussion of
-        ; DOES>'s internal workings. This uses tmp1 and tmp2
+        ; DOES>'s internal workings.
+        ;
+        ; This uses tmp1 and tmp2
         ; """
 .scope
 xt_does:
@@ -3344,6 +3369,7 @@ z_dot_quote:    rts
 ; ## DOT_R ( n u -- ) "Print NOS as unsigned number with TOS with"
 ; ## ".r"  tested  ANS core ext
         ; """https://forth-standard.org/standard/core/DotR
+        ;
         ; Based on the Forth code
         ;  : .R  >R DUP ABS 0 <# #S ROT SIGN #> R> OVER - SPACES TYPE ;
         ; """
@@ -3373,10 +3399,11 @@ z_dot_r:      rts
 ; ## DOT_S ( -- ) "Print content of Data Stack"
 ; ## ".s"  tested  ANS tools 
         ; """https://forth-standard.org/standard/tools/DotS
-        ; Print content of Data Stack non-distructively. Since this is for
-        ; humans, we don't have to worry about speed. We follow the format
+        ; Print content of Data Stack non-distructively. We follow the format
         ; of Gforth and print the number of elements first in brackets,
         ; followed by the Data Stack content (if any).
+        ;
+        ; Since this is for humans, we don't have to worry about speed. 
         ; """
 .scope
 xt_dot_s:
@@ -3451,6 +3478,7 @@ z_dot_s:        rts
 ; ## D_DOT ( d -- ) "Print double"
 ; ## "d."  tested  ANS double
         ; """http://forth-standard.org/standard/double/Dd"""
+        ;
         ; From the Forth code:
         ; : D. TUCK DABS <# #S ROT SIGN #> TYPE SPACE ;
         ; """
@@ -3513,6 +3541,7 @@ z_drop:         rts
 ; ## DUMP ( addr u -- ) "Display a memory region"
 ; ## "dump"  tested  ANS tools
         ; """https://forth-standard.org/standard/tools/DUMP
+        ; 
         ; DUMP's exact output is defined as "implementation dependent".
         ; This is in assembler because it is 
         ; useful for testing and development, so we want to have it work
@@ -3652,7 +3681,7 @@ z_dup:          rts
 ; ## ED ( -- u ) "Line-based editor"
 ; ## "ed"  fragment  Tali Forth
         ; """Start the line-based editor ed6502. See separate file
-        ; for details.
+        ; ed.asm or the manual for details.
         ; """
 xt_ed:
                 jsr ed6502      ; kept in separate file
@@ -3662,12 +3691,14 @@ z_ed:       rts
 
 ; ## EDITOR_WORDLIST ( -- u ) "WID for the Editor wordlist"
 ; ## "editor-wordlist"  tested  Tali Editor
+        ;
         ; """This is a dummy entry, the code is shared with ONE"""
 
 
 ; ## ELSE (C: orig -- orig) ( -- ) "Conditional flow control"
 ; ## "else"  auto  ANS core
         ; """http://forth-standard.org/standard/core/ELSE
+        ;
         ; The code is shared with ENDOF
         ; """
 .scope
@@ -3731,7 +3762,7 @@ branch_runtime:
         ; Run-time default for EMIT. The user can revector this by changing
         ; the value of the OUTPUT variable. We ignore the MSB completely, and 
         ; do not check to see if we have been given a valid ASCII character. 
-        ; Don't make this native compile
+        ; Don't make this native compile.
         ; """
 .scope
 xt_emit:
@@ -3805,7 +3836,7 @@ z_endcase:      rts
 ; ## ENVIRONMENT_Q  ( addr u -- 0 | i*x true )  "Return system information"
 ; ## "environment?"  auto  ANS core
         ; """https://forth-standard.org/standard/core/ENVIRONMENTq
-
+        ;
         ; By ANS definition, we use upper-case strings here, see the
         ; string file for details. This can be realized as a high-level
         ; Forth word as
@@ -4196,7 +4227,9 @@ doexecute:
         ; """https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/The-Input-Stream.html
         ; Execute the parsing word defined by the execution token (xt) on the
         ; string as if it were passed on the command line. See the file
-        ; tests/tali.fs for examples. Note that this word is coded completely
+        ; tests/tali.fs for examples.
+        ;
+        ; Note that this word is coded completely
         ; different in its Gforth version, see the file execute-parsing.fs
         ; (in /usr/share/gforth/0.7.3/compat/ on Ubuntu 18.04 LTS) for details.
         ; """
@@ -4233,7 +4266,7 @@ z_execute_parsing:
         ; """https://forth-standard.org/standard/core/EXIT
         ; If we're in a loop, we need to UNLOOP first and get everything
         ; we we might have put on the Return Stack off as well. This should
-        ; be natively compiled
+        ; be natively compiled.
         ; """
 .scope
 xt_exit:        
@@ -4557,13 +4590,14 @@ z_flush:
 ; ## FM_SLASH_MOD ( d n1  -- rem n2 ) "Floored signed division"
 ; ## "fm/mod"  auto  ANS core
         ; """https://forth-standard.org/standard/core/FMDivMOD
+        ; Note that by default, Tali Forth uses SM/REM for most things.
+        ; 
         ; There are various ways to realize this. We follow EForth with
         ;    DUP 0< DUP >R  IF NEGATE >R DNEGATE R> THEN >R DUP
         ;    0<  IF R@ + THEN  R> UM/MOD R> IF SWAP NEGATE SWAP THEN 
         ; See (http://www.forth.org/eforth.html). However you can also
         ; go FM/MOD via SM/REM (http://www.figuk.plus.com/build/arith.htm):
         ;     DUP >R  SM/REM DUP 0< IF SWAP R> + SWAP 1+ ELSE  R> DROP THEN 
-        ; Note that by default, Tali Forth uses SM/REM for most things.
         ; """
 .scope
 xt_fm_slash_mod:
@@ -4933,6 +4967,7 @@ z_hexstore:     rts
         ; Insert a character at the current position of a pictured numeric
         ; output string on 
         ; https://github.com/philburk/pforth/blob/master/fth/numberio.fth
+        ; 
         ; Forth code is : HOLD  -1 HLD +!  HLD @ C! ;  We use the the internal
         ; variable tohold instead of HLD.
         ; """
@@ -4957,8 +4992,9 @@ z_hold:         rts
 ; ## "i"  auto  ANS core
         ; """https://forth-standard.org/standard/core/I
         ; Note that this is not the same as R@ because we use a fudge
-        ; factor for loop control; see docs/loop.txt for details. We
-        ; should make this native compile for speed. 
+        ; factor for loop control; see docs/loop.txt for details.
+        ;
+        ; We should make this native compile for speed. 
         ; """
 .scope
 xt_i:           
@@ -5106,21 +5142,23 @@ z_input:        rts
 
 ; ## INPUT_TO_R ( -- ) ( R: -- n n n n ) "Save input state to the Return Stack"
 ; ## "input>r"  tested  Tali Forth
-   	; """Save the current input state as defined by insrc, cib, ciblen, and
-        ; toin to the Return Stack. Used by EVALUTE. The naive way of doing
+   	    ; """Save the current input state as defined by insrc, cib, ciblen, and
+        ; toin to the Return Stack. Used by EVALUTE.
+        ;
+        ; The naive way of doing
         ; this is to push each two-byte variable to the stack in the form of
-
+        ;
         ;       lda insrc
         ;       pha
         ;       lda insrc+1
         ;       pha
-
+        ;
         ; for a total of 24 byte of instruction in one direction and later
         ; a further 24 bytes to reverse the process. We shorten this at the
         ; cost of some speed by assuming the four variables are grouped
         ; together on the Zero Page and start with insrc (see definitions.asm
         ; for details). The reverse operation is r_to_input. These words must 
-	; be flagged as Never Native. Uses tmp1
+	    ; be flagged as Never Native. Uses tmp1
         ; """ 
 .scope
 xt_input_to_r: 
@@ -5409,6 +5447,7 @@ z_latestxt:     rts
         ; Note that this does not work with  anything but a DO/LOOP in
         ; contrast to other versions such as discussed at
         ; http://blogs.msdn.com/b/ashleyf/archive/2011/02/06/loopty-do-i-loop.aspx
+        ;
         ;       : LEAVE POSTPONE BRANCH HERE SWAP 0 , ; IMMEDIATE COMPILE-ONLY
         ; See docs/loops.txt on details of how this works. This must be native
         ; compile and not IMMEDIATE
@@ -5442,7 +5481,9 @@ z_left_bracket: rts
 ; ## LESS_NUMBER_SIGN ( -- ) "Start number conversion"
 ; ## "<#"  auto  ANS core
         ; """https://forth-standard.org/standard/core/num-start
-        ; Start the process to create pictured numeric output. The new
+        ; Start the process to create pictured numeric output.
+        ;
+        ; The new
         ; string is constructed from back to front, saving the new character
         ; at the beginning of the output string. Since we use PAD as a 
         ; starting address and work backward (!), the string is constructed
@@ -5517,6 +5558,7 @@ z_list:         rts
         ; Compile-only word to store TOS so that it is pushed on stack
         ; during runtime. This is a immediate, compile-only word. At runtime,
         ; it works by calling literal_runtime by compling JSR LITERAL_RT.
+        ; 
         ; Note the cmpl_ routines use TMPTOS
         ; """
 xt_literal:     
@@ -5574,8 +5616,9 @@ literal_runtime:
 ; ## LOAD ( scr# -- ) "Load the Forth code in a screen/block"
 ; ## "load"  auto  ANS block
         ; """https://forth-standard.org/standard/block/LOAD
+        ; 
         ; Note: LOAD current works because there is only one buffer.
-        ; if/when multiple buffers are supported, we'll have to deal
+        ; If/when multiple buffers are supported, we'll have to deal
         ; with the fact that it might re-load the old block into a
         ; different buffer.
         ; """
@@ -5647,7 +5690,9 @@ z_load:         rts
 ; ## "loop"  auto  ANS core
         ; """https://forth-standard.org/standard/core/LOOP
         ; Compile-time part of LOOP. This does nothing more but push 1 on
-        ; the stack and then call +LOOP. In Forth, this is 
+        ; the stack and then call +LOOP.
+        ;
+        ; In Forth, this is 
         ;       : LOOP  POSTPONE 1 POSTPONE (+LOOP) , POSTPONE UNLOOP ;
         ;       IMMEDIATE ; COMPILE-ONLY
         ; This drops through to +LOOP
@@ -5662,6 +5707,7 @@ xt_loop:
 ; ## PLUS_LOOP ( -- ) "Finish loop construct"
 ; ## "+loop"  auto  ANS core
         ; """https://forth-standard.org/standard/core/PlusLOOP
+        ;
         ; Compile-time part of +LOOP, also used for LOOP. Is usually
         ;       : +LOOP POSTPONE (+LOOP) , POSTPONE UNLOOP ; IMMEDIATE
         ;       COMPILE-ONLY 
@@ -5828,8 +5874,9 @@ z_lshift:       rts
 ; ## "m*"  auto  ANS core
         ; """https://forth-standard.org/standard/core/MTimes
         ; Multiply two 16 bit numbers, producing a 32 bit result. All
-        ; values are signed. Adapted from FIG Forth for Tali Forth. The
-        ; original Forth is : M* OVER OVER XOR >R ABS SWAP ABS UM* R> D+- ;
+        ; values are signed. Adapted from FIG Forth for Tali Forth.
+        ;
+        ; The original Forth is : M* OVER OVER XOR >R ABS SWAP ABS UM* R> D+- ;
         ; with  : D+- O< IF DNEGATE THEN ;
         ; """
 .scope
@@ -5871,7 +5918,7 @@ z_m_star:       rts
         ; Run the named word at a later time to restore all of the wordlists
         ; to their state when the word was created with marker.  Any words
         ; created after the marker (including the marker) will be forgotten.
-
+        ;
         ; To do this, we want to end up with something that jumps to a
         ; run-time component with a link to the original CP and DP values:
         ;
@@ -6200,6 +6247,7 @@ z_minus_trailing:
 ; ## MOD ( n1 n2 -- n ) "Divide NOS by TOS and return the remainder"
 ; ## "mod"  auto  ANS core
         ; """https://forth-standard.org/standard/core/MOD
+        ; 
         ; The Forth definition of this word is  : MOD /MOD DROP ;  
         ; so we just jump to xt_slash_mod and dump the actual result.
         ; """
@@ -6220,7 +6268,9 @@ z_mod:
         ; Copy u "address units" from addr1 to addr2. Since our address
         ; units are bytes, this is just a front-end for CMOVE and CMOVE>. This
         ; is actually the only one of these three words that is in the CORE
-        ; set. This word must not be natively compiled
+        ; set.
+        ;
+        ; This word must not be natively compiled.
         ; """
 .scope
 xt_move:
@@ -6383,6 +6433,7 @@ z_nip:          rts
 ; ## NOT_EQUALS ( n m -- f ) "Return a true flag if TOS != NOS"
 ; ## "<>"  auto  ANS core ext
         ; """https://forth-standard.org/standard/core/ne
+        ; 
         ; This is just a variant of EQUAL, we code it separately
         ; for speed.
         ; """
@@ -6455,7 +6506,9 @@ z_not_rote:     rts
         ; https://www.complang.tuwien.ac.at/forth/gforth/Docs-html/Number-Conversion.html
         ; Another difference to Gforth is that we follow ANS Forth that the
         ; dot to signal a double cell number is required to be the last
-        ; character of the string. Number calls >NUMBER which in turn calls UM*,
+        ; character of the string.
+        ;
+        ; Number calls >NUMBER which in turn calls UM*,
         ; which uses tmp1, tmp2, and tmp3, so we can't use them here, which is
         ; a pain. 
         ;"""
@@ -6598,8 +6651,10 @@ z_number:       rts
 ; ## NUMBER_SIGN ( ud -- ud ) "Add character to pictured output string"
 ; ## "#"  auto  ANS core
         ; """https://forth-standard.org/standard/core/num
-        ; Add one char to the beginning of the pictured output string. Based
-        ; on https://github.com/philburk/pforth/blob/master/fth/numberio.fth
+        ; Add one char to the beginning of the pictured output string.
+        ;
+        ; Based on
+        ; https://github.com/philburk/pforth/blob/master/fth/numberio.fth
         ; Forth code  BASE @ UD/MOD ROT 9 OVER < IF 7 + THEN [CHAR] 0 + HOLD ;
         ; """
 xt_number_sign:        
@@ -6645,7 +6700,9 @@ z_number_sign:
 ; ## "#>"  auto  ANS core
         ; """https://forth-standard.org/standard/core/num-end
         ; Finish conversion of pictured number string, putting address and
-        ; length on the Data Stack. Original Fort is  2DROP HLD @ PAD OVER -
+        ; length on the Data Stack.
+        ;
+        ; Original Fort is  2DROP HLD @ PAD OVER -
         ; Based on
         ; https://github.com/philburk/pforth/blob/master/fth/numberio.fth
         ; """
@@ -6683,7 +6740,9 @@ z_number_sign_greater:
 ; ## NUMBER_SIGN_S ( d -- addr u ) "Completely convert pictured output"
 ; ## "#s"  auto  ANS core
         ; """https://forth-standard.org/standard/core/numS
-        ; Completely convert number for pictured numerical output. Based on
+        ; Completely convert number for pictured numerical output.
+        ;
+        ; Based on
         ; https://github.com/philburk/pforth/blob/master/fth/system.fth
         ; Original Forth code  BEGIN # 2DUP OR 0= UNTIL
         ; """
@@ -6767,6 +6826,7 @@ z_one_minus:    rts
 ; ## ONE_PLUS ( u -- u+1 ) "Increase TOS by one"
 ; ## "1+"  auto  ANS core
         ; """https://forth-standard.org/standard/core/OnePlus
+        ;
         ; Code is shared with CHAR-PLUS
         ; """
 .scope
@@ -6823,8 +6883,12 @@ z_or:           rts
 ; ## ORDER ( -- ) "Print current word order list and current WID"
 ; ## "order"  auto  ANS core
         ; """https://forth-standard.org/standard/search/ORDER
+        ; Note the search order is displayed from first search to last
+        ; searched and is therefore exactly the reverse of the order in which
+        ; Forth stacks are displayed.
+        ;
         ; A Forth implementation of this word is:
-
+        ;
         ; 	: .wid ( wid -- )
         ; 	dup 0=  if ." FORTH "  drop    else
         ; 	dup 1 = if ." EDITOR " drop    else
@@ -6832,14 +6896,12 @@ z_or:           rts
         ; 	dup 3 = if ." ROOT " drop      else
         ; 	           . ( just print the number )
         ; 	then then then then ;
-
-	; 	: ORDER ( -- )
+        ;
+	    ; : ORDER ( -- )
         ; 	cr get-order 0 ?do .wid loop
         ; 	space space get-current .wid ;
-        
-        ; Note the search order is displayed from first search to last
-        ; searched and is therefore exactly the reverse of the order in which
-        ; Forth stacks are displayed. This is an interactive program, so speed
+        ;
+        ; This is an interactive program, so speed
         ; is not as important as size. We assume we do not have more than 255
         ; wordlists.
         ; """
@@ -7148,7 +7210,7 @@ _char_found:
         ; skip leading delimiters -- this is the main difference to PARSE-NAME.
         ; PARSE and PARSE-NAME replace WORD in modern systems. ANS discussion
         ; http://www.forth200x.org/documents/html3/rationale.html#rat:core:PARSE 
-
+        ;
         ;
         ;     cib  cib+toin   cib+ciblen
         ;      v      v            v
@@ -7408,8 +7470,9 @@ z_plus_store:   rts
         ; Add the compilation behavior of a word to a new word at
         ; compile time. If the word that follows it is immediate, include
         ; it so that it will be compiled when the word being defined is
-        ; itself used for a new word. Tricky, but very useful. Because
-        ; POSTPONE expects a word (not an xt) in the input stream (not
+        ; itself used for a new word. Tricky, but very useful.
+        ;
+        ; Because POSTPONE expects a word (not an xt) in the input stream (not
         ; on the Data Stack). This means we cannot build words with
         ; "jsr xt_postpone, jsr <word>" directly.
         ; """
@@ -7491,6 +7554,7 @@ z_previous:     rts
 ; ## QUESTION ( addr -- ) "Print content of a variable"
 ; ## "?"  tested  ANS tools
         ; """https://forth-standard.org/standard/tools/q
+        ;
         ; Only used interactively. Since humans are so slow, we
         ; save size and just go for the subroutine jumps
         ; """
@@ -7530,7 +7594,9 @@ z_question_dup: rts
 ; ## "r@"  auto  ANS core
         ; """https://forth-standard.org/standard/core/RFetch
         ; This word is Compile Only in Tali Forth, though Gforth has it
-        ; work normally as well -- An alternative way to write this word
+        ; work normally as well
+        ;
+        ; An alternative way to write this word
         ; would be to access the elements on the stack directly like 2R@
         ; does, these versions should be compared at some point.
         ; """
@@ -7569,7 +7635,9 @@ z_r_fetch:      rts
 ; ## R_FROM ( -- n )(R: n --) "Move top of Return Stack to TOS"
 ; ## "r>"  auto  ANS core
         ; """https://forth-standard.org/standard/core/Rfrom
-        ; Move Top of Return Stack to Top of Data Stack. We have to move
+        ; Move Top of Return Stack to Top of Data Stack.
+        ;
+        ; We have to move
         ; the RTS address out of the way first. This word is handled
         ; differently for native and and subroutine compilation, see COMPILE,
         ; This is a compile-only word
@@ -7608,8 +7676,9 @@ z_r_from:       rts
 ; ## R_TO_INPUT ( -- ) ( R: n n n n -- ) "Restore input state from Return Stack"
 ; ## "r>input"  tested  Tali Forth
         ; """Restore the current input state as defined by insrc, cib, ciblen,
-        ; and toin from the Return Stack. See INPUT_TO_R for a discussion of
-        ; this word. Uses tmp1
+        ; and toin from the Return Stack.
+        ;
+        ; See INPUT_TO_R for a discussion of this word. Uses tmp1
         ; """ 
 .scope
 xt_r_to_input: 
@@ -7646,6 +7715,7 @@ z_r_to_input: 	rts
 ; ## RECURSE ( -- ) "Copy recursive call to word being defined"
 ; ## "recurse"  auto  ANS core
         ; """https://forth-standard.org/standard/core/RECURSE
+        ; 
         ; This word may not be natively compiled
         ; """
 .scope
@@ -8342,7 +8412,9 @@ z_set_order:    rts
         ; Store address and length of string given, returning ( addr u ).
         ; ANS core claims this is compile-only, but the file set expands it
         ; to be interpreted, so it is a state-sensitive word, which in theory
-        ; are evil. We follow general usage. Can also be realized as 
+        ; are evil. We follow general usage.
+        ;
+        ; Can also be realized as 
         ;     : S" [CHAR] " PARSE POSTPONE SLITERAL ; IMMEDIATE
         ; but it is used so much we want it in code.
         ; """
@@ -8908,7 +8980,9 @@ z_search:       rts
 ; ## SEMICOLON ( -- ) "End compilation of new word"
 ; ## ";"  auto  ANS core
         ; """https://forth-standard.org/standard/core/Semi
-        ; End the compilation of a new word into the Dictionary. When we
+        ; End the compilation of a new word into the Dictionary.
+        ;
+        ; When we
         ; enter this, WORKWORD is pointing to the nt_ of this word in the
         ; Dictionary, DP to the previous word, and CP to the next free byte.
         ; A Forth definition would be (see "Starting Forth"):
@@ -9024,6 +9098,7 @@ z_semicolon:    rts
 ; ## SIGN ( n -- ) "Add minus to pictured output"
 ; ## "sign"  auto  ANS core
         ; """https://forth-standard.org/standard/core/SIGN
+        ; 
         ; Code based on 
         ; http://pforth.googlecode.com/svn/trunk/fth/numberio.fth
         ; Original Forth code is   0< IF ASCII - HOLD THEN 
@@ -9053,6 +9128,7 @@ z_sign:         rts
 ; ## SLASH ( n1 n2 -- n ) "Divide NOS by TOS"
 ; ## "/"  auto  ANS core
         ; """https://forth-standard.org/standard/core/Div
+        ;
         ; Forth code is either  >R S>D R> FM/MOD SWAP DROP 
         ; or >R S>D R> SM/REM SWAP DROP -- we use SM/REM in Tali Forth.
         ; This code is currently unoptimized. This code without the SLASH
@@ -9097,6 +9173,7 @@ z_slash:        rts
 ; ## SLASH_MOD ( n1 n2 -- n3 n4 ) "Divide NOS by TOS with a remainder"
 ; ## "/mod"  auto  ANS core
         ; """https://forth-standard.org/standard/core/DivMOD
+        ;
         ; This is a dummy entry, the actual code is shared with SLASH
         ; """
 
@@ -9104,6 +9181,7 @@ z_slash:        rts
 ; ## SLASH_STRING ( addr u n -- addr u ) "Shorten string by n"
 ; ## "/string"  auto  ANS string
         ; """https://forth-standard.org/standard/string/DivSTRING
+        ;
         ; Forth code is
         ; : /STRING ( ADDR U N -- ADDR U ) ROT OVER + ROT ROT - ; 
         ; Put differently, we need to add TOS and 3OS, and subtract
@@ -9310,7 +9388,9 @@ sliteral_runtime:
 ; ## "sm/rem"  auto  ANS core
         ; """https://forth-standard.org/standard/core/SMDivREM
         ; Symmetic signed division. Compare FM/MOD. Based on F-PC 3.6
-        ; by Ulrich Hoffmann. See http://www.xlerb.de/uho/ansi.seq Forth:
+        ; by Ulrich Hoffmann. See http://www.xlerb.de/uho/ansi.seq
+        ;
+        ; Forth:
         ; OVER >R 2DUP XOR 0< >R ABS >R DABS R> UM/MOD R> ?NEGATE SWAP
         ; R> ?NEGATE SWAP
         ; """
@@ -9478,6 +9558,7 @@ z_spaces:       rts
 ; ## "*"  auto  ANS core
         ; """https://forth-standard.org/standard/core/Times
         ; Multiply two signed 16 bit numbers, returning a 16 bit result.
+        ; 
         ; This is nothing  more than UM* DROP
         ; """
 .scope
@@ -9496,8 +9577,10 @@ z_star:         rts
 ; ## "*/"  auto  ANS core
         ; """https://forth-standard.org/standard/core/TimesDiv
         ; Multiply n1 by n2 and divide by n3, returning the result
-        ; without a remainder. This is */MOD without the mod, and 
-        ; can be defined in Fort as : */  */MOD SWAP DROP ; which is
+        ; without a remainder. This is */MOD without the mod.
+        ;
+        ; This word 
+        ; can be defined in Forth as : */  */MOD SWAP DROP ; which is
         ; pretty much what we do here
         ; """
 xt_star_slash:
@@ -9515,7 +9598,9 @@ z_star_slash:
         ; """https://forth-standard.org/standard/core/TimesDivMOD
         ; Multiply n1 by n2 producing the intermediate double-cell result
         ; d. Divide d by n3 producing the single-cell remainder n4 and the
-        ; single-cell quotient n5. In Forth, this is
+        ; single-cell quotient n5.
+        ;
+        ; In Forth, this is
         ; : */MOD  >R M* >R SM/REM ;  Note that */ accesses this routine.
         ; """
 xt_star_slash_mod:
@@ -9750,7 +9835,7 @@ z_tick:         rts
 ; ## "to"  auto  ANS core ext
         ; """https://forth-standard.org/standard/core/TO
         ; Gives a new value to a, uh, VALUE.
-
+        ;
         ; One possible Forth
         ; implementation is  ' >BODY !  but given the problems we have
         ; with >BODY on STC Forths, we do this the hard way. Since 
@@ -9864,7 +9949,9 @@ z_to:           rts
         ; """https://forth-standard.org/standard/core/toBODY
         ; Given a word's execution token (xt), return the address of the
         ; start of that word's parameter field (PFA). This is defined as the
-        ; address that HERE would return right after CREATE. This is a
+        ; address that HERE would return right after CREATE.
+        ;
+        ; This is a
         ; difficult word for STC Forths, because most words don't actually
         ; have a Code Field Area (CFA) to skip. We solve this by having CREATE
         ; add a flag, "has CFA" (HC), in the header so >BODY know to skip
@@ -9930,7 +10017,7 @@ z_to_in:        rts
         ; to deal with a dot as a last character that signalizes double -
         ; this should be a pure number string. This routine calles UM*, which
         ; uses tmp1, tmp2 and tmp3, so we cannot access any of those.
-        
+        ;
         ; For the math routine, we move the inputs to the scratchpad to
         ; avoid having to fool around with the Data Stack. 
         ;
@@ -9939,7 +10026,7 @@ z_to_in:        rts
         ;     |           |           |           |           |
         ;     |  S    S+1 | S+2   S+3 | S+4   S+5 | S+6   S+7 |
         ;     +-----+-----+-----+-----+-----+-----+-----+-----+
-
+        ;
         ; The math routine works by converting one character to its
         ; numerical value (N) via DIGIT? and storing it in S+4 for
         ; the moment. We then multiply the UD-HI value with the radix
@@ -10319,6 +10406,7 @@ z_two_over:     rts
 ; ## TWO_R_FETCH ( -- n n ) "Copy top two entries from Return Stack"
 ; ## "2r@"  auto  ANS core ext
         ; """https://forth-standard.org/standard/core/TwoRFetch
+        ;
         ; This is R> R> 2DUP >R >R SWAP but we can do it a lot faster in
         ; assembler. We use trickery to access the elements on the Return
         ; Stack instead of pulling the return address first and storing
@@ -10363,7 +10451,9 @@ z_two_r_fetch:  rts
 ; ## TWO_R_FROM ( -- n1 n2 ) (R: n1 n2 -- ) "Pull two cells from Return Stack"
 ; ## "2r>"  auto  ANS core ext
 	    ; """https://forth-standard.org/standard/core/TwoRfrom
-        ; Pull top two entries from Return Stack. Is the same as
+        ; Pull top two entries from Return Stack.
+        ;
+        ; Is the same as
         ; R> R> SWAP. As with R>, the problem with the is word is that
         ; the top value on the ReturnStack for a STC Forth is the
         ; return address, which we need to get out of the way first.
@@ -10519,7 +10609,9 @@ z_two_swap:     rts
 ; ## TWO_TO_R ( n1 n2 -- )(R: -- n1 n2 "Push top two entries to Return Stack"
 ; ## "2>r"  auto  ANS core ext
         ; """https://forth-standard.org/standard/core/TwotoR
-        ; Push top two entries to Return Stack. The same as SWAP >R >R
+        ; Push top two entries to Return Stack.
+        ;
+        ; The same as SWAP >R >R
         ; except that if we jumped here, the return address will be in the
         ; way. May not be natively compiled unless we're clever and use
         ; special routines.
@@ -10567,6 +10659,7 @@ z_two_to_r:     rts
 ; ## TWO_CONSTANT (C: d "name" -- ) ( -- d) "Create a constant for a double word"
 ; ## "2constant"  auto  ANS double
         ; """https://forth-standard.org/standard/double/TwoCONSTANT
+        ;
         ; Based on the Forth code
         ; : 2CONSTANT ( D -- )  CREATE SWAP , , DOES> DUP @ SWAP CELL+ @ ;
         ; """
@@ -10613,10 +10706,11 @@ z_two_literal:  rts
 ; ## TWO_VARIABLE ( "name" -- ) "Create a variable for a double word"
 ; ## "2variable"  auto  ANS double
         ; """https://forth-standard.org/standard/double/TwoVARIABLE
+        ; The variable is not initialized to zero.
+        ;
         ; This can be realized in Forth as either 
         ; CREATE 2 CELLS ALLOT  or just  CREATE 0 , 0 , 
-        ; Note that in this case, the variable is not initialized to
-        ; zero"""
+        ; """
 .scope
 xt_two_variable:
                 ; We just let CRATE and ALLOT do the heavy lifting
@@ -10637,8 +10731,7 @@ z_two_variable: rts
 ; ## TYPE ( addr u -- ) "Print string"
 ; ## "type"  auto  ANS core
         ; """https://forth-standard.org/standard/core/TYPE
-        ; Works through EMIT to allow OUTPUT revectoring. Currently, only
-        ; strings of up to 255 characters are printed
+        ; Works through EMIT to allow OUTPUT revectoring.
         ; """
 .scope
 xt_type:        
@@ -10685,6 +10778,7 @@ z_type:         rts
 ; ## U_DOT ( u -- ) "Print TOS as unsigned number"
 ; ## "u."  tested  ANS core
         ; """https://forth-standard.org/standard/core/Ud
+        ;
         ; This is : U. 0 <# #S #> TYPE SPACE ; in Forth
         ; We use the internal assembler function print_u followed
         ; by a single space
@@ -10816,7 +10910,8 @@ z_ud_dot_r:      rts
         ; quotient as TOS and any remainder as NOS. All numbers are unsigned.
         ; This is the basic division operation all others use. Based on FIG
         ; Forth code, modified by Garth Wilson, see
-        ; http://6502.org/source/integers/ummodfix/ummodfix.htm 
+        ; http://6502.org/source/integers/ummodfix/ummodfix.htm
+        ; 
         ; This uses tmp1, tmp1+1, and tmptos
         ; """
 .scope
@@ -10886,7 +10981,7 @@ z_um_slash_mod: rts
         ; """https://forth-standard.org/standard/core/UMTimes
         ; Multiply two unsigned 16 bit numbers, producing a 32 bit result.
         ; Old Forth versions such as FIG Forth call this U*
-        
+        ;
         ; This is based on modified FIG Forth code by Dr. Jefyll, see
         ; http://forum.6502.org/viewtopic.php?f=9&t=689 for a detailed
         ; discussion.
@@ -10961,6 +11056,7 @@ z_um_star:      rts
 ; ## UNLOOP ( -- )(R: n1 n2 n3 ---) "Drop loop control from Return stack"
 ; ## "unloop"  auto  ANS core
         ; """https://forth-standard.org/standard/core/UNLOOP
+        ;
         ; Note that 6xPLA uses just as many bytes as a loop would
         ; """
 .scope
@@ -11052,6 +11148,7 @@ z_useraddr:     rts
 ; ## VALUE ( n "name" -- ) "Define a value"
 ; ## "value"  auto  ANS core
         ; """https://forth-standard.org/standard/core/VALUE
+        ;
         ; This is a dummy header for the WORDLIST. The actual code is
         ; identical to that of CONSTANT
         ; """
@@ -11061,7 +11158,7 @@ z_useraddr:     rts
 ; ## "variable"  auto  ANS core
         ; """https://forth-standard.org/standard/core/VARIABLE
         ; There are various Forth definitions for this word, such as
-        ; CREATE 1 CELLS ALLOT  or  CREATE 0 ,  We use a variant of the
+        ; `CREATE 1 CELLS ALLOT`  or  `CREATE 0 ,`  We use a variant of the
         ; second one so the variable is initialized to zero
         ; """
 xt_variable:    
@@ -11116,6 +11213,7 @@ z_while:        rts
 ; ## WITHIN ( n1 n2 n3 -- ) "See if within a range"
 ; ## "within"  auto  ANS core ext
         ; """https://forth-standard.org/standard/core/WITHIN
+        ;
         ; This an assembler version of the ANS Forth implementation 
         ; at https://forth-standard.org/standard/core/WITHIN which is
         ; OVER - >R - R> U<  note there is an alternative high-level version
@@ -11143,7 +11241,9 @@ z_within:       rts
         ; to modern format), and inserts a space after the string. See "Forth
         ; Programmer's Handbook" 3rd edition p. 159 and
         ; http://www.forth200x.org/documents/html/rationale.html#rat:core:PARSE 
-        ; for discussions of why you shouldn't be using WORD anymore. Forth
+        ; for discussions of why you shouldn't be using WORD anymore.
+        ;
+        ; Forth
         ; would be   PARSE DUP BUFFER1 C! OUTPUT 1+ SWAP MOVE BUFFER1
         ; We only allow input of 255 chars. Seriously, use PARSE-NAME.
         ; """
@@ -11236,6 +11336,7 @@ z_wordlist:     rts
 
 ; ## WORDS ( -- ) "Print known words from Dictionary"
 ; ## "words"  tested  ANS tools
+        ;
         ; """https://forth-standard.org/standard/tools/WORDS
         ; This is pretty much only used at the command line so we can
         ; be slow and try to save space. DROP must always be the first word in a
@@ -11398,9 +11499,10 @@ z_xor:          rts
 
 ; ## ZERO ( -- 0 ) "Push 0 to Data Stack"
 ; ## "0"  auto  Tali Forth
-;       ; """The disassembler assumes that this routine does not use Y. Note
-;       that CASE and FORTH-WORDLIST use the same routine, as the WD for Forth
-;       is 0."""
+
+        ; """The disassembler assumes that this routine does not use Y. Note
+        ; that CASE and FORTH-WORDLIST use the same routine, as the WD for Forth
+        ; is 0."""
 xt_case:
 xt_forth_wordlist:
 xt_zero:        

--- a/native_words.asm
+++ b/native_words.asm
@@ -5158,7 +5158,7 @@ z_input:        rts
         ; cost of some speed by assuming the four variables are grouped
         ; together on the Zero Page and start with insrc (see definitions.asm
         ; for details). The reverse operation is r_to_input. These words must 
-	    ; be flagged as Never Native. Uses tmp1
+        ; be flagged as Never Native. Uses tmp1
         ; """ 
 .scope
 xt_input_to_r: 

--- a/native_words.asm
+++ b/native_words.asm
@@ -3805,6 +3805,7 @@ z_endcase:      rts
 ; ## ENVIRONMENT_Q  ( addr u -- 0 | i*x true )  "Return system information"
 ; ## "environment?"  auto  ANS core
         ; """https://forth-standard.org/standard/core/ENVIRONMENTq
+
         ; By ANS definition, we use upper-case strings here, see the
         ; string file for details. This can be realized as a high-level
         ; Forth word as

--- a/tools/generate_glossary.py
+++ b/tools/generate_glossary.py
@@ -60,8 +60,6 @@ def main():
             if match:
                 word_name = match.group(1)
                 word_source = match.group(2)
-                # DEBUG
-                print('Found: '+word_name)
                 # Try to get the description from the first line.
                 descr_match = first_line_re.match(first_line)
                 if descr_match:

--- a/tools/generate_glossary.py
+++ b/tools/generate_glossary.py
@@ -78,7 +78,8 @@ def main():
                 print("Error determining short description on line:")
                 print(line)
         elif current_state == State.COMMENT:
-            # Save the multi-line comments.
+            # Save the multi-line comments up until the first 
+            # non-comment line or blank (only ; on line) comment line.
             line = line.strip()
             if line.startswith(';'):
                 # It's a comment line.  Strip the semicolon and the
@@ -86,9 +87,17 @@ def main():
                 line = line.strip(';')
                 line = line.strip()
                 line = line.strip('"""')
-                # Add this to any existing long description content.
-                long_descr[word_name] = long_descr.get(word_name, '') \
-                                        + line + "\n"
+                # See if there is anything left!
+                if line != "":
+                    # Add this to any existing long description content.
+                    long_descr[word_name] = \
+                      long_descr.get(word_name, '') + line + "\n"
+                else:
+                    # It was a blank comment line.
+                    # Go back to the idle state to ignore the rest of
+                    # the comment block.
+                    current_state = State.IDLE
+
             else:
                 # Not a comment line - back to the idle state.
                 current_state = State.IDLE

--- a/tools/generate_glossary.py
+++ b/tools/generate_glossary.py
@@ -94,10 +94,18 @@ def main():
             else:
                 # Not a comment line - back to the idle state.
                 current_state = State.IDLE
+
     # All of the words have been read in.
+
     # Print them back out in ASCIIbetical order.
+    print("[horizontal]")
     for word_name in sorted(short_descr.keys()):
-        print(word_name + short_descr[word_name])
+        print("`" + word_name + "`" + ":: _" + source[word_name] + \
+              "_ " +short_descr[word_name])
+        # Not all words have a long description.
+        # Print it for those that do.
+        if word_name in long_descr:
+            print(long_descr[word_name])
 
 
 if __name__ == '__main__':

--- a/tools/generate_glossary.py
+++ b/tools/generate_glossary.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# PROGRAMMER  : Sam Colwell
+# FILE        : generate_glossary.py
+# DATE        : 2019-01-01
+# DESCRIPTION : Generate the glossary for the manual for Tali Forth 2
+# from native_words.asm.
+# Based on Scot W. Stevenson's generate_wordlist.py.
+"""Creates an asciidoc formated glossary of words based on the header
+comments in native_words.asm.
+"""
+
+import sys
+import re
+from enum import Enum
+
+SOURCE = 'native_words.asm'
+MARKER = '; ## '
+
+# This runs as a state machine to capture the wordname, short 
+# description, and the first comment block for each word.
+class State(Enum):
+    IDLE = 0
+    HEADER = 1
+    COMMENT = 2
+
+# Regular expressions to capture the data in the header.
+# Capture everything after the marker and first word.
+first_line_re = re.compile(r"; ## \w+\s+(.*)$")
+# Capture the name of the word and where it comes from
+second_line_re = re.compile(r"; ## \"(\S+)\"\s+\w+\s+(.*)$")
+
+def main():
+
+    with open(SOURCE) as f:
+        raw_list = f.readlines()
+
+    # Set up dictionaries to store the data using the word name as 
+    # the key.
+    short_descr = {}
+    source      = {}
+    long_descr  = {}
+
+    # Use the state machine to process the input.
+    current_state = State.IDLE
+    for line in raw_list:
+
+        if current_state == State.IDLE:
+            # In the idle state, we are on the lookout for the
+            # beginning of a header.
+            if line.startswith(MARKER):
+                # We've found a header.  We don't know the word's
+                # name yet, so just save this line.
+                first_line = line
+                current_state = State.HEADER
+        elif current_state == State.HEADER:
+            # We're in a header on the second line.
+            # Determine the name, and then save the short description
+            # and where it comes from
+            match = second_line_re.match(line)
+            if match:
+                word_name = match.group(1)
+                word_source = match.group(2)
+                # DEBUG
+                print('Found: '+word_name)
+                # Try to get the description from the first line.
+                descr_match = first_line_re.match(first_line)
+                if descr_match:
+                    # Save everything so far.
+                    short_descr[word_name] = descr_match.group(1)
+                    source[word_name] = word_source
+                    # Look for the comment next.
+                    current_state = State.COMMENT
+                else:
+                    # Something went wrong processing the first line.
+                    print("Error determining name on line:")
+                    print(first_line)
+                    current_state = State.IDLE
+            else:
+                # Something went wrong on the second line.
+                print("Error determining short description on line:")
+                print(line)
+        elif current_state == State.COMMENT:
+            # Save the multi-line comments.
+            line = line.strip()
+            if line.startswith(';'):
+                # It's a comment line.  Strip the semicolon and the
+                # triple quotes.
+                line = line.strip(';')
+                line = line.strip()
+                line = line.strip('"""')
+                # Add this to any existing long description content.
+                long_descr[word_name] = long_descr.get(word_name, '') \
+                                        + line + "\n"
+            else:
+                # Not a comment line - back to the idle state.
+                current_state = State.IDLE
+    # All of the words have been read in.
+    # Print them back out in ASCIIbetical order.
+    for word_name in sorted(short_descr.keys()):
+        print(word_name + short_descr[word_name])
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
#210 
The glossary will be updated anytime native-words.asm is modified and `make docs` (or `make gitready`, which makes the docs) is run.

It grabs the name (as seen in Forth), the source (eg. ANS vs Tali vs Gforth), the short desciprtion and the first non-blank (a blank comment line with just a `;`counts as blank) lines of the multi-line comment.  

I had it stop on a blank line or blank comment line to make it easy to separate the content that goes into the glossary from comments that describe implementation details.  I then went through the words and added a blank comment line for those words with lots of implementation details that didn't need to be in the glossary.  I think it looks pretty good.  Let me know if there's anything you want different.