### PR TITLE
Add platform_bye for SamCo's SBC

### DIFF
--- a/platform/platform-sbc.asm
+++ b/platform/platform-sbc.asm
@@ -146,6 +146,11 @@ _done:
                 jmp forth
 .scend
 
+; My SBC runs Tali Forth 2 as the OS, to there is nowhere to go back to.
+; Just restart TALI.
+platform_bye:   
+        jmp kernel_init
+
 
 
     ;; Defines for hardware:


### PR DESCRIPTION
Added a platform_bye for my SBC.  Because Tali Forth 2 _**IS**_ the OS, it just jumps to kernel_init to reinitialize the hardware and restart Tali.