### PR TITLE
Crossplatform/makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,57 @@
 # Makefile for Tali Forth 2
-# This version: 16. Oct 2018
+# This version: 14. Jan 2020
 
-# Note the manual is not automatically updated because not everybody can be
-# expected to have the asciidoc toolchain installed
+# Notes: The manual is not automatically updated because not everybody can be
+# expected to have the asciidoc toolchain installed.  Tali requires python 3.x,
+# Ophis, and GNU make to build the 65C02 binary image.
+
+# Example uses ($ is the prompt - yours might be C:\>):
+# Build tailforth-py65mon.bin for use with the py65mon simulator.
+# The py65mon version is the default.
+# $ make
+#
+# Build Taliforth 2 for a different platform (steckschwein shown here).
+# There must be a matching platform file in the platform folder.
+# $ make taliforth-steckschwein.bin
+
+# Determine which python launcher to use (python3 on Linux, "py -3" on Windows)
+# and other OS-specific commands (rm vs del)
+ifdef OS
+	RM = del
+	PYTHON = py -3
+else
+	RM = rm
+	PYTHON = python3
+endif
 
 COMMON_SOURCES=taliforth.asm definitions.asm native_words.asm headers.asm strings.asm forth_words.asc user_words.asc disassembler.asm ed.asm assembler.asm
 TEST_SOURCES=tests/core.fs tests/string.fs tests/double.fs tests/facility.fs tests/stringlong.fs tests/tali.fs tests/tools.fs tests/block.fs tests/user.fs tests/cycles.fs tests/talitest.py tests/ed.fs tests/search.fs tests/asm.fs
 
 all: taliforth-py65mon.bin docs/WORDLIST.md
 clean:
-	rm *.bin *.prg
+	$(RM) *.bin *.prg
 
 taliforth-%.bin: platform/platform-%.asm $(COMMON_SOURCES)
 	ophis -l docs/$*-listing.txt \
 	-m docs/$*-labelmap.txt \
 	-o $@ \
-	-c $< ;
+	-c $<
 
 taliforth-%.prg: platform/platform-%.asm $(COMMON_SOURCES)
 	ophis -l docs/$*-listing.txt \
 	-m docs/$*-labelmap.txt \
 	-o $@ \
-	-c $< ;
+	-c $<
 
 # Convert the high-level Forth words to ASCII files that Ophis can include
 %.asc: forth_code/%.fs
-	python3 forth_code/forth_to_ophisbin.py -i $< > $@
+	$(PYTHON) forth_code/forth_to_ophisbin.py -i $< > $@
 
 # Automatically update the wordlist which also gives us the status of the words
 # We need for the binary to be generated first or else we won't be able to find
 # new words in the label listing
 docs/WORDLIST.md: taliforth-py65mon.bin
-	python3 tools/generate_wordlist.py > docs/WORDLIST.md
+	$(PYTHON) tools/generate_wordlist.py > docs/WORDLIST.md
 
 
 # Some convenience targets to make running the tests and simulation easier.
@@ -40,11 +60,11 @@ docs/WORDLIST.md: taliforth-py65mon.bin
 tests:	tests/results.txt
 
 tests/results.txt:	taliforth-py65mon.bin $(TEST_SOURCES)
-	cd tests; ./talitest.py
+	cd tests && ./talitest.py
 
 # Convenience target for parallel tests
 ptests:	taliforth-py65mon.bin $(TEST_SOURCES)
-	cd tests; ./ptest.sh
+	cd tests && ./ptest.sh
 
 # Convenience target to run the py65mon simulator.
 # Because taliforth-py65mon.bin is listed as a dependency, it will be
