### PR TITLE
Zero page dynamic

### DIFF
--- a/definitions.asm
+++ b/definitions.asm
@@ -74,7 +74,7 @@
 ; First usable Data Stack location: $003E (decimal 62)
 ; Bytes avaible for Data Stack: 128-62 = 66 --> 33 16-bit cells
 
-.alias dsp0      $78       ; initial Data Stack Pointer, see docs/stack.md
+.alias dsp0      zpage_end-8  ; initial Data Stack Pointer
 
 ; User Variables:
 ; Block variables

--- a/native_words.asm
+++ b/native_words.asm
@@ -39,13 +39,13 @@ _load_zp_loop:
                 ; This loop loads them back to front. We can use X here
                 ; because Tali hasn't started using the stack yet.
                 lda cold_zp_table,x
-                sta 0,x
+                sta zpage,x
                 dex
                 bne _load_zp_loop
 
                 ; Copy the 0th element.
                 lda cold_zp_table
-                sta 0
+                sta zpage
 
                 ; Initialize 65c02 stack (Return Stack)
                 ldx #rsp0
@@ -70,7 +70,6 @@ _load_user_vars_loop:
                 ; Copy the 0th element.
                 lda cold_user_table
                 sta (up)
-
                 jsr xt_cr
 
                 ; Define high-level words in forth_words.asm via EVALUATE. If

--- a/platform/platform-apple1-ram.asm
+++ b/platform/platform-apple1-ram.asm
@@ -79,6 +79,7 @@
 .alias ram_start $0000          ; start of installed 32 KiB of RAM
 .alias ram_end   $2900-1        ; end of free RAM
 .alias zpage     ram_start      ; begin of Zero Page ($0000-$00ff)
+.alias zpage_end $7F            ; end of Zero Page used ($0000-$007f)	
 .alias stack0    $0100          ; begin of Return Stack ($0100-$01ff)
 .alias hist_buff ram_end-$03ff  ; begin of history buffers
 

--- a/platform/platform-apple1-rom.asm
+++ b/platform/platform-apple1-rom.asm
@@ -79,6 +79,7 @@
 .alias ram_start $0000          ; start of installed 32 KiB of RAM
 .alias ram_end   $8000-1        ; end of installed RAM
 .alias zpage     ram_start      ; begin of Zero Page ($0000-$00ff)
+.alias zpage_end $7F            ; end of Zero Page used ($0000-$007f)	
 .alias stack0    $0100          ; begin of Return Stack ($0100-$01ff)
 .alias hist_buff ram_end-$03ff  ; begin of history buffers
 

--- a/platform/platform-py65mon.asm
+++ b/platform/platform-py65mon.asm
@@ -65,6 +65,7 @@
 .alias ram_start $0000          ; start of installed 32 KiB of RAM
 .alias ram_end   $8000-1        ; end of installed RAM
 .alias zpage     ram_start      ; begin of Zero Page ($0000-$00ff)
+.alias zpage_end $7F            ; end of Zero Page used ($0000-$007f)	
 .alias stack0    $0100          ; begin of Return Stack ($0100-$01ff)
 .alias hist_buff ram_end-$03ff  ; begin of history buffers
 

--- a/platform/platform-sbc.asm
+++ b/platform/platform-sbc.asm
@@ -64,6 +64,7 @@
 .alias ram_start $0000          ; start of installed 32 KiB of RAM
 .alias ram_end   $7F00-1        ; end of installed RAM
 .alias zpage     ram_start      ; begin of Zero Page ($0000-$00ff)
+.alias zpage_end $7F            ; end of Zero Page used ($0000-$007f)	
 .alias stack0    $0100          ; begin of Return Stack ($0100-$01ff)
 .alias hist_buff ram_end-$03ff  ; begin of history buffers
 .alias acia_buff hist_buff-$102 ; begin of ACIA buffer memory                

--- a/platform/platform-steckschwein.asm
+++ b/platform/platform-steckschwein.asm
@@ -96,6 +96,7 @@ _done:
 .alias ram_start $0000          ; start of installed 32 KiB of RAM
 .alias ram_end   $8000-1        ; end of installed RAM
 .alias zpage     ram_start      ; begin of Zero Page ($0000-$00ff)
+.alias zpage_end $7F            ; end of Zero Page used ($0000-$007f)	
 .alias stack0    $0100          ; begin of Return Stack ($0100-$01ff)
 .alias hist_buff ram_end-$03ff  ; begin of history buffers
 


### PR DESCRIPTION
I'm working on a platform file for the Western Design Center w65c134sxb development board. On this board, only zero page adresses above $80 are free and available for TaliForth to use.

This change allows to move the zero page locations upwards, it also makes the initial data stack pointer dynamic relative to the end of the free zero page ram.

I also removed the reference to "see docs/stack.md" that does not exist anymore