### PR TITLE
Updated Makefile to make CBM-style .prg files properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,11 @@ taliforth-%.bin: platform/platform-%.asm $(COMMON_SOURCES)
 	$<
 
 taliforth-%.prg: platform/platform-%.asm $(COMMON_SOURCES)
-	ophis -l docs/$*-listing.txt \
-	-m docs/$*-labelmap.txt \
-	-o $@ \
-	-c $<
+	64tass --cbm-prg \
+	--list=docs/$*-listing.txt \
+	--labels=docs/$*-labelmap.txt \
+	--output $@ \
+	$<
 
 # Convert the high-level Forth words to ASCII files that Ophis can include
 %.asc: forth_code/%.fs

--- a/platform/platform-steckschwein.asm
+++ b/platform/platform-steckschwein.asm
@@ -11,8 +11,10 @@ krn_uart_rx  = $FFE0
 
 ; steckOS uses the prg format used on the C64 with the first
 ; two bytes containing the load address
-* = $7FFE        
-.word $8000
+; This is now handled in the makefile by running:
+;   make taliforth-steckschwein.prg
+;* = $7FFE
+;.word $8000
 * = $8000
 kernel_init:
         ; """Initialize the hardware.


### PR DESCRIPTION
Also updated the steckschwein platform file, which is currently our only platform using this format.

I suppose it shouldn't be surprising that this is actually 64tass' default output format.  I removed the --nostart flag and added the --cbm-prg flag (even though that's the default) to make it clear.

I don't have the hardware to test this, but I did verify that the first two bytes in the file were "0080" in hex, which is the address $8000 where the rest of the file should be loaded. I also verified the first couple of opcodes that should come after that.  The resulting file is about 22K, which sounds correct for a full Tali2 with no filler.