@@ -54,21 +74,21 @@ sim:	taliforth-py65mon.bin
 
 # Some convenience targets for the documentation.
 docs/manual.html: docs/*.adoc
-	cd docs; asciidoctor -a toc=left manual.adoc
+	cd docs && asciidoctor -a toc=left manual.adoc
 
 docs/ch_glossary.adoc:	native_words.asm
-	tools/generate_glossary.py > docs/ch_glossary.adoc
+	$(PYTHON) tools/generate_glossary.py > docs/ch_glossary.adoc
 
 # The diagrams use ditaa to generate pretty diagrams from text files.
 # They have their own makefile in the docs/pics directory.
 docs-diagrams: docs/pics/*.txt
-	cd docs/pics; $(MAKE)
+	cd docs/pics && $(MAKE)
 
 docs: docs/manual.html docs-diagrams
 
 # This one is experimental at the moment.
 docsmd: docs/manual.html
-	cd docs; ./asciidoc_to_markdown.sh
+	cd docs && ./asciidoc_to_markdown.sh
 
 # A convenience target for preparing for a git commit.
 gitready: docs all tests

--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,9 @@ docs/WORDLIST.md: taliforth-py65mon.bin
 tests:	tests/results.txt
 
 tests/results.txt:	taliforth-py65mon.bin $(TEST_SOURCES)
-	cd tests && ./talitest.py
+	cd tests && $(PYTHON) ./talitest.py
 
-# Convenience target for parallel tests
+# Convenience target for parallel tests (Linux only)
 ptests:	taliforth-py65mon.bin $(TEST_SOURCES)
 	cd tests && ./ptest.sh
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ifdef OS
 	RM = del
 	PYTHON = py -3
 else
-	RM = rm
+	RM = rm -f
 	PYTHON = python3
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 # Makefile for Tali Forth 2
 # This version: 14. Jan 2020
 
-# Notes: The manual is not automatically updated because not everybody can be
-# expected to have the asciidoc toolchain installed.  Tali requires python 3.x,
-# Ophis, and GNU make to build the 65C02 binary image.
+# Notes: The manual is not automatically updated because not everybody
+# can be expected to have the asciidoc toolchain and ditaa installed.
+# Tali requires python 3.x, Ophis, and GNU make to build the 65C02
+# binary image.
 
 # Example uses ($ is the prompt - yours might be C:\>):
 # Build tailforth-py65mon.bin for use with the py65mon simulator.
@@ -14,8 +15,8 @@
 # There must be a matching platform file in the platform folder.
 # $ make taliforth-steckschwein.bin
 
-# Determine which python launcher to use (python3 on Linux, "py -3" on Windows)
-# and other OS-specific commands (rm vs del)
+# Determine which python launcher to use (python3 on Linux and OSX,
+# "py -3" on Windows) and other OS-specific commands (rm vs del).
 ifdef OS
 	RM = del
 	PYTHON = py -3
@@ -25,7 +26,7 @@ else
 endif
 
 COMMON_SOURCES=taliforth.asm definitions.asm native_words.asm headers.asm strings.asm forth_words.asc user_words.asc disassembler.asm ed.asm assembler.asm
-TEST_SOURCES=tests/core.fs tests/string.fs tests/double.fs tests/facility.fs tests/stringlong.fs tests/tali.fs tests/tools.fs tests/block.fs tests/user.fs tests/cycles.fs tests/talitest.py tests/ed.fs tests/search.fs tests/asm.fs
+TEST_SOURCES=tests/core_a.fs tests/core_b.fs tests/core_c.fs tests/string.fs tests/double.fs tests/facility.fs tests/tali.fs tests/tools.fs tests/block.fs tests/user.fs tests/cycles.fs tests/talitest.py tests/ed.fs tests/search.fs tests/asm.fs
 
 all: taliforth-py65mon.bin docs/WORDLIST.md
 clean:


### PR DESCRIPTION
This makes `make` work on Windows (tested on Win10 *without cygwin*, which was the issue reported on the 6502 forums) for everything except for the docs.  I was able to install ruby/asciidoctor and that works, but ditaa doesn't have an easy way to just install on Windows (I'd have to create a batch file or something for it), so `make docs` technically works except for the generation of the images (eg. if no input files used to generate the images have changed, it works).  At this point, I'm OK with leaving it at that until we have a developer who wants to make new ditaa charts on Windows for the documentation.

The following now works on windows:
`make` - builds taliforth-py65mon.bin
`make taliforth-steckschwein.bin` (or any version that has a platform file)
`make clean`
`make tests` - note that this runs the older single-process tests, but that version works fine on Windows.
`make sim` - assembles taliforth-py65mon.bin if needed and then runs it in py65mon.