### PR TITLE
fix spelling to -> do

### DIFF
--- a/native_words.asm
+++ b/native_words.asm
@@ -190,7 +190,7 @@ _get_line:
                 stz ciblen+1
 
                 ; Accept a line from the current import source. This is how
-                ; modern Forths to it.
+                ; modern Forths do it.
                 jsr xt_refill           ; ( -- f )
 
                 ; Test flag: LSB of TOS


### PR DESCRIPTION
This is a stupid one character change that I happened to
notice while reading through the code. Feel free to close
the PR and just fix it as part of something else. Cheers!
